### PR TITLE
Fix link

### DIFF
--- a/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
+++ b/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
@@ -252,7 +252,7 @@ The <i>lpJobObjectInfo</i> parameter is a pointer to a
 </td>
 <td width="60%">
 The <i>lpJobObjectInfo</i> parameter is a pointer to a 
-        <a href="https://docs.microsoft.com/windows/win32/api/winnt/ns-winnt-jobobject_notification_limit_information">JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2</a> 
+        <a href="https://docs.microsoft.com/windows/win32/api/winnt/ns-winnt-jobobject_notification_limit_information_2">JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2</a> 
         structure.
         
 


### PR DESCRIPTION
Fix the link to JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 which incorrectly linked to JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION.