### PR TITLE
Mention MKSYS_URLMONIKER in MKSYS enumeration?

### DIFF
--- a/sdk-api-src/content/objidl/ne-objidl-mksys.md
+++ b/sdk-api-src/content/objidl/ne-objidl-mksys.md
@@ -106,6 +106,9 @@ Indicates the system's terminal server session moniker class.
 
 Indicates the system's elevation moniker class.
 
+## Remark
+
+MKSYS_URLMONIKER is an additional value.
 
 ## -see-also
 


### PR DESCRIPTION
MKSYS_URLMONIKER can be obtained from IsSystemMoniker (see https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-imoniker-issystemmoniker), but is not mentioned in the linked MKSYS enumeration documentation.

I see that it is not defined in the enum (at least not in my ObjIdl.h), but it is defined in urlmon.h and seems to fill exactly the gap in ObjIdl.h.