### PR TITLE
Transfer packaging not using microframes

### DIFF
--- a/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipe.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipe.md
@@ -106,10 +106,11 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_ReadIsochPipe</b> packetizes the transfer buffer so that in each interval,  the host can receive the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_ReadIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval,  the host can receive the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple read requests to stream data from the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
+Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipe.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipe.md
@@ -75,7 +75,7 @@ Length in bytes of the transfer buffer.
 
 ### -param FrameNumber [in, out]
 
-On input, indicates the starting frame number for the transfer.  On output, contains the frame number of the frame that follows the last frame used in the transfer.
+On input, indicates the starting frame number for the transfer. On output, contains the frame number of the frame that follows the last frame used in the transfer.
 
 
 ### -param NumberOfPackets [in]
@@ -97,7 +97,7 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_ReadIsochPipe</b> returns TRUE if the operation succeeds.  Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
+<b>WinUsb_ReadIsochPipe</b> returns TRUE if the operation succeeds. Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
 
 
 
@@ -106,11 +106,12 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_ReadIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval,  the host can receive the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_ReadIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval, the host can receive the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple read requests to stream data from the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
-Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
+Because of the transfer packaging used in the underlying kernel-mode interface, the lowest latency notification to an application or driver is 1ms intervals.
+
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipeasap.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipeasap.md
@@ -97,7 +97,7 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_ReadIsochPipeAsap</b> returns TRUE if the operation succeeds.  Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
+<b>WinUsb_ReadIsochPipeAsap</b> returns TRUE if the operation succeeds. Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
 
 If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.sys is unable to schedule the transfer to continue the stream without dropping one or more frames.
 
@@ -111,11 +111,12 @@ If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.s
 <b>WinUsb_ReadIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer. If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
 
 
-<b>WinUsb_ReadIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
-If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
+<b>WinUsb_ReadIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval, the host can receive the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+If the caller submits multiple read requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
-Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
+Because of the transfer packaging used in the underlying kernel-mode interface, the lowest latency notification to an application or driver is 1ms intervals.
+
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipeasap.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_readisochpipeasap.md
@@ -108,13 +108,14 @@ If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.s
 
 
 
-<b>WinUsb_ReadIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer.  If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
+<b>WinUsb_ReadIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer. If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
 
 
-<b>WinUsb_ReadIsochPipeAsap</b> packetizes the transfer buffer so that in each interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_ReadIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
+Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipe.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipe.md
@@ -96,10 +96,11 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_WriteIsochPipe</b> packetizes the transfer buffer so that in each interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_WriteIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
+Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipe.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipe.md
@@ -75,7 +75,7 @@ Length in bytes of the transfer buffer.
 
 ### -param FrameNumber [in, out]
 
-On input, indicates the starting frame number for the transfer.  On output, contains the frame number of the frame that follows the last frame used in the transfer.
+On input, indicates the starting frame number for the transfer. On output, contains the frame number of the frame that follows the last frame used in the transfer.
 
 
 ### -param Overlapped [in, optional]
@@ -87,7 +87,7 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_WriteIsochPipe</b> returns TRUE if the operation succeeds.  Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
+<b>WinUsb_WriteIsochPipe</b> returns TRUE if the operation succeeds. Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
 
 
 
@@ -96,11 +96,11 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_WriteIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_WriteIsochPipe</b> packetizes the transfer buffer so that in each 1ms interval, the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
-Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
+Because of the transfer packaging used in the underlying kernel-mode interface, the lowest latency notification to an application or driver is 1ms intervals.
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipeasap.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipeasap.md
@@ -75,7 +75,7 @@ Length in bytes of the transfer buffer.
 
 ### -param ContinueStream [in]
 
-Indicates that the transfer  should only be submitted if it can be scheduled in the first frame after the last pending transfer.  
+Indicates that the transfer should only be submitted if it can be scheduled in the first frame after the last pending transfer.  
 
 
 ### -param Overlapped [in, optional]
@@ -87,7 +87,7 @@ Pointer to an <a href="https://docs.microsoft.com/windows/desktop/api/shobjidl/n
 
 
 
-<b>WinUsb_WriteIsochPipeAsap</b> returns TRUE if the operation succeeds.  Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
+<b>WinUsb_WriteIsochPipeAsap</b> returns TRUE if the operation succeeds. Otherwise this function returns FALSE, and the caller can retrieve the logged error by calling <b>GetLastError</b>.
 
 If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.sys is unable to schedule the transfer to continue the stream without dropping one or more frames.
 
@@ -98,14 +98,14 @@ If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.s
 
 
 
-<b>WinUsb_WriteIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer.  If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
+<b>WinUsb_WriteIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer. If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
 
 
-<b>WinUsb_WriteIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_WriteIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval, the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
-Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
+Because of the transfer packaging used in the underlying kernel-mode interface, the lowest latency notification to an application or driver is 1ms intervals.
 
 
 

--- a/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipeasap.md
+++ b/sdk-api-src/content/winusb/nf-winusb-winusb_writeisochpipeasap.md
@@ -101,10 +101,11 @@ If the caller sets <i>ContinueStream</i> to TRUE, The transfer fails if Winusb.s
 <b>WinUsb_WriteIsochPipeAsap</b> allows the USB driver stack to choose the starting frame number for the transfer.  If one or more transfers are already pending on the endpoint, the transfer will be scheduled for the frame number immediately following the last frame number of the last currently pending transfer.
 
 
-<b>WinUsb_WriteIsochPipeAsap</b> packetizes the transfer buffer so that in each interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
+<b>WinUsb_WriteIsochPipeAsap</b> packetizes the transfer buffer so that in each 1ms interval,  the host can send the maximum bytes allowed per interval. The maximum bytes is as specified by the endpoint descriptor for full and high-speed endpoints, and endpoint companion descriptor for SuperSpeed endpoints.
 If the caller submits multiple write requests to stream data to the device, the transfer size should be a multiple of the maximum bytes per interval (as returned by <a href="https://docs.microsoft.com/windows/desktop/api/winusb/nf-winusb-winusb_querypipeex">WinUsb_QueryPipeEx</a>) * 8 / interval.
 
 
+Because of the transfer packaging, <b>only full 1ms USB frames are available</b> and low-latency applications requiring microframe transfers must use a kernel mode driver instead.
 
 
 


### PR DESCRIPTION
Making it very clear that the USB "frames" are in fact 1ms frames and not microframes.