### PR TITLE
Update nf-psapi-getmappedfilenamea.md

### DIFF
--- a/sdk-api-src/content/psapi/nf-psapi-getmappedfilenamea.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getmappedfilenamea.md
@@ -69,7 +69,7 @@ Checks whether the specified address is within a memory-mapped file in the addre
 
 ### -param hProcess [in]
 
-A handle to the process. The handle must have the <b>PROCESS_QUERY_INFORMATION</b> and <b>PROCESS_VM_READ</b> access rights. For more information, see <a href="https://docs.microsoft.com/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
+A handle to the process. The handle must have the <b>PROCESS_QUERY_INFORMATION</b> access right. For more information, see <a href="https://docs.microsoft.com/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
 
 
 ### -param lpv [in]


### PR DESCRIPTION
The process handle just needs PROCESS_QUERY_INFORMATION (PROCESS_VM_READ does not seem to be needed)