### PR TITLE
Correcting definition of AlignedByteOffset

### DIFF
--- a/sdk-api-src/content/d3d11/ns-d3d11-d3d11_input_element_desc.md
+++ b/sdk-api-src/content/d3d11/ns-d3d11-d3d11_input_element_desc.md
@@ -99,7 +99,7 @@ An integer value that identifies the input-assembler (see input slot). Valid val
 
 Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
 
-Optional. Offset (in bytes) between each element. Use D3D11_APPEND_ALIGNED_ELEMENT for convenience to define the current element directly 
+Optional. Offset (in bytes) from the start of the vertex. Use D3D11_APPEND_ALIGNED_ELEMENT for convenience to define the current element directly 
         after the previous one, including any packing if necessary.
 
 


### PR DESCRIPTION
It's the offset from the start of the vertex not the offset between each element.