### PR TITLE
Add missing backslash to prefix to bypass MAX_PATH

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
@@ -77,8 +77,8 @@ To perform this operation as a transacted operation, which results in a handle t
 The name of the file or device to be created or opened. You may use either forward slashes (/) or backslashes (\) in this name.
 
 In the ANSI version of this function, the name is limited to <b>MAX_PATH</b> characters. 
-       To extend this limit to 32,767 wide characters, call the Unicode version of the function and prepend 
-       "\\?\" to the path. For more information, see 
+       To extend this limit to 32,767 wide characters, use this Unicode version of the function and prepend 
+       "\\\\?\\" to the path. For more information, see 
        <a href="https://docs.microsoft.com/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 For information on special device names, see 


### PR DESCRIPTION
Comment is about Unicode version (suffix W) inside the Unicode call page.
Backslash must be repeated to display correctly on the page as done in the 1603 tip.