### PR TITLE
Corrected description of FirstElement in the D3D11_BUFFER_SRV structure

### DIFF
--- a/sdk-api-src/content/d3d11/ns-d3d11-d3d11_buffer_srv.md
+++ b/sdk-api-src/content/d3d11/ns-d3d11-d3d11_buffer_srv.md
@@ -62,7 +62,7 @@ Specifies the elements in a buffer resource to use in a shader-resource view.
 
 Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
 
-Number of bytes between the beginning of the buffer and the first element to access.
+Index of the first element to access.
             
 
 


### PR DESCRIPTION
Corrected description of FirstElement in the D3D11_BUFFER_SRV structure.  It is not a count of bytes before the first element but rather the index of the first element using the stride.