### PR TITLE
Updating Creduipromptforcredentials flags

### DIFF
--- a/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsa.md
+++ b/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsa.md
@@ -5,7 +5,7 @@ description: Creates and displays a configurable dialog box that allows users to
 old-location: security\creduipromptforwindowscredentials.htm
 tech.root: SecAuthN
 ms.assetid: 946ac279-d30a-4a6c-a76d-d93597121427
-ms.date: 12/05/2018
+ms.date: 1/14/2020
 ms.keywords: CREDUIWIN_AUTHPACKAGE_ONLY, CREDUIWIN_CHECKBOX, CREDUIWIN_ENUMERATE_ADMINS, CREDUIWIN_ENUMERATE_CURRENT_USER, CREDUIWIN_GENERIC, CREDUIWIN_IN_CRED_ONLY, CREDUIWIN_PACK_32_WOW, CREDUIWIN_PREPROMPTING, CREDUIWIN_SECURE_PROMPT, CredUIPromptForWindowsCredentials, CredUIPromptForWindowsCredentials function [Security], CredUIPromptForWindowsCredentialsA, CredUIPromptForWindowsCredentialsW, security.creduipromptforwindowscredentials, wincred/CredUIPromptForWindowsCredentials, wincred/CredUIPromptForWindowsCredentialsA, wincred/CredUIPromptForWindowsCredentialsW
 f1_keywords:
 - wincred/CredUIPromptForWindowsCredentials
@@ -230,6 +230,19 @@ The credential dialog box is invoked by the <a href="https://docs.microsoft.com/
 </td>
 </tr>
 <tr>
+<td width="40%"><a id=""></a><a id=""></a><dl>
+<dt><b></b></dt>
+<dt>0x40000</dt>
+</dl>
+</td>
+<td width="60%">
+The credential provider will not pack the AAD authority name. This is only applied to Azure AD joined devices.
+
+<b>Windows 10, version 1607:  </b>This value is supported beginning with Windows 10, version 1607.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="CREDUIWIN_PACK_32_WOW"></a><a id="creduiwin_pack_32_wow"></a><dl>
 <dt><b>CREDUIWIN_PACK_32_WOW</b></dt>
 <dt>0x10000000</dt>
@@ -237,6 +250,19 @@ The credential dialog box is invoked by the <a href="https://docs.microsoft.com/
 </td>
 <td width="60%">
 The credential provider should align the credential BLOB pointed to by the <i>ppvOutAuthBuffer</i> parameter to a 32-bit boundary, even if the provider is running on a 64-bit system.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id=""></a><a id=""></a><dl>
+<dt><b></b></dt>
+<dt>0x80000000</dt>
+</dl>
+</td>
+<td width="60%">
+Windows Hello credentials will be packed in a smart card auth buffer. This only applies to the face, fingerprint, and PIN credential providers. 
+
+<b>Windows 10, version 1809:  </b>This value is supported beginning with Windows 10, version 1809.
 
 </td>
 </tr>

--- a/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsw.md
+++ b/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsw.md
@@ -230,6 +230,19 @@ The credential dialog box is invoked by the <a href="https://docs.microsoft.com/
 </td>
 </tr>
 <tr>
+<td width="40%"><a id=""></a><a id=""></a><dl>
+<dt><b></b></dt>
+<dt>0x40000</dt>
+</dl>
+</td>
+<td width="60%">
+The credential provider will not pack the AAD authority name. This is only applied to Azure AD joined devices.
+
+<b>Windows 10, version 1607:  </b>This value is supported beginning with Windows 10, version 1607.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="CREDUIWIN_PACK_32_WOW"></a><a id="creduiwin_pack_32_wow"></a><dl>
 <dt><b>CREDUIWIN_PACK_32_WOW</b></dt>
 <dt>0x10000000</dt>
@@ -240,6 +253,20 @@ The credential provider should align the credential BLOB pointed to by the <i>pp
 
 </td>
 </tr>
+<tr>
+<td width="40%"><a id=""></a><a id=""></a><dl>
+<dt><b></b></dt>
+<dt>0x10000000</dt>
+</dl>
+</td>
+<td width="60%">
+Windows Hello credentials will be packed in a smart card auth buffer. This only applies to the face, fingerprint, and PIN credential providers. 
+
+<b>Windows 10, version 1809:  </b>This value is supported beginning with Windows 10, version 1809.
+
+</td>
+</tr>
+
 </table>
  
 

--- a/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsw.md
+++ b/sdk-api-src/content/wincred/nf-wincred-creduipromptforwindowscredentialsw.md
@@ -5,7 +5,7 @@ description: Creates and displays a configurable dialog box that allows users to
 old-location: security\creduipromptforwindowscredentials.htm
 tech.root: SecAuthN
 ms.assetid: 946ac279-d30a-4a6c-a76d-d93597121427
-ms.date: 12/05/2018
+ms.date: 1/14/2020
 ms.keywords: CREDUIWIN_AUTHPACKAGE_ONLY, CREDUIWIN_CHECKBOX, CREDUIWIN_ENUMERATE_ADMINS, CREDUIWIN_ENUMERATE_CURRENT_USER, CREDUIWIN_GENERIC, CREDUIWIN_IN_CRED_ONLY, CREDUIWIN_PACK_32_WOW, CREDUIWIN_PREPROMPTING, CREDUIWIN_SECURE_PROMPT, CredUIPromptForWindowsCredentials, CredUIPromptForWindowsCredentials function [Security], CredUIPromptForWindowsCredentialsA, CredUIPromptForWindowsCredentialsW, security.creduipromptforwindowscredentials, wincred/CredUIPromptForWindowsCredentials, wincred/CredUIPromptForWindowsCredentialsA, wincred/CredUIPromptForWindowsCredentialsW
 f1_keywords:
 - wincred/CredUIPromptForWindowsCredentials
@@ -256,7 +256,7 @@ The credential provider should align the credential BLOB pointed to by the <i>pp
 <tr>
 <td width="40%"><a id=""></a><a id=""></a><dl>
 <dt><b></b></dt>
-<dt>0x10000000</dt>
+<dt>0x80000000</dt>
 </dl>
 </td>
 <td width="60%">
@@ -266,7 +266,6 @@ Windows Hello credentials will be packed in a smart card auth buffer. This only 
 
 </td>
 </tr>
-
 </table>
  
 


### PR DESCRIPTION
Updating the flags for creduipromptforcredentialsa and creduipromptforcredentialsw. These flags were introduced in previous windows versions but were missing from documentation.