### PR TITLE
Fix garbage after OpenMutex link.

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexa.md
@@ -192,7 +192,7 @@ For an example that uses
 
 
 
-[OpenMutex](/windows/win32/api/synchapi/nf-synchapi-openmutexw)a>
+[OpenMutex](/windows/win32/api/synchapi/nf-synchapi-openmutexw)
 
 
 


### PR DESCRIPTION
Was reading the docs and noticed these trailing characters.