### PR TITLE
Incorrect declaration of sockaddr_in

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-recvfrom.md
+++ b/sdk-api-src/content/winsock/nf-winsock-recvfrom.md
@@ -361,14 +361,14 @@ int main()
     WSADATA wsaData;
 
     SOCKET RecvSocket;
-    sockaddr_in RecvAddr;
+    struct sockaddr_in RecvAddr;
 
     unsigned short Port = 27015;
 
     char RecvBuf[1024];
     int BufLen = 1024;
 
-    sockaddr_in SenderAddr;
+    struct sockaddr_in SenderAddr;
     int SenderAddrSize = sizeof (SenderAddr);
 
     //-----------------------------------------------


### PR DESCRIPTION
This code incorrectly declares `sockaddr_in`, which is actually `struct sockaddr_in`. This leads to the following compile failures on the Microsoft C++ compiler:

```
serv.c(25): error C2065: 'sockaddr_in': undeclared identifier
serv.c(25): error C2146: syntax error: missing ';' before identifier 'RecvAddr'
serv.c(25): error C2065: 'RecvAddr': undeclared identifier
serv.c(32): error C2065: 'sockaddr_in': undeclared identifier
serv.c(32): error C2146: syntax error: missing ';' before identifier 'SenderAddr'
serv.c(32): error C2065: 'SenderAddr': undeclared identifier
serv.c(33): error C2065: 'SenderAddr': undeclared identifier
serv.c(51): error C2065: 'RecvAddr': undeclared identifier
serv.c(51): error C2224: left of '.sin_family' must have struct/union type
serv.c(52): error C2065: 'RecvAddr': undeclared identifier
serv.c(52): error C2224: left of '.sin_port' must have struct/union type
serv.c(53): error C2065: 'RecvAddr': undeclared identifier
serv.c(53): error C2224: left of '.sin_addr' must have struct/union type
serv.c(55): error C2065: 'RecvAddr': undeclared identifier
serv.c(65): error C2065: 'SenderAddr': undeclared identifier
```

However, changing to `struct sockaddr_in` for each declaration makes it compile with no errors:

```
>cl serv.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27032.1 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

serv.c
Microsoft (R) Incremental Linker Version 14.16.27032.1
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:serv.exe
serv.obj
```