### PR TITLE
Update nf-d3dcompiler-d3dcompile.md

### DIFF
--- a/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
+++ b/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
@@ -25,7 +25,7 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: D3dcompiler_47.lib
+req.lib: d3dcompiler.lib
 req.dll: D3dcompiler_47.dll
 req.irql: 
 topic_type:

--- a/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
+++ b/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
@@ -26,7 +26,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: d3dcompiler.lib
-req.dll: D3dcompiler_47.dll
+req.dll: d3dcompiler.dll
 req.irql: 
 topic_type:
 - APIRef
@@ -34,7 +34,7 @@ topic_type:
 api_type:
 - DllExport
 api_location:
-- d3dcompiler_47.dll
+- d3dcompiler.dll
 api_name:
 - D3DCompile
 targetos: Windows


### PR DESCRIPTION
There’s no D3dcompiler_47.lib anywhere in Windows SDK. However, I have 16 different versions of d3dcompiler.lib in different places under "Program Files (x86)".