### PR TITLE
Fixed formatting in the parameters description.

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getclassnamea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getclassnamea.md
@@ -85,13 +85,7 @@ The class name string.
 
 Type: <b>int</b>
 
-The length
-					
-					 of the 
-					<i>lpClassName</i> buffer, in 
-	
-
-					characters. The buffer must be large enough to include the terminating null character; otherwise, the class name string is truncated to <code>nMaxCount-1</code> characters.
+The length of the *lpClassName* buffer, in characters. The buffer must be large enough to include the terminating null character; otherwise, the class name string is truncated to `nMaxCount-1` characters.
 
 
 ## -returns

--- a/sdk-api-src/content/winuser/nf-winuser-getclassnamew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getclassnamew.md
@@ -85,13 +85,7 @@ The class name string.
 
 Type: <b>int</b>
 
-The length
-					
-					 of the 
-					<i>lpClassName</i> buffer, in 
-	
-
-					characters. The buffer must be large enough to include the terminating null character; otherwise, the class name string is truncated to <code>nMaxCount-1</code> characters.
+The length of the *lpClassName* buffer, in characters. The buffer must be large enough to include the terminating null character; otherwise, the class name string is truncated to `nMaxCount-1` characters.
 
 
 ## -returns


### PR DESCRIPTION
The description for `nMaxCount` accidentally used indentation that got interpreted by the Markdown processor as a code section (which it isn').