### PR TITLE
Added semantic of D3D12_BUFFER_UAV::StructureByteStride

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_uav.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_uav.md
@@ -90,7 +90,8 @@ A <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/ne-d3d12-d3d12_b
 
 
 Use this structure with a <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/ns-d3d12-d3d12_unordered_access_view_desc">D3D12_UNORDERED_ACCESS_VIEW_DESC</a> structure to view the resource as a buffer.
-      
+
+If <i>StructureByteStride</i> value is not 0, a view of a structured buffer is created and the D3D12_UNORDERED_ACCESS_VIEW_DESC::Format field must be DXGI_FORMAT_UNKNOWN. If <i>StructureByteStride</i> is 0, a typed view of a buffer is created and a format must be supplied. The specified format for the typed view must be supported by the hardware. More information on this topic can be found in the <a href="https://docs.microsoft.com/en-gb/windows/win32/direct3d12/typed-unordered-access-view-loads">Typed unordered access view (UAV) loads</a> page.
 
 
 
@@ -101,6 +102,8 @@ Use this structure with a <a href="https://docs.microsoft.com/windows/desktop/ap
 
 
 <a href="https://docs.microsoft.com/windows/desktop/direct3d12/direct3d-12-structures">Core Structures</a>
+
+<a href="https://docs.microsoft.com/en-gb/windows/win32/direct3d12/typed-unordered-access-view-loads">Typed unordered access view (UAV) loads</a>
  
 
  


### PR DESCRIPTION
I could not find relevant information about this and used the debug layer to find out how to create a UAV that I can clear using ID3D12GraphicsCommandList::ClearUnorderedAccessViewUint (https://docs.microsoft.com/en-gb/windows/win32/api/d3d12/nf-d3d12-id3d12device-createunorderedaccessview).

The debug layer messages i was relying on:
StructureByteStride = 0 and Format = DXGI_FORMAT_UNKNOWN:
D3D12 ERROR: ID3D12Device::CreateUnorderedAccessView: The Format (0, UNKNOWN) cannot be used when creating a typed View of a Buffer. [ STATE_CREATION ERROR #342: CREATEUNORDEREDACCESSVIEW_INVALIDFORMAT]

StructureByteStride = 4 and Format = DXGI_FORMAT_R32_UINT:
D3D12 ERROR: ID3D12Device::CreateUnorderedAccessView: The Format (0x2a, R32_UINT) is invalid, when creating a View of a Structured Buffer; it must be DXGI_FORMAT_UNKNOWN. [ STATE_CREATION ERROR #342: CREATEUNORDEREDACCESSVIEW_INVALIDFORMAT]