### PR TITLE
Fix typos on QUERY_CHANGES_VIRTUAL_DISK_RANGE doc

### DIFF
--- a/sdk-api-src/content/virtdisk/ns-virtdisk-query_changes_virtual_disk_range.md
+++ b/sdk-api-src/content/virtdisk/ns-virtdisk-query_changes_virtual_disk_range.md
@@ -83,7 +83,7 @@ Reserved.
 
 
 
-[QueryCangesVirtualDisk](/windows/win32/api/virtdisk/nf-virtdisk-querychangesvirtualdisk)a>
+[QueryChangesVirtualDisk](/windows/win32/api/virtdisk/nf-virtdisk-querychangesvirtualdisk)
 
 
 


### PR DESCRIPTION
This commit fixes typos in the "See also" section of the QUERY_CHANGES_VIRTUAL_DISK_RANGE structure documentation.