### PR TITLE
Update nf-ws2tcpip-inet_ntop.md

### DIFF
--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-inet_ntop.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-inet_ntop.md
@@ -172,7 +172,7 @@ An invalid parameter was passed to the function. This error is returned if a <b>
 
 
 The 
-<b>InetNtop</b> function is supported on Windows Vistaand later.
+<b>InetNtop</b> function is supported on Windows Vista and later.
 
 The 
 <b>InetNtop</b> function provides a protocol-independent address-to-string translation. The 


### PR DESCRIPTION
Add missing space between "Windows Vista" and "and".