### PR TITLE
Updated DHCP and DHCPv6 Client API.

### DIFF
--- a/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcpregisterparamchange.md
+++ b/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcpregisterparamchange.md
@@ -70,7 +70,7 @@ Reserved. Must be set to <b>NULL</b>.
 
 ### -param AdapterName [in]
 
-Name of the adapter for which event notification is being requested.  Must be under 256 characters. 
+GUID of the adapter for which event notification is being requested.  Must be under 256 characters. 
 
 
 ### -param ClassId [in]

--- a/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcprequestparams.md
+++ b/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcprequestparams.md
@@ -98,7 +98,7 @@ Reserved for future use. Must be set to <b>NULL</b>.
 
 ### -param AdapterName [in]
 
-Name of the adapter on which requested data is being made. Must be under 256 characters.
+GUID of the adapter on which requested data is being made. Must be under 256 characters.
 
 
 ### -param ClassId [in]

--- a/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcpundorequestparams.md
+++ b/sdk-api-src/content/dhcpcsdk/nf-dhcpcsdk-dhcpundorequestparams.md
@@ -71,7 +71,7 @@ Reserved for future use. Must be set to <b>NULL</b>.
 
 ### -param AdapterName [in]
 
-Name of the adapter for which information is no longer required.  Must be under 256 characters.
+GUID of the adapter for which information is no longer required.  Must be under 256 characters.
 
 <div class="alert"><b>Note</b>  This parameter is no longer used.</div>
 <div> </div>

--- a/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6releaseprefix.md
+++ b/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6releaseprefix.md
@@ -95,11 +95,24 @@ Returns ERROR_SUCCESS upon successful completion.
 Returned if one of the following conditions are true:
 
 <ul>
-<li><i>AdapterName</i> is <b>NULL</b>.</li>
+<li><i>AdapterName</i> is <b>NULL</b>. Or no adapter is found with the GUID specified.</li>
 <li><i>prefixleaseInfo</i> is <b>NULL</b>.</li>
 </ul>
 </td>
 </tr>
+
+<tr>
+<td width="40%">
+<dl>
+<dt><b>ERROR_INVALID_NAME</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <i>AdapterName</i> is not in the correct format. It should be in this format: {00000000-0000-0000-0000-000000000000}.
+
+</td>
+</tr>
+
 </table>
  
 

--- a/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6renewprefix.md
+++ b/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6renewprefix.md
@@ -59,12 +59,12 @@ The <b>Dhcpv6RenewPrefix</b> function renews a prefix previously acquired with t
 
 ### -param adapterName [in]
 
-Name of the adapter on which the prefix renewal must be sent.
+GUID of the adapter on which the prefix renewal must be sent.
 
 
 ### -param pclassId [in]
 
-Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to send on the wire.
+Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to send on the wire. This parameter is can be <b>NULL</b>.
 
 <div class="alert"><b>Note</b>  DHCPv6 Option Code 15 (0x000F) is not supported by this API. Typically, the User Class option is used by a client to identify the type or category of user or application it represents. A server selects the configuration information for the client based on the classes identified in this option.</div>
 <div> </div>
@@ -105,7 +105,7 @@ Returns ERROR_SUCCESS upon successful completion.
 Returned if one of the following conditions are true:
 
 <ul>
-<li><i>AdapterName</i> is <b>NULL</b>.</li>
+<li><i>AdapterName</i> is <b>NULL</b>. Or no adapter is found with the GUID specified. </li>
 <li><i>prefixleaseInfo</i> is <b>NULL</b>.</li>
 <li><i>pdwTimeToWait</i> is <b>NULL</b>.</li>
 </ul>
@@ -122,6 +122,19 @@ Returned if the API responds with more prefixes than there is memory allocated.
 
 </td>
 </tr>
+
+<tr>
+<td width="40%">
+<dl>
+<dt><b>ERROR_INVALID_NAME</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <i>AdapterName</i> is not in the correct format. It should be in this format: {00000000-0000-0000-0000-000000000000}.
+
+</td>
+</tr>
+
 </table>
  
 

--- a/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6requestparams.md
+++ b/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6requestparams.md
@@ -69,12 +69,12 @@ Reserved for future use.  Must be set to <b>NULL</b>.
 
 ### -param adapterName
 
-Name of the adapter for which this request is meant.  This parameter must not be <b>NULL</b>.
+GUID of the adapter for which this request is meant.  This parameter must not be <b>NULL</b>.
 
 
 ### -param classId
 
-Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to use to send on the wire.
+Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to use to send on the wire. This parameter is optional.
 
 
 ### -param recdParams
@@ -114,7 +114,7 @@ Returned if one of the following conditions are true:
 
 <ul>
 <li><i>reserved</i> has a value that is not <b>NULL</b>.</li>
-<li><i>AdapterName</i> is <b>NULL</b>.</li>
+<li><i>AdapterName</i> is <b>NULL</b>. Or no adapter is found with the GUID specified. </li>
 <li><i>pSize</i> is <b>NULL</b>.</li>
 <li><i>buffer</i> is <b>NULL</b>.</li>
 </ul>
@@ -131,6 +131,19 @@ The call to this API was made with insufficient memory allocated for the <i>Buff
 
 </td>
 </tr>
+
+<tr>
+<td width="40%">
+<dl>
+<dt><b>ERROR_INVALID_NAME</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <i>AdapterName</i> is not in the correct format. It should be in this format: {00000000-0000-0000-0000-000000000000}.
+
+</td>
+</tr>
+
 </table>
  
 

--- a/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6requestprefix.md
+++ b/sdk-api-src/content/dhcpv6csdk/nf-dhcpv6csdk-dhcpv6requestprefix.md
@@ -59,12 +59,12 @@ The <b>Dhcpv6RequestPrefix</b> function requests a specific prefix.
 
 ### -param adapterName [in]
 
-Name of the adapter on which the prefix request must be sent.
+GUID of the adapter on which the prefix request must be sent. 
 
 
 ### -param pclassId [in]
 
-Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to  send on the wire.
+Pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/dhcpv6csdk/ns-dhcpv6csdk-dhcpv6capi_classid">DHCPV6CAPI_CLASSID</a> structure that contains the binary ClassId information to  send on the wire. This parameter is optional.
 
 <div class="alert"><b>Note</b>  DHCPv6 Option Code 15 (0x000F) is not supported by this API. Typically, the User Class option is used by a client to identify the type or category of user or application it represents. A server selects the configuration information for the client based on the classes identified in this option.</div>
 <div> </div>
@@ -130,6 +130,7 @@ The value of the <b>nPrefixes</b> or the <b>ServerIdLen</b> member specified is 
 
 </td>
 </tr>
+
 <tr>
 <td width="40%">
 <dl>
@@ -140,13 +141,27 @@ The value of the <b>nPrefixes</b> or the <b>ServerIdLen</b> member specified is 
 Returned if one of the following conditions are true:
 
 <ul>
-<li><i>AdapterName</i> is <b>NULL</b>.</li>
+<li><i>AdapterName</i> is <b>NULL</b>. Or no adapter is found with the GUID specified. </li>
 <li><i>prefixleaseInfo</i> is <b>NULL</b>.</li>
 <li><i>pdwTimeToWait</i> is <b>NULL</b>.</li>
 <li>The <b>iaid</b> member of the <i>prefixleaseInfo</i> is zero.</li>
 </ul>
 </td>
 </tr>
+
+
+<tr>
+<td width="40%">
+<dl>
+<dt><b>ERROR_INVALID_NAME</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <i>AdapterName</i> is not in the correct format. It should be in this format: {00000000-0000-0000-0000-000000000000}.
+
+</td>
+</tr>
+
 </table>
  
 


### PR DESCRIPTION
1. Emphasized that _AdapterName_ is a GUID, not the name of the adapter.
2. Added notes that `pclassId` can be null for the DHCPv6 APIs.
3. Added `ERROR_INVALID_NAME` as a possible return value.
4. Added "Or no adapter is found with the GUID specified. " to the return value of `ERROR_INVALID_PARAMETER`.