### PR TITLE
Only the first 259 TCHAR's are displayed not 260.

### DIFF
--- a/sdk-api-src/content/commctrl/ns-commctrl-lvitema.md
+++ b/sdk-api-src/content/commctrl/ns-commctrl-lvitema.md
@@ -1,7 +1,8 @@
 ---
 UID: NS:commctrl.tagLVITEMA
 title: LVITEMA (commctrl.h)
-description: Specifies or receives the attributes of a list-view item. This structure has been updated to support a new mask value (LVIF_INDENT) that enables item indenting. This structure supersedes the LV_ITEM structure.helpviewer_keywords: ["*LPLVITEMA","I_GROUPIDCALLBACK","I_GROUPIDNONE","LPLVITEM","LPLVITEM structure pointer [Windows Controls]","LVCFMT_FILL","LVCFMT_LINE_BREAK","LVCFMT_NO_TITLE","LVCFMT_TILE_PLACEMENTMASK","LVCFMT_WRAP","LVIF_COLFMT","LVIF_COLUMNS","LVIF_DI_SETITEM","LVIF_GROUPID","LVIF_IMAGE","LVIF_INDENT","LVIF_NORECOMPUTE","LVIF_PARAM","LVIF_STATE","LVIF_TEXT","LVITEM","LVITEM structure [Windows Controls]","LVITEMA","LVITEMW","_win32_LVITEM","_win32_LVITEM_cpp","commctrl/LPLVITEM","commctrl/LVITEM","commctrl/LVITEMA","commctrl/LVITEMW","controls.LVITEM","controls._win32_LVITEM"]
+description: Specifies or receives the attributes of a list-view item. This structure has been updated to support a new mask value (LVIF_INDENT) that enables item indenting. This structure supersedes the LV_ITEM structure.
+helpviewer_keywords: ["*LPLVITEMA","I_GROUPIDCALLBACK","I_GROUPIDNONE","LPLVITEM","LPLVITEM structure pointer [Windows Controls]","LVCFMT_FILL","LVCFMT_LINE_BREAK","LVCFMT_NO_TITLE","LVCFMT_TILE_PLACEMENTMASK","LVCFMT_WRAP","LVIF_COLFMT","LVIF_COLUMNS","LVIF_DI_SETITEM","LVIF_GROUPID","LVIF_IMAGE","LVIF_INDENT","LVIF_NORECOMPUTE","LVIF_PARAM","LVIF_STATE","LVIF_TEXT","LVITEM","LVITEM structure [Windows Controls]","LVITEMA","LVITEMW","_win32_LVITEM","_win32_LVITEM_cpp","commctrl/LPLVITEM","commctrl/LVITEM","commctrl/LVITEMA","commctrl/LVITEMW","controls.LVITEM","controls._win32_LVITEM"]
 old-location: controls\LVITEM.htm
 tech.root: Controls
 ms.assetid: VS|Controls|~\controls\listview\structures\lvitem.htm
@@ -238,7 +239,7 @@ If the structure specifies item attributes, <b>pszText</b> is a pointer to a nul
 
 
 
-If the structure receives item attributes, <b>pszText</b> is a pointer to a buffer that receives the item text. Note that although the list-view control allows any length string to be stored as item text, only the first 260 <b>TCHAR</b>s are displayed.
+If the structure receives item attributes, <b>pszText</b> is a pointer to a buffer that receives the item text. Note that although the list-view control allows any length string to be stored as item text, only the first 259 <b>TCHAR</b>s are displayed.
 
 
 


### PR DESCRIPTION
Although the list-view control allows any length string to be stored as item text, only the first 259 TCHAR's are displayed. The last character is a null character.