### PR TITLE
Add notes about SetDllDirectory having effect on children processes

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-setdlldirectorya.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setdlldirectorya.md
@@ -92,6 +92,11 @@ The
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> functions. It also effectively disables safe DLL search mode while the specified directory is in the search path. 
 
+<div class="alert">
+    <b>Note</b><br/>
+    Calling this function will also affect the DLL search order of the children processes started from the process that has called the function, given the children processes don't call `SetDllDirectory` themselves.
+</div>
+
 After calling 
 <b>SetDllDirectory</b>, the standard DLL search path is:
 

--- a/sdk-api-src/content/winbase/nf-winbase-setdlldirectorya.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setdlldirectorya.md
@@ -92,10 +92,8 @@ The
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> functions. It also effectively disables safe DLL search mode while the specified directory is in the search path. 
 
-<div class="alert">
-    <b>Note</b><br/>
-    Calling this function will also affect the DLL search order of the children processes started from the process that has called the function, given the children processes don't call `SetDllDirectory` themselves.
-</div>
+> [!NOTE]
+> For Win32 processes that are **not** running a packaged or protected process, calling this function will also affect the DLL search order of the children processes started from the process that has called the function.
 
 After calling 
 <b>SetDllDirectory</b>, the standard DLL search path is:

--- a/sdk-api-src/content/winbase/nf-winbase-setdlldirectoryw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setdlldirectoryw.md
@@ -92,6 +92,11 @@ The
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> functions. It also effectively disables safe DLL search mode while the specified directory is in the search path. 
 
+<div class="alert">
+    <b>Note</b><br/>
+    Calling this function will also affect the DLL search order of the children processes started from the process that has called the function, given the children processes don't call `SetDllDirectory` themselves.
+</div>
+
 After calling 
 <b>SetDllDirectory</b>, the standard DLL search path is:
 

--- a/sdk-api-src/content/winbase/nf-winbase-setdlldirectoryw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setdlldirectoryw.md
@@ -92,10 +92,8 @@ The
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
 <a href="https://docs.microsoft.com/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> functions. It also effectively disables safe DLL search mode while the specified directory is in the search path. 
 
-<div class="alert">
-    <b>Note</b><br/>
-    Calling this function will also affect the DLL search order of the children processes started from the process that has called the function, given the children processes don't call `SetDllDirectory` themselves.
-</div>
+> [!NOTE]
+> For Win32 processes that are **not** running a packaged or protected process, calling this function will also affect the DLL search order of the children processes started from the process that has called the function.
 
 After calling 
 <b>SetDllDirectory</b>, the standard DLL search path is:


### PR DESCRIPTION
This fact is [widely known](https://stackoverflow.com/a/44589008/2684760) but I never found it documented anywhere, thus I've decided to send you a PR.

Hope it will improve the documentation!

See also my PR to the win32 documentation repository: https://github.com/MicrosoftDocs/win32/pull/202