### PR TITLE
Fix a typo in service account name

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-logonusera.md
+++ b/sdk-api-src/content/winbase/nf-winbase-logonusera.md
@@ -266,7 +266,7 @@ You can generate a LocalService token by using the following code.
 
 
 ```cpp
-LogonUser(L"LocalServer", L"NT AUTHORITY", NULL, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, &hToken)
+LogonUser(L"LocalService", L"NT AUTHORITY", NULL, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, &hToken)
 
 ```
 

--- a/sdk-api-src/content/winbase/nf-winbase-logonuserw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-logonuserw.md
@@ -266,7 +266,7 @@ You can generate a LocalService token by using the following code.
 
 
 ```cpp
-LogonUser(L"LocalServer", L"NT AUTHORITY", NULL, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, &hToken)
+LogonUser(L"LocalService", L"NT AUTHORITY", NULL, LOGON32_LOGON_SERVICE, LOGON32_PROVIDER_DEFAULT, &hToken)
 
 ```
 


### PR DESCRIPTION
An example provided for `LogonUser` contains a typo. There is no such account as _LocalServer_.