### PR TITLE
lint: Escape backslash separators

### DIFF
--- a/sdk-api-src/content/wincred/nf-wincred-creduipromptforcredentialsw.md
+++ b/sdk-api-src/content/wincred/nf-wincred-creduipromptforcredentialsw.md
@@ -79,7 +79,7 @@ A pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/wincred/n
 
 ### -param pszTargetName [in]
 
-A pointer to a null-terminated string that contains  the name of the target for the credentials, typically a server name. For Distributed File System (DFS) connections, this string is of the form <i>ServerName</i>\<i>ShareName</i>. This parameter is used to identify target information when storing and retrieving credentials.
+A pointer to a null-terminated string that contains  the name of the target for the credentials, typically a server name. For Distributed File System (DFS) connections, this string is of the form <i>ServerName</i>\\<i>ShareName</i>. This parameter is used to identify target information when storing and retrieving credentials.
 
 
 ### -param pContext [in]
@@ -102,7 +102,7 @@ This function copies the user-supplied name to this buffer, copying a maximum of
 
 If the CREDUI_FLAGS_DO_NOT_PERSIST flag is not specified, the value returned in this parameter is of a form that should not be inspected, printed, or persisted other than passing it to <a href="https://docs.microsoft.com/windows/desktop/api/wincred/nf-wincred-creduiparseusernamea">CredUIParseUsername</a>. The subsequent results of <b>CredUIParseUsername</b> can  be passed only to a client-side authentication function such as <a href="https://docs.microsoft.com/windows/desktop/api/winnetwk/nf-winnetwk-wnetaddconnectiona">WNetAddConnection</a> or an SSP function.
 
-If no domain or server is specified as part of this parameter, the value of the  <b>pszTargetName</b> parameter is used as the domain to form a <i>DomainName</i>\<i>UserName</i> pair. On output, this parameter receives a string that contains that <i>DomainName</i>\<i>UserName</i> pair.
+If no domain or server is specified as part of this parameter, the value of the  <b>pszTargetName</b> parameter is used as the domain to form a <i>DomainName</i>\\<i>UserName</i> pair. On output, this parameter receives a string that contains that <i>DomainName</i>\\<i>UserName</i> pair.
 
 
 ### -param ulUserNameBufferSize [in]


### PR DESCRIPTION
This change escapes the backslash separator between `ServerName\ShareName` and `DomainName\UserName`. Because this was not escaped, it was causing one of the `<i>` tags to show, instead of the slash itself.

TODO:
- [ ] ~~Escape the same backslashes in the CredUIPromptForCredentialsA doc~~ Will do in another PR