### PR TITLE
Fix doc on GetIpErrorString's Size parameter

### DIFF
--- a/sdk-api-src/content/iphlpapi/nf-iphlpapi-getiperrorstring.md
+++ b/sdk-api-src/content/iphlpapi/nf-iphlpapi-getiperrorstring.md
@@ -70,7 +70,7 @@ A pointer to the buffer that contains the error code string if the function retu
 
 ### -param Size [in, out]
 
-A pointer to a <b>DWORD</b> that specifies the length, in bytes, of the buffer pointed to by <i>Buffer</i> parameter.
+A pointer to a <b>DWORD</b> that specifies the length, in characters, of the buffer pointed to by <i>Buffer</i> parameter, excluding the terminating null (i.e. the size of Buffer in characters, minus one).
 
 
 ## -returns


### PR DESCRIPTION
There are two errors in the current doc for this param:
-it claims to be in bytes but is really in characters.
-in the implementation, the size doesn't account for the terminating null.