### PR TITLE
Correct backslashes in GetTempPathW

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-gettemppathw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-gettemppathw.md
@@ -82,7 +82,7 @@ The size of the string buffer identified by <i>lpBuffer</i>, in
 ### -param lpBuffer [out]
 
 A pointer to a string buffer that receives the null-terminated string specifying the temporary file path. 
-      The returned string ends with a backslash, for example, "C:\TEMP\".
+      The returned string ends with a backslash, for example, "C:\\TEMP\\".
 
 
 ## -returns


### PR DESCRIPTION
The current documentation is rendered as follows:
> The returned string ends with a backslash, for example, "C:\TEMP".

The second backslash in the example output is applied to the following punctuation character, and should be doubled.