### PR TITLE
Update nf-synchapi-initonceexecuteonce.md

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
@@ -72,14 +72,14 @@ A pointer to the one-time initialization structure.
 A pointer to an application-defined <a href="https://docs.microsoft.com/windows/desktop/api/synchapi/nc-synchapi-pinit_once_fn">InitOnceCallback</a> function.
 
 
-### -param Context [out, optional]
+### -param Parameter [in, optional]
+
+A parameter to be passed to the callback function.
+
+### -param Context [in, out, optional]
 
 A parameter that receives data stored with the one-time initialization structure upon success. The low-order <b>INIT_ONCE_CTX_RESERVED_BITS</b> bits of the data are always zero.
 
-
-### -param Parameter [in, out, optional]
-
-A parameter to be passed to the callback function.
 
 
 ## -returns


### PR DESCRIPTION
The actual parameter order in the header is:

```
WINBASEAPI
BOOL
WINAPI
InitOnceExecuteOnce(
    _Inout_ PINIT_ONCE InitOnce,
    _In_ __callback PINIT_ONCE_FN InitFn,
    _Inout_opt_ PVOID Parameter,
    _Outptr_opt_result_maybenull_ LPVOID* Context
    );
```

Also, the SAL on the third parameter is wrong in the header. It should be ``__In_opt_`` because it's just a void-pointer.