### PR TITLE
Correct minimum OS version for GetPointerInputTransform API

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getpointerinputtransform.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getpointerinputtransform.md
@@ -14,8 +14,8 @@ dev_langs:
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 [desktop apps only]
+req.target-min-winverclnt: Windows 8.1 [desktop apps only]
+req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
GetPointerInputTransform was introduced in Win8.1, not Win8. Stated here: https://software.intel.com/en-us/articles/ultrabook-device-and-tablet-windows-touch-developer-guide, but I have also checked in the official Windows SDK header (WinUser.h)

Thanks!