### PR TITLE
Link SetThreadDescription to a How to article

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:processthreadsapi.SetThreadDescription
 title: SetThreadDescription function (processthreadsapi.h)
-description: Assigns a description to a thread.helpviewer_keywords: ["SetThreadDescription","SetThreadDescription function","base.setthreaddescription","processthreadsapi/SetThreadDescription"]
+description: Assigns a description to a thread.
+helpviewer_keywords: ["SetThreadDescription","SetThreadDescription function","base.setthreaddescription","processthreadsapi/SetThreadDescription"]
 old-location: base\setthreaddescription.htm
 tech.root: ProcThread
 ms.assetid: 0C17C60A-8DC9-4DB1-A3ED-5AFEBE598CBB
@@ -108,10 +109,10 @@ if (FAILED(hr))
 ## -see-also
 
 
-
-
 <a href="https://docs.microsoft.com/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription">GetThreadDescription</a>
  
+ 
+<a href="https://docs.microsoft.com/visualstudio/debugger/how-to-set-a-thread-name-in-native-code">How to: Set a Thread Name in Native Code</a>
+
 
  
-


### PR DESCRIPTION
How to article describes alternative to `SetThreadDescription`, which has own advantages and disadvantages.