### PR TITLE
Remove field from CHOOSECOLOR

### DIFF
--- a/sdk-api-src/content/commdlg/ns-commdlg-choosecolora~r1.md
+++ b/sdk-api-src/content/commdlg/ns-commdlg-choosecolora~r1.md
@@ -206,8 +206,6 @@ Type: <b>LPCTSTR</b>
 
 The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CC_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member. 
 
-### -field lpEditInfo
-
 ## -remarks
 
 ## -see-also

--- a/sdk-api-src/content/commdlg/ns-commdlg-choosecolorw~r1.md
+++ b/sdk-api-src/content/commdlg/ns-commdlg-choosecolorw~r1.md
@@ -211,8 +211,6 @@ Type: <b>LPCTSTR</b>
 The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CC_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member. 
 
 
-### -field lpEditInfo
-
 
 
 ## -remarks


### PR DESCRIPTION
Per `commdlg.h`, this field is not present on Win32, unless running on a Mac (?)