### PR TITLE
Correct mistaken cchFilePath parameter description

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
@@ -81,8 +81,7 @@ A pointer to a buffer that receives the path of <i>hFile</i>.
 
 ### -param cchFilePath [in]
 
-The size of <i>lpszFilePath</i>, in <b>TCHAR</b>s. This value does 
-      not include a <b>NULL</b> termination character.
+The size of <i>lpszFilePath</i>, in <b>TCHAR</b>s. This value must include a <b>NULL</b> termination character.
 
 
 ### -param dwFlags [in]

--- a/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlew.md
@@ -81,8 +81,7 @@ A pointer to a buffer that receives the path of <i>hFile</i>.
 
 ### -param cchFilePath [in]
 
-The size of <i>lpszFilePath</i>, in <b>TCHAR</b>s. This value does 
-      not include a <b>NULL</b> termination character.
+The size of <i>lpszFilePath</i>, in <b>TCHAR</b>s. This value must include a <b>NULL</b> termination character.
 
 
 ### -param dwFlags [in]


### PR DESCRIPTION
I've tested this and stepped through the API under windbg, and if cchFilePath does not account for the NULL terminator, the API fails with ERROR_NOT_ENOUGH_MEMORY, and and returns cchFilePath + 1.