### PR TITLE
Fix missing struct field and leftover TODO

### DIFF
--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_stats.md
@@ -6,7 +6,7 @@ old-location:
 tech.root: WinHttp
 ms.assetid: 7c65777e-24eb-4713-a7b8-7263a217e8ba
 ms.date: 02/25/2020
-ms.keywords: '*LPWINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS structure [HTTP], http.winhttp_request_stats, winhttp/WINHTTP_REQUEST_STATS, WINHTTP_OPTION_REQUEST_STATS'
+ms.keywords: '*PWINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS, WINHTTP_REQUEST_STATS structure [HTTP], http.winhttp_request_stats, winhttp/WINHTTP_REQUEST_STATS, WINHTTP_OPTION_REQUEST_STATS'
 f1_keywords:
 - winhttp/WINHTTP_REQUEST_STATS
 dev_langs:
@@ -38,7 +38,7 @@ api_location:
 api_name:
 - WINHTTP_REQUEST_STATS
 targetos: Windows
-req.typenames: WINHTTP_REQUEST_STATS, *LPWINHTTP_REQUEST_STATS
+req.typenames: WINHTTP_REQUEST_STATS, *PWINHTTP_REQUEST_STATS
 req.redist:
 ms.custom: 19H1
 ---
@@ -52,6 +52,23 @@ The **WINHTTP\_REQUEST\_STATS** structure contains a variety of statistics for a
 
 
 ## -struct-fields
+
+
+### -field ullFlags
+
+Flags containing details on how the request was made. The following flags are available:
+| Value | Meaning |
+|-|-|
+| WINHTTP_REQUEST_STAT_FLAG_TCP_FAST_OPEN | TCP Fast Open occurred. |
+| WINHTTP_REQUEST_STAT_FLAG_TLS_SESSION_RESUMPTION | TLS Session Resumption occurred. |
+| WINHTTP_REQUEST_STAT_FLAG_TLS_FALSE_START | TLS False Start occurred. |
+| WINHTTP_REQUEST_STAT_FLAG_PROXY_TLS_SESSION_RESUMPTION | TLS Session Resumption occurred for the proxy connection. |
+| WINHTTP_REQUEST_STAT_FLAG_PROXY_TLS_FALSE_START | TLS False Start occurred for the proxy connection. |
+| WINHTTP_REQUEST_STAT_FLAG_FIRST_REQUEST | This is the first request on the connection. |
+
+### -field ulIndex
+
+The index of the request on the connection. This indicates how many prior requests were sent over the shared connection.
 
 
 ### -field cStats

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_request_times.md
@@ -6,7 +6,7 @@ old-location:
 tech.root: WinHttp
 ms.assetid: 4d30cd0a-88ea-4d03-951d-be50c017efd3
 ms.date: 02/25/2020
-ms.keywords: '*LPWINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES structure [HTTP], http.winhttp_request_times, winhttp/WINHTTP_REQUEST_TIMES, WINHTTP_OPTION_REQUEST_TIMES'
+ms.keywords: '*PWINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES, WINHTTP_REQUEST_TIMES structure [HTTP], http.winhttp_request_times, winhttp/WINHTTP_REQUEST_TIMES, WINHTTP_OPTION_REQUEST_TIMES'
 f1_keywords:
 - winhttp/WINHTTP_REQUEST_TIMES
 dev_langs:
@@ -38,7 +38,7 @@ api_location:
 api_name:
 - WINHTTP_REQUEST_TIMES
 targetos: Windows
-req.typenames: WINHTTP_REQUEST_TIMES, *LPWINHTTP_REQUEST_TIMES
+req.typenames: WINHTTP_REQUEST_TIMES, *PWINHTTP_REQUEST_TIMES
 req.redist:
 ms.custom: 19H1
 ---
@@ -61,7 +61,9 @@ Unsigned long integer value that contains the number of timings to retrieve. Thi
 
 ### -field rgullTimes
 
-Array of unsigned long long integer values that will contain the returned timings, indexed by [**WINHTTP\_REQUEST\_TIME\_ENTRY**](/windows/desktop/api/winhttp/ne-winhttp-winhttp_request_time_entry). Times are measured in performance counter ticks; for more information, see TODO.
+Array of unsigned long long integer values that will contain the returned timings, indexed by [**WINHTTP\_REQUEST\_TIME\_ENTRY**](/windows/desktop/api/winhttp/ne-winhttp-winhttp_request_time_entry).
+
+Times are measured as performance counter values; for more information, see [QueryPerformanceCounter](/windows/desktop/api/profileapi/nf-profileapi-queryperformancecounter).
 
 
 ## -remarks
@@ -72,3 +74,5 @@ This structure is used with [WinHttpQueryOption](/windows/desktop/api/winhttp/nf
 ## -see-also
 
 [WinHttpQueryOption](/windows/desktop/api/winhttp/nf-winhttp-winhttpqueryoption)
+
+[QueryPerformanceCounter](/windows/desktop/api/profileapi/nf-profileapi-queryperformancecounter)

--- a/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
+++ b/sdk-api-src/content/winhttp/ns-winhttp-winhttp_security_info.md
@@ -6,7 +6,7 @@ old-location:
 tech.root: WinHttp
 ms.assetid: f4459d2c-de31-4313-ae26-b8f8c1c7b56b
 ms.date: 02/25/2020
-ms.keywords: '*LPWINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO structure [HTTP], http.winhttp_security_info, winhttp/WINHTTP_SECURITY_INFO, WINHTTP_OPTION_SECURITY_INFO'
+ms.keywords: '*PWINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO, WINHTTP_SECURITY_INFO structure [HTTP], http.winhttp_security_info, winhttp/WINHTTP_SECURITY_INFO, WINHTTP_OPTION_SECURITY_INFO'
 f1_keywords:
 - winhttp/WINHTTP_SECURITY_INFO
 dev_langs:
@@ -38,7 +38,7 @@ api_location:
 api_name:
 - WINHTTP_SECURITY_INFO
 targetos: Windows
-req.typenames: WINHTTP_SECURITY_INFO, *LPWINHTTP_SECURITY_INFO
+req.typenames: WINHTTP_SECURITY_INFO, *PWINHTTP_SECURITY_INFO
 req.redist:
 ms.custom: Vb
 ---


### PR DESCRIPTION
I overlooked two struct fields and a TODO marker when I submitted #104; this PR fills in the missing information.