### PR TITLE
Use escape for backslash

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-querydosdevicew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-querydosdevicew.md
@@ -79,7 +79,7 @@ MS-DOS device names are stored as junctions in the object namespace. The code th
 ### -param lpDeviceName [in, optional]
 
 An MS-DOS device name string specifying the target of the query. The device name cannot have a trailing 
-       backslash; for example, use "C:", not "C:\".
+       backslash; for example, use "C:", not "C:\\".
 
 This parameter can be <b>NULL</b>. In that case, the 
        <b>QueryDosDevice</b> function will store a list of all 


### PR DESCRIPTION
Fixes the missing backslash in this text.

![image](https://user-images.githubusercontent.com/1027111/76524819-09634380-646b-11ea-8f8f-dd75c3561e2a.png)
