### PR TITLE
Update nf-winsvc-createservicew.md

### DIFF
--- a/sdk-api-src/content/winsvc/nf-winsvc-createservicew.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-createservicew.md
@@ -73,7 +73,7 @@ A handle to the service control manager database. This handle is returned by the
 
 ### -param lpServiceName [in]
 
-The name of the service to install. The maximum string length is 256 characters. The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive. Forward-slash (/) and backslash (\) are not valid service name characters.
+The name of the service to install. The maximum string length is 256 characters. The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive. Forward-slash (/) and backslash (\\) are not valid service name characters.
 
 
 ### -param lpDisplayName [in, optional]
@@ -413,7 +413,7 @@ A shared process can run as any user.
 
 If the service type is <b>SERVICE_KERNEL_DRIVER</b> or <b>SERVICE_FILE_SYSTEM_DRIVER</b>, the name is the driver object name that the system uses to load the device driver. Specify NULL if the driver is to use a default object name created by the I/O system.
 
-A service can be configured to use a managed account or a virtual  account. If the service is configured to use a managed service account, the name is the managed service account name. If the service is configured to use a virtual  account, specify the name as *NT SERVICE\ServiceName*. For more information about managed service accounts and virtual accounts, see the <a href="https://go.microsoft.com/fwlink/p/?linkid=147314">Service Accounts Step-by-Step Guide</a>.
+A service can be configured to use a managed account or a virtual  account. If the service is configured to use a managed service account, the name is the managed service account name. If the service is configured to use a virtual  account, specify the name as NT SERVICE\\*ServiceName*. For more information about managed service accounts and virtual accounts, see the <a href="https://go.microsoft.com/fwlink/p/?linkid=147314">Service Accounts Step-by-Step Guide</a>.
 
 <b>Windows Server 2008, Windows Vista, Windows Server 2003 and Windows XP:  </b>Managed service accounts and virtual accounts are not supported until Windows 7 and Windows Server 2008 R2.
 


### PR DESCRIPTION
See #46. I think the convention is to only italicize variable names. The `ServiceName` should be changed to the actual name of the service, but `NT SERVICE` should not, so it seems we'd better not italicize `NT SERVICE`.