### PR TITLE
Fixed typo with backslash escape character.

### DIFF
--- a/sdk-api-src/content/winsvc/nf-winsvc-createservicea.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-createservicea.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winsvc.CreateServiceA
 title: CreateServiceA function (winsvc.h)
-description: Creates a service object and adds it to the specified service control manager database.helpviewer_keywords: ["CreateService","CreateService function","CreateServiceA","CreateServiceW","SERVICE_ADAPTER","SERVICE_AUTO_START","SERVICE_BOOT_START","SERVICE_DEMAND_START","SERVICE_DISABLED","SERVICE_ERROR_CRITICAL","SERVICE_ERROR_IGNORE","SERVICE_ERROR_NORMAL","SERVICE_ERROR_SEVERE","SERVICE_FILE_SYSTEM_DRIVER","SERVICE_INTERACTIVE_PROCESS","SERVICE_KERNEL_DRIVER","SERVICE_RECOGNIZER_DRIVER","SERVICE_SYSTEM_START","SERVICE_USER_OWN_PROCESS","SERVICE_USER_SHARE_PROCESS","SERVICE_WIN32_OWN_PROCESS","SERVICE_WIN32_SHARE_PROCESS","_win32_createservice","base.createservice","winsvc/CreateService","winsvc/CreateServiceA","winsvc/CreateServiceW"]
+description: Creates a service object and adds it to the specified service control manager database.
+helpviewer_keywords: ["CreateService","CreateService function","CreateServiceA","CreateServiceW","SERVICE_ADAPTER","SERVICE_AUTO_START","SERVICE_BOOT_START","SERVICE_DEMAND_START","SERVICE_DISABLED","SERVICE_ERROR_CRITICAL","SERVICE_ERROR_IGNORE","SERVICE_ERROR_NORMAL","SERVICE_ERROR_SEVERE","SERVICE_FILE_SYSTEM_DRIVER","SERVICE_INTERACTIVE_PROCESS","SERVICE_KERNEL_DRIVER","SERVICE_RECOGNIZER_DRIVER","SERVICE_SYSTEM_START","SERVICE_USER_OWN_PROCESS","SERVICE_USER_SHARE_PROCESS","SERVICE_WIN32_OWN_PROCESS","SERVICE_WIN32_SHARE_PROCESS","_win32_createservice","base.createservice","winsvc/CreateService","winsvc/CreateServiceA","winsvc/CreateServiceW"]
 old-location: base\createservice.htm
 tech.root: Services
 ms.assetid: 47288924-3294-4a50-b27d-7df80d5c957c
@@ -73,7 +74,7 @@ A handle to the service control manager database. This handle is returned by the
 
 ### -param lpServiceName [in]
 
-The name of the service to install. The maximum string length is 256 characters. The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive. Forward-slash (/) and backslash (\) are not valid service name characters.
+The name of the service to install. The maximum string length is 256 characters. The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive. Forward-slash (/) and backslash (\\) are not valid service name characters.
 
 
 ### -param lpDisplayName [in, optional]


### PR DESCRIPTION
"\" -> "\\"