### PR TITLE
Escape backslashes in GetDiskFreeSpace[Ex] docs

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespacea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespacea.md
@@ -72,8 +72,8 @@ Retrieves information about the specified disk, including the amount of free spa
 
 The root directory of the disk for which information is to be returned. If this parameter is 
       <b>NULL</b>, the function uses the root of the current disk. If this parameter is a UNC name, 
-      it must include a trailing backslash (for example, "\\MyServer\MyShare\"). Furthermore, a drive 
-      specification must have a trailing backslash (for example, "C:\"). The calling application must 
+      it must include a trailing backslash (for example, "\\\\MyServer\\MyShare\\"). Furthermore, a drive 
+      specification must have a trailing backslash (for example, "C:\\"). The calling application must 
       have <b>FILE_LIST_DIRECTORY</b> access rights for this  directory.
 
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespaceexa.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespaceexa.md
@@ -76,7 +76,7 @@ A directory on the disk.
 If this parameter is <b>NULL</b>, the function uses the root of the current disk.
 
 If this parameter is a UNC name, it must include a trailing backslash, for example, 
-       "\\MyServer\MyShare\".
+       "\\\\MyServer\\MyShare\\".
 
 This parameter does not have to specify the root directory on a disk. The function accepts any directory on a 
        disk.

--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespaceexw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespaceexw.md
@@ -76,7 +76,7 @@ A directory on the disk.
 If this parameter is <b>NULL</b>, the function uses the root of the current disk.
 
 If this parameter is a UNC name, it must include a trailing backslash, for example, 
-       "\\MyServer\MyShare\".
+       "\\\\MyServer\\MyShare\\".
 
 This parameter does not have to specify the root directory on a disk. The function accepts any directory on a 
        disk.

--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespacew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskfreespacew.md
@@ -72,8 +72,8 @@ Retrieves information about the specified disk, including the amount of free spa
 
 The root directory of the disk for which information is to be returned. If this parameter is 
       <b>NULL</b>, the function uses the root of the current disk. If this parameter is a UNC name, 
-      it must include a trailing backslash (for example, "\\MyServer\MyShare\"). Furthermore, a drive 
-      specification must have a trailing backslash (for example, "C:\"). The calling application must 
+      it must include a trailing backslash (for example, "\\\\MyServer\\MyShare\\"). Furthermore, a drive 
+      specification must have a trailing backslash (for example, "C:\\"). The calling application must 
       have <b>FILE_LIST_DIRECTORY</b> access rights for this  directory.
 
 


### PR DESCRIPTION
Escape backslash characters because otherwise they are not rendered (or single backslash is rendered in place of double).