### PR TITLE
 Updated description for ID3D11Fence::CreateSharedHandle

### DIFF
--- a/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11fence-createsharedhandle.md
+++ b/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11fence-createsharedhandle.md
@@ -52,7 +52,7 @@ ms.custom: 19H1
 Creates a shared handle to a fence object.
         
 
-This member function is equivalent to the Direct3D 12 <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createsharedhandle">ID3D12Device::CreateSharedHandle</a> member function, and applies between Direct3D 11 and Direct3D 12 in interop scenarios.
+This member function is equivalent to the Direct3D 12 <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createsharedhandle">ID3D12Device::CreateSharedHandle</a> member function, and applies between Direct3D 11 and Direct3D 12 in interop scenarios.  In DX11, the shared fence handle can be opened with the <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11_4/nf-d3d11_4-id3d11device5-opensharedfence">ID3D11Device5::OpenSharedFence</a> member function.  In DX12, the shared fence handle can be opened with the <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-opensharedhandle">ID3D12Device::OpenSharedHandle</a> member function.
 
 
 ## -parameters

--- a/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11fence-createsharedhandle.md
+++ b/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11fence-createsharedhandle.md
@@ -52,7 +52,7 @@ ms.custom: 19H1
 Creates a shared handle to a fence object.
         
 
-This member function is equivalent to the Direct3D 12 <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createsharedhandle">ID3D12Device::CreateSharedHandle</a> member function, and applies between Direct3D 11 and Direct3D 12 in interop scenarios.  In DX11, the shared fence handle can be opened with the <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d11_4/nf-d3d11_4-id3d11device5-opensharedfence">ID3D11Device5::OpenSharedFence</a> member function.  In DX12, the shared fence handle can be opened with the <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-opensharedhandle">ID3D12Device::OpenSharedHandle</a> member function.
+This method is equivalent to the Direct3D 12 <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createsharedhandle">ID3D12Device::CreateSharedHandle</a> method, and it applies in scenarios involving interoperation between Direct3D 11 and Direct3D 12. In DirecX 11, you can open the shared fence handle with the <a href="/windows/win32/api/d3d11_4/nf-d3d11_4-id3d11device5-opensharedfence">ID3D11Device5::OpenSharedFence</a> method. In DirecX 12, you can open the shared fence handle with the <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12device-opensharedhandle">ID3D12Device::OpenSharedHandle</a> method.
 
 
 ## -parameters
@@ -62,9 +62,9 @@ This member function is equivalent to the Direct3D 12 <a href="https://docs.micr
 
 ### -param pAttributes [in, optional]
 
-Type: <b>const <a href="https://docs.microsoft.com/previous-versions/windows/desktop/legacy/aa379560(v=vs.85)">SECURITY_ATTRIBUTES</a>*</b>
+Type: <b>const <a href="/previous-versions/windows/desktop/legacy/aa379560(v=vs.85)">SECURITY_ATTRIBUTES</a>*</b>
 
-A pointer to a <a href="https://docs.microsoft.com/previous-versions/windows/desktop/legacy/aa379560(v=vs.85)">SECURITY_ATTRIBUTES</a>structure that contains two separate but related data members: an optional security descriptor, and a <b>Boolean</b>value that determines whether child processes can inherit the returned handle.
+A pointer to a <a href="/previous-versions/windows/desktop/legacy/aa379560(v=vs.85)">SECURITY_ATTRIBUTES</a>structure that contains two separate but related data members: an optional security descriptor, and a <b>Boolean</b>value that determines whether child processes can inherit the returned handle.
             
 
 Set this parameter to <b>NULL</b> if you want child processes that the
@@ -74,16 +74,16 @@ Set this parameter to <b>NULL</b> if you want child processes that the
             
 
 The <b>lpSecurityDescriptor</b> member of the structure specifies a
-              <a href="https://docs.microsoft.com/windows/desktop/api/winnt/ns-winnt-security_descriptor">SECURITY_DESCRIPTOR</a> for the resource.
+              <a href="/windows/desktop/api/winnt/ns-winnt-security_descriptor">SECURITY_DESCRIPTOR</a> for the resource.
               Set this member to <b>NULL</b> if you want the runtime to assign a default security descriptor to the resource that is associated with the returned handle.
               The ACLs in the default security descriptor for the resource come from the primary or impersonation token of the creator.
-              For more info, see <a href="https://docs.microsoft.com/windows/desktop/Sync/synchronization-object-security-and-access-rights">Synchronization Object Security and Access Rights</a>.
+              For more info, see <a href="/windows/desktop/Sync/synchronization-object-security-and-access-rights">Synchronization Object Security and Access Rights</a>.
             
 
 
 ### -param dwAccess
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">DWORD</a></b>
+Type: <b><a href="/windows/desktop/WinProg/windows-data-types">DWORD</a></b>
 
 Currently the only value this parameter accepts is GENERIC_ALL.
 
@@ -97,26 +97,26 @@ A <b>NULL</b>-terminated <b>UNICODE</b> string that contains the name to associa
               Name comparison is case-sensitive.
             
 
-If <i>Name</i> matches the name of an existing resource, <b>CreateSharedHandle</b> fails with <a href="https://docs.microsoft.com/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_NAME_ALREADY_EXISTS</a>.
+If <i>Name</i> matches the name of an existing resource, <b>CreateSharedHandle</b> fails with <a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_NAME_ALREADY_EXISTS</a>.
               This occurs because these objects share the same namespace.
             
 
 The name can have a "Global\" or "Local\" prefix to explicitly create the object in the global or session namespace.
               The remainder of the name can contain any character except the backslash character (\).
               For more information, see
-              <a href="https://docs.microsoft.com/windows/desktop/TermServ/kernel-object-namespaces">Kernel Object Namespaces</a>.
+              <a href="/windows/desktop/TermServ/kernel-object-namespaces">Kernel Object Namespaces</a>.
               Fast user switching is implemented using Terminal Services sessions.
               Kernel object names must follow the guidelines outlined for Terminal Services so that applications can support multiple users.
             
 
 The object can be created in a private namespace.
-              For more information, see <a href="https://docs.microsoft.com/windows/desktop/Sync/object-namespaces">Object Namespaces</a>.
+              For more information, see <a href="/windows/desktop/Sync/object-namespaces">Object Namespaces</a>.
             
 
 
 ### -param pHandle [out]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">HANDLE</a>*</b>
+Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HANDLE</a>*</b>
 
 A pointer to a variable that receives the NT HANDLE value to the resource to share.
             You can use this handle in calls to access the resource.
@@ -133,13 +133,13 @@ Returns S_OK if successful; otherwise, returns one of the following values:
               
 
 <ul>
-<li><a href="https://docs.microsoft.com/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_INVALID_CALL</a> if one of the parameters is invalid.
+<li><a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_INVALID_CALL</a> if one of the parameters is invalid.
               </li>
-<li><a href="https://docs.microsoft.com/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_NAME_ALREADY_EXISTS</a> if the supplied name of the resource to share is already associated with another resource.
+<li><a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_NAME_ALREADY_EXISTS</a> if the supplied name of the resource to share is already associated with another resource.
               </li>
 <li>E_ACCESSDENIED if the object is being created in a protected namespace.</li>
 <li>E_OUTOFMEMORY if sufficient memory is not available to create the handle.</li>
-<li>Possibly other error codes that are described in the <a href="https://docs.microsoft.com/windows/desktop/direct3d11/d3d11-graphics-reference-returnvalues">Direct3D 11 Return Codes</a> topic.
+<li>Possibly other error codes that are described in the <a href="/windows/desktop/direct3d11/d3d11-graphics-reference-returnvalues">Direct3D 11 Return Codes</a> topic.
               </li>
 </ul>
 
@@ -149,7 +149,7 @@ Returns S_OK if successful; otherwise, returns one of the following values:
 
 
 
-In order to to create a shared handle for the specified fence, the fence must have been created with either the <b>D3D11_FENCE_FLAG_SHARED</b> or <b>D3D11_FENCE_FLAG_SHARED_CROSS_ADAPTER</b> flags. For more information see the <a href="https://docs.microsoft.com/windows/desktop/api/d3d11_3/ne-d3d11_3-d3d11_fence_flag">D3D11_FENCE_FLAG</a> enumeration.
+In order to to create a shared handle for the specified fence, the fence must have been created with either the <b>D3D11_FENCE_FLAG_SHARED</b> or <b>D3D11_FENCE_FLAG_SHARED_CROSS_ADAPTER</b> flags. For more information see the <a href="/windows/desktop/api/d3d11_3/ne-d3d11_3-d3d11_fence_flag">D3D11_FENCE_FLAG</a> enumeration.
 
 
 
@@ -159,7 +159,7 @@ In order to to create a shared handle for the specified fence, the fence must ha
 
 
 
-<a href="https://docs.microsoft.com/windows/desktop/api/d3d11_3/nn-d3d11_3-id3d11fence">ID3D11Fence</a>
+<a href="/windows/desktop/api/d3d11_3/nn-d3d11_3-id3d11fence">ID3D11Fence</a>
  
 
  


### PR DESCRIPTION
Updated description to describe how to use the shared handle in DX11 and DX12.