### PR TITLE
Add structs and enums for new WinHttp options

### DIFF
--- a/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_stat_entry.md
+++ b/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_stat_entry.md
@@ -13,8 +13,8 @@ dev_langs:
 req.header: winhttp.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
-req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:

--- a/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_stat_entry.md
+++ b/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_stat_entry.md
@@ -1,0 +1,156 @@
+---
+UID: NE:winhttp._WINHTTP_REQUEST_STAT_ENTRY
+title: WINHTTP_REQUEST_STAT_ENTRY (winhttp.h)
+description: The WINHTTP_REQUEST_STAT_ENTRY enumeration lists the available types of request statistics.
+tech.root: WinHttp
+ms.assetid: d9620011-7092-4260-a51f-48d84aebc89b
+ms.date: 02/25/2020
+ms.keywords: WINHTTP_REQUEST_STAT_ENTRY, WINHTTP_REQUEST_STAT_ENTRY enumeration [HTTP], http.winhttp_request_stat_entry, winhttp/WINHTTP_REQUEST_STAT_ENTRY, WinHttpConnectFailureCount, WinHttpProxyFailureCount, WinHttpTlsHandshakeClientLeg1Size, WinHttpTlsHandshakeServerLeg1Size, WinHttpTlsHandshakeClientLeg2Size, WinHttpTlsHandshakeServerLeg2Size, WinHttpRequestHeadersSize, WinHttpRequestHeadersCompressedSize, WinHttpResponseHeadersSize, WinHttpResponseHeadersCompressedSize, WinHttpResponseBodySize, WinHttpResponseBodyCompressedSize, WinHttpProxyTlsHandshakeClientLeg1Size, WinHttpProxyTlsHandshakeServerLeg1Size, WinHttpProxyTlsHandshakeClientLeg2Size, WinHttpProxyTlsHandshakeServerLeg2Size, WinHttpRequestStatLast, WinHttpRequestStatMax, winhttp/WinHttpConnectFailureCount, winhttp/WinHttpProxyFailureCount, winhttp/WinHttpTlsHandshakeClientLeg1Size, winhttp/WinHttpTlsHandshakeServerLeg1Size, winhttp/WinHttpTlsHandshakeClientLeg2Size, winhttp/WinHttpTlsHandshakeServerLeg2Size, winhttp/WinHttpRequestHeadersSize, winhttp/WinHttpRequestHeadersCompressedSize, winhttp/WinHttpResponseHeadersSize, winhttp/WinHttpResponseHeadersCompressedSize, winhttp/WinHttpResponseBodySize, winhttp/WinHttpResponseBodyCompressedSize, winhttp/WinHttpProxyTlsHandshakeClientLeg1Size, winhttp/WinHttpProxyTlsHandshakeServerLeg1Size, winhttp/WinHttpProxyTlsHandshakeClientLeg2Size, winhttp/WinHttpProxyTlsHandshakeServerLeg2Size, winhttp/WinHttpRequestStatLast, winhttp/WinHttpRequestStatMax
+f1_keywords:
+- winhttp/WINHTTP_REQUEST_STAT_ENTRY
+dev_langs:
+- c++
+req.header: winhttp.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- HeaderDef
+api_location:
+- winhttp.h
+api_name:
+- WINHTTP_REQUEST_STAT_ENTRY
+targetos: Windows
+req.typenames: WINHTTP_REQUEST_STAT_ENTRY
+req.redist:
+ms.custom: 19H1
+---
+
+# WINHTTP_REQUEST_STAT_ENTRY enumeration
+
+
+## -description
+
+
+The **WINHTTP\_REQUEST\_STAT\_ENTRY** enumeration lists the available types of request statistics.
+
+
+## -enum-fields
+
+
+### -field WinHttpConnectFailureCount
+
+The number of connection failures during connection establishment.
+
+
+### -field WinHttpProxyFailureCount
+
+The number of proxy connection failures during connection establishment.
+
+
+### -field WinHttpTlsHandshakeClientLeg1Size
+
+The size of the client data for the first leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeServerLeg1Size
+
+The size of the server data for the first leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg2Size
+
+The size of the client data for the second leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeServerLeg2Size
+
+The size of the server data for the second leg of the TLS handshake.
+
+
+### -field WinHttpRequestHeadersSize
+
+The size of the request headers.
+
+
+### -field WinHttpRequestHeadersCompressedSize
+
+The compressed size of the request headers.
+
+
+### -field WinHttpResponseHeadersSize
+
+The size of the response headers.
+
+
+### -field WinHttpResponseHeadersCompressedSize
+
+The compressed size of the response headers.
+
+
+### -field WinHttpResponseBodySize
+
+The size of the response body.
+
+
+### -field WinHttpResponseBodyCompressedSize
+
+The compressed size of the response body.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg1Size
+
+The size of the client data for the first leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeServerLeg1Size
+
+The size of the server data for the first leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg2Size
+
+The size of the client data for the second leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeServerLeg2Size
+
+The size of the server data for the second leg of the proxy TLS handshake.
+
+
+### -field WinHttpRequestStatLast
+
+Marker for the end of the list of available statistics.
+
+
+### -field WinHttpRequestStatMax
+
+The maximum number of statistics available.
+
+
+## -remarks
+
+This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption) to retrieve statistics for a request by specifying the **WINHTTP\_OPTION\_REQUEST\_STATS** flag.
+
+
+## -see-also
+
+[WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)
+
+[WINHTTP\_REQUEST\_STATS](/windows/desktop/api/winhttp/ns-winhttp-winhttp_request_stats)

--- a/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_time_entry.md
+++ b/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_time_entry.md
@@ -13,8 +13,8 @@ dev_langs:
 req.header: winhttp.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
-req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:

--- a/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_time_entry.md
+++ b/sdk-api-src/content/winhttp/ne-winhttp-winhttp_request_time_entry.md
@@ -1,0 +1,255 @@
+---
+UID: NE:winhttp._WINHTTP_REQUEST_TIME_ENTRY
+title: WINHTTP_REQUEST_TIME_ENTRY (winhttp.h)
+description: The WINHTTP_REQUEST_TIME_ENTRY enumeration lists the available types of request timing information.
+tech.root: WinHttp
+ms.assetid: bf88ad85-4fd8-4bd5-9cbb-361b2a486bab
+ms.date: 02/25/2020
+ms.keywords: WINHTTP_REQUEST_TIME_ENTRY, WINHTTP_REQUEST_TIME_ENTRY enumeration [HTTP], http.winhttp_request_time_entry, winhttp/WINHTTP_REQUEST_TIME_ENTRY, WinHttpProxyDetectionStart, WinHttpProxyDetectionEnd, WinHttpConnectionAcquireStart, WinHttpConnectionAcquireWaitEnd, WinHttpConnectionAcquireEnd, WinHttpNameResolutionStart, WinHttpNameResolutionEnd, WinHttpConnectionEstablishmentStart, WinHttpConnectionEstablishmentEnd, WinHttpTlsHandshakeClientLeg1Start, WinHttpTlsHandshakeClientLeg1End, WinHttpTlsHandshakeClientLeg2Start, WinHttpTlsHandshakeClientLeg2End, WinHttpTlsHandshakeClientLeg3Start, WinHttpTlsHandshakeClientLeg3End, WinHttpStreamWaitStart, WinHttpStreamWaitEnd, WinHttpSendRequestStart, WinHttpSendRequestHeadersCompressionStart, WinHttpSendRequestHeadersCompressionEnd, WinHttpSendRequestHeadersEnd, WinHttpSendRequestEnd, WinHttpReceiveResponseStart, WinHttpReceiveResponseHeadersDecompressionStart, WinHttpReceiveResponseHeadersDecompressionEnd, WinHttpReceiveResponseHeadersEnd, WinHttpReceiveResponseBodyDecompressionDelta, WinHttpReceiveResponseEnd, WinHttpProxyTunnelStart, WinHttpProxyTunnelEnd, WinHttpProxyTlsHandshakeClientLeg1Start, WinHttpProxyTlsHandshakeClientLeg1End, WinHttpProxyTlsHandshakeClientLeg2Start, WinHttpProxyTlsHandshakeClientLeg2End, WinHttpProxyTlsHandshakeClientLeg3Start, WinHttpProxyTlsHandshakeClientLeg3End, WinHttpRequestTimeLast, WinHttpRequestTimeMax, winhttp/WinHttpProxyDetectionStart, winhttp/WinHttpProxyDetectionEnd, winhttp/WinHttpConnectionAcquireStart, winhttp/WinHttpConnectionAcquireWaitEnd, winhttp/WinHttpConnectionAcquireEnd, winhttp/WinHttpNameResolutionStart, winhttp/WinHttpNameResolutionEnd, winhttp/WinHttpConnectionEstablishmentStart, winhttp/WinHttpConnectionEstablishmentEnd, winhttp/WinHttpTlsHandshakeClientLeg1Start, winhttp/WinHttpTlsHandshakeClientLeg1End, winhttp/WinHttpTlsHandshakeClientLeg2Start, winhttp/WinHttpTlsHandshakeClientLeg2End, winhttp/WinHttpTlsHandshakeClientLeg3Start, winhttp/WinHttpTlsHandshakeClientLeg3End, winhttp/WinHttpStreamWaitStart, winhttp/WinHttpStreamWaitEnd, winhttp/WinHttpSendRequestStart, winhttp/WinHttpSendRequestHeadersCompressionStart, winhttp/WinHttpSendRequestHeadersCompressionEnd, winhttp/WinHttpSendRequestHeadersEnd, winhttp/WinHttpSendRequestEnd, winhttp/WinHttpReceiveResponseStart, winhttp/WinHttpReceiveResponseHeadersDecompressionStart, winhttp/WinHttpReceiveResponseHeadersDecompressionEnd, winhttp/WinHttpReceiveResponseHeadersEnd, winhttp/WinHttpReceiveResponseBodyDecompressionDelta, winhttp/WinHttpReceiveResponseEnd, winhttp/WinHttpProxyTunnelStart, winhttp/WinHttpProxyTunnelEnd, winhttp/WinHttpProxyTlsHandshakeClientLeg1Start, winhttp/WinHttpProxyTlsHandshakeClientLeg1End, winhttp/WinHttpProxyTlsHandshakeClientLeg2Start, winhttp/WinHttpProxyTlsHandshakeClientLeg2End, winhttp/WinHttpProxyTlsHandshakeClientLeg3Start, winhttp/WinHttpProxyTlsHandshakeClientLeg3End, winhttp/WinHttpRequestTimeLast, winhttp/WinHttpRequestTimeMax
+f1_keywords:
+- winhttp/WINHTTP_REQUEST_TIME_ENTRY
+dev_langs:
+- c++
+req.header: winhttp.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- HeaderDef
+api_location:
+- winhttp.h
+api_name:
+- WINHTTP_REQUEST_TIME_ENTRY
+targetos: Windows
+req.typenames: WINHTTP_REQUEST_TIME_ENTRY
+req.redist:
+ms.custom: 19H1
+---
+
+# WINHTTP_REQUEST_TIME_ENTRY enumeration
+
+
+## -description
+
+The **WINHTTP\_REQUEST\_TIME\_ENTRY** enumeration lists the available types of request timing information.
+
+
+## -enum-fields
+
+
+### -field WinHttpProxyDetectionStart
+
+Start of proxy detection.
+
+
+### -field WinHttpProxyDetectionEnd
+
+End of proxy detection.
+
+
+### -field WinHttpConnectionAcquireStart
+
+Start of connection acquisition.
+
+
+### -field WinHttpConnectionAcquireWaitEnd
+
+End waiting for an available connection.
+
+
+### -field WinHttpConnectionAcquireEnd
+
+End of connection acquisition.
+
+
+### -field WinHttpNameResolutionStart
+
+Start of name resolution.
+
+
+### -field WinHttpNameResolutionEnd
+
+End of name resolution.
+
+
+### -field WinHttpConnectionEstablishmentStart
+
+Start of connection establishment.
+
+
+### -field WinHttpConnectionEstablishmentEnd
+
+End of connection establishment.
+
+
+### -field WinHttpTlsHandshakeClientLeg1Start
+
+Start of the first leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg1End
+
+End of the first leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg2Start
+
+Start of the second leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg2End
+
+End of the second leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg3Start
+
+Start of the third leg of the TLS handshake.
+
+
+### -field WinHttpTlsHandshakeClientLeg3End
+
+End of the third leg of the TLS handshake.
+
+
+### -field WinHttpStreamWaitStart
+
+Start waiting for an available stream.
+
+
+### -field WinHttpStreamWaitEnd
+
+End waiting for an available stream.
+
+
+### -field WinHttpSendRequestStart
+
+Start sending a request.
+
+
+### -field WinHttpSendRequestHeadersCompressionStart
+
+Start of request header compression.
+
+
+### -field WinHttpSendRequestHeadersCompressionEnd
+
+End of request header compression.
+
+
+### -field WinHttpSendRequestHeadersEnd
+
+End sending request headers.
+
+
+### -field WinHttpSendRequestEnd
+
+End sending a request.
+
+
+### -field WinHttpReceiveResponseStart
+
+Start receiving a response.
+
+
+### -field WinHttpReceiveResponseHeadersDecompressionStart
+
+Start of response header decompression.
+
+
+### -field WinHttpReceiveResponseHeadersDecompressionEnd
+
+End of response header decompression.
+
+
+### -field WinHttpReceiveResponseHeadersEnd
+
+End receiving response headers.
+
+
+### -field WinHttpReceiveResponseBodyDecompressionDelta
+
+Delta between start and end times for response body decompression.
+
+
+### -field WinHttpReceiveResponseEnd
+
+End receiving a response.
+
+
+### -field WinHttpProxyTunnelStart
+
+Start establishing a proxy tunnel.
+
+
+### -field WinHttpProxyTunnelEnd
+
+End establishing a proxy tunnel.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg1Start
+
+Start of the first leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg1End
+
+End of the first leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg2Start
+
+Start of the second leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg2End
+
+End of the second leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg3Start
+
+Start of the third leg of the proxy TLS handshake.
+
+
+### -field WinHttpProxyTlsHandshakeClientLeg3End
+
+End of the third leg of the proxy TLS handshake.
+
+
+### -field WinHttpRequestTimeLast
+
+Marker for the end of the list of available timings.
+
+
+### -field WinHttpRequestTimeMax
+
+The maximum number of timings available.
+
+
+## -remarks
+
+This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption) to retrieve timing information for a request by specifying the **WINHTTP\_OPTION\_REQUEST\_TIMES** flag.
+
+
+## -see-also
+
+[WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)
+
+[WINHTTP\_REQUEST\_TIMES](/windows/desktop/api/winhttp/ns-winhttp-winhttp_request_times)

--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpqueryoption.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpqueryoption.md
@@ -89,7 +89,7 @@ A pointer to an unsigned long integer variable that contains the length of
 
 
 Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise. To get a specific error message, call 
-<a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following.
+<a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following:
 
 <table>
 <tr>

--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpsetoption.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpsetoption.md
@@ -84,7 +84,7 @@ Unsigned long integer value that contains the length of the
 
 
 Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise. For extended error information, call 
-<a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following
+<a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following:
 
 <table>
 <tr>

--- a/sdk-api-src/content/winhttp/ns-winhttp-http_version_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-http_version_info.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_1
+UID: NS:winhttp._HTTP_VERSION_INFO
 title: HTTP_VERSION_INFO (winhttp.h)
 description: The HTTP_VERSION_INFO structure contains the global HTTP version.
 old-location: http\http_version_info.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-url_components.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-url_components.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_2
+UID: NS:winhttp._URL_COMPONENTS
 title: URL_COMPONENTS (winhttp.h)
 description: The URL_COMPONENTS structure contains the constituent parts of a URL. This structure is used with the WinHttpCrackUrl and WinHttpCreateUrl functions.
 old-location: http\url_components.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_async_result.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_async_result.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_0
+UID: NS:winhttp._WINHTTP_ASYNC_RESULT
 title: WINHTTP_ASYNC_RESULT (winhttp.h)
 description: The WINHTTP_ASYNC_RESULT structure contains the result of a call to an asynchronous function. This structure is used with the WINHTTP_STATUS_CALLBACK prototype.
 old-location: http\winhttp_async_result.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_autoproxy_options.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_autoproxy_options.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_4
+UID: NS:winhttp._WINHTTP_AUTOPROXY_OPTIONS
 title: WINHTTP_AUTOPROXY_OPTIONS (winhttp.h)
 description: The WINHTTP_AUTOPROXY_OPTIONS structure is used to indicate to the WinHttpGetProxyForURL function whether to specify the URL of the Proxy Auto-Configuration (PAC) file or to automatically locate the URL with DHCP or DNS queries to the network.
 old-location: http\winhttp_autoproxy_options.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_certificate_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_certificate_info.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_5
+UID: NS:winhttp._WINHTTP_CERTIFICATE_INFO
 title: WINHTTP_CERTIFICATE_INFO (winhttp.h)
 description: The WINHTTP_CERTIFICATE_INFO structure contains certificate information returned from the server. This structure is used by the WinHttpQueryOption function.
 old-location: http\internet_certificate_info.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_connection_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_connection_info.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_6
+UID: NS:winhttp._WINHTTP_CONNECTION_INFO
 title: WINHTTP_CONNECTION_INFO (winhttp.h)
 description: The WINHTTP_CONNECTION_INFO structure contains the source and destination IP address of the request that generated the response.
 old-location: http\winhttp_connection_info.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_current_user_ie_proxy_config.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_current_user_ie_proxy_config.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_7
+UID: NS:winhttp._WINHTTP_CURRENT_USER_IE_PROXY_CONFIG
 title: WINHTTP_CURRENT_USER_IE_PROXY_CONFIG (winhttp.h)
 description: The WINHTTP_CURRENT_USER_IE_PROXY_CONFIG structure contains the Internet Explorer proxy configuration information.
 old-location: http\winhttp_current_user_ie_proxy_config.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_proxy_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_proxy_info.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winhttp.__unnamed_struct_3
+UID: NS:winhttp._WINHTTP_PROXY_INFO
 title: WINHTTP_PROXY_INFO (winhttp.h)
 description: The WINHTTP_PROXY_INFO structure contains the session or default proxy configuration.
 old-location: http\internet_proxy_info.htm

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
@@ -1,0 +1,74 @@
+---
+UID: NS:winhttp._WINHTTP_REQUEST_STATS
+title: WINHTTP_REQUEST_STATS (winhttp.h)
+description: The WINHTTP_REQUEST_STATS structure contains a variety of statistics for a request.
+old-location:
+tech.root: WinHttp
+ms.assetid: 7c65777e-24eb-4713-a7b8-7263a217e8ba
+ms.date: 02/25/2020
+ms.keywords: '*LPWINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS structure [HTTP], http.winhttp_request_stats, winhttp/WINHTTP_REQUEST_STATS, WINHTTP_OPTION_REQUEST_STATS'
+f1_keywords:
+- winhttp/WINHTTP_REQUEST_STATS
+dev_langs:
+- c++
+req.header: winhttp.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- HeaderDef
+api_location:
+- Winhttp.h
+api_name:
+- WINHTTP_REQUEST_STATS
+targetos: Windows
+req.typenames: WINHTTP_REQUEST_STATS, *LPWINHTTP_REQUEST_STATS
+req.redist:
+ms.custom: 19H1
+---
+
+# WINHTTP_REQUEST_STATS structure
+
+
+## -description
+
+The **WINHTTP\_REQUEST\_STATS** structure contains a variety of statistics for a request.
+
+
+## -struct-fields
+
+
+### -field cStats
+
+Unsigned long integer value that contains the number of statistics to retrieve. This should generally be set to **WinHttpRequestStatLast**.
+
+
+### -field rgullStats
+
+Array of unsigned long long integer values that will contain the returned statistics, indexed by [**WINHTTP\_REQUEST\_STAT\_ENTRY**](/windows/desktop/api/winhttp/ne-winhttp-winhttp_request_stat_entry).
+
+
+## -remarks
+
+This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption) to retrieve statistics for a request by specifying the **WINHTTP\_OPTION\_REQUEST\_STATS** flag.
+
+
+## -see-also
+
+[WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
@@ -14,7 +14,7 @@ dev_langs:
 req.header: winhttp.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
 req.target-min-winversvr: Windows Server 2019 [desktop apps only]
 req.kmdf-ver:
 req.umdf-ver:

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
@@ -14,7 +14,7 @@ dev_langs:
 req.header: winhttp.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
 req.target-min-winversvr: Windows Server 2019 [desktop apps only]
 req.kmdf-ver:
 req.umdf-ver:

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
@@ -1,0 +1,74 @@
+---
+UID: NS:winhttp._WINHTTP_REQUEST_TIMES
+title: WINHTTP_REQUEST_TIMES (winhttp.h)
+description: The WINHTTP_REQUEST_TIMES structure contains a variety of timing information for an HTTP request.
+old-location:
+tech.root: WinHttp
+ms.assetid: 4d30cd0a-88ea-4d03-951d-be50c017efd3
+ms.date: 02/25/2020
+ms.keywords: '*LPWINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES structure [HTTP], http.winhttp_request_times, winhttp/WINHTTP_REQUEST_TIMES, WINHTTP_OPTION_REQUEST_TIMES'
+f1_keywords:
+- winhttp/WINHTTP_REQUEST_TIMES
+dev_langs:
+- c++
+req.header: winhttp.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- HeaderDef
+api_location:
+- Winhttp.h
+api_name:
+- WINHTTP_REQUEST_TIMES
+targetos: Windows
+req.typenames: WINHTTP_REQUEST_TIMES, *LPWINHTTP_REQUEST_TIMES
+req.redist:
+ms.custom: 19H1
+---
+
+# WINHTTP_REQUEST_TIMES structure
+
+
+## -description
+
+The **WINHTTP\_REQUEST\_TIMES** structure contains a variety of timing information for a request.
+
+
+## -struct-fields
+
+
+### -field cTimes
+
+Unsigned long integer value that contains the number of timings to retrieve. This should generally be set to **WinHttpRequestTimeLast**.
+
+
+### -field rgullTimes
+
+Array of unsigned long long integer values that will contain the returned timings, indexed by [**WINHTTP\_REQUEST\_TIME\_ENTRY**](/windows/desktop/api/winhttp/ne-winhttp-winhttp_request_time_entry). Times are measured in performance counter ticks; for more information, see TODO.
+
+
+## -remarks
+
+This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption) to retrieve timing information for a request by specifying the **WINHTTP\_OPTION\_REQUEST\_TIMES** flag.
+
+
+## -see-also
+
+[WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
@@ -14,8 +14,8 @@ dev_langs:
 req.header: winhttp.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
-req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 2004 [desktop apps only]
+req.target-min-winversvr: Windows Server Insider Preview [desktop apps only]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:
@@ -40,7 +40,7 @@ api_name:
 targetos: Windows
 req.typenames: WINHTTP_SECURITY_INFO, *LPWINHTTP_SECURITY_INFO
 req.redist:
-ms.custom: 19H1
+ms.custom: Vb
 ---
 
 # WINHTTP_SECURITY_INFO structure

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
@@ -1,0 +1,74 @@
+---
+UID: NS:winhttp._WINHTTP_SECURITY_INFO
+title: WINHTTP_SECURITY_INFO (winhttp.h)
+description: The WINHTTP_SECURITY_INFO structure contains a variety of timing information for an HTTP request.
+old-location:
+tech.root: WinHttp
+ms.assetid: f4459d2c-de31-4313-ae26-b8f8c1c7b56b
+ms.date: 02/25/2020
+ms.keywords: '*LPWINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO structure [HTTP], http.winhttp_security_info, winhttp/WINHTTP_SECURITY_INFO, WINHTTP_OPTION_SECURITY_INFO'
+f1_keywords:
+- winhttp/WINHTTP_SECURITY_INFO
+dev_langs:
+- c++
+req.header: winhttp.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt: Windows 10, version 1903 [desktop apps only]
+req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- HeaderDef
+api_location:
+- Winhttp.h
+api_name:
+- WINHTTP_SECURITY_INFO
+targetos: Windows
+req.typenames: WINHTTP_SECURITY_INFO, *LPWINHTTP_SECURITY_INFO
+req.redist:
+ms.custom: 19H1
+---
+
+# WINHTTP_SECURITY_INFO structure
+
+
+## -description
+
+The **WINHTTP\_SECURITY\_INFO** structure contains the SChannel connection and cipher information for a request.
+
+
+## -struct-fields
+
+
+### -field ConnectionInfo
+
+[**SecPkgContext\_ConnectionInfo**](/windows/desktop/api/schannel/ns-schannel-secpkgcontext_connectioninfo) containing the SChannel connection information for the request.
+
+
+### -field CipherInfo
+
+[**SecPkgContext\_CipherInfo**](/windows/desktop/api/schannel/ns-schannel-secpkgcontext_cipherinfo) containing the SChannel cipher information for the request.
+
+
+## -remarks
+
+This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption) to retrieve security information for a request by specifying the **WINHTTP\_OPTION\_SECURITY\_INFO** flag.
+
+
+## -see-also
+
+[WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)


### PR DESCRIPTION
Add structs and enums for new WinHttp options. See also: MicrosoftDocs/win32#237, MicrosoftDocs/win32#238