### PR TITLE
Added missing trailing zero to the `FILE_FLAG_POSIX_SEMANTICS` constant.

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilea.md
@@ -593,7 +593,7 @@ For information about considerations when using a file handle created with this 
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">

--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
@@ -593,7 +593,7 @@ For information about considerations when using a file handle created with this 
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">

--- a/sdk-api-src/content/fileapi/ns-fileapi-createfile2_extended_parameters.md
+++ b/sdk-api-src/content/fileapi/ns-fileapi-createfile2_extended_parameters.md
@@ -353,7 +353,7 @@ For information about considerations when using a file handle created with this 
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">

--- a/sdk-api-src/content/winbase/nf-winbase-createfiletransacteda.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createfiletransacteda.md
@@ -604,7 +604,7 @@ If this flag is not specified, then I/O operations are serialized, even if the c
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">

--- a/sdk-api-src/content/winbase/nf-winbase-createfiletransactedw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createfiletransactedw.md
@@ -604,7 +604,7 @@ If this flag is not specified, then I/O operations are serialized, even if the c
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">

--- a/sdk-api-src/content/winbase/nf-winbase-reopenfile.md
+++ b/sdk-api-src/content/winbase/nf-winbase-reopenfile.md
@@ -279,7 +279,7 @@ This flag also enables more than one operation to be performed simultaneously wi
 <tr>
 <td width="40%"><a id="FILE_FLAG_POSIX_SEMANTICS"></a><a id="file_flag_posix_semantics"></a><dl>
 <dt><b>FILE_FLAG_POSIX_SEMANTICS</b></dt>
-<dt>0x0100000</dt>
+<dt>0x01000000</dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpepnp/0f2fef8b-ef79-40ff-8314-5f56787e6d9d for the correct value.