### PR TITLE
Fixed broken markdown in registry path

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-movefileexa.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefileexa.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winbase.MoveFileExA
 title: MoveFileExA function (winbase.h)
-description: Moves an existing file or directory, including its children, with various move options.helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_FAIL_IF_NOT_TRACKABLE","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileEx","MoveFileEx function [Files]","MoveFileExA","MoveFileExW","_win32_movefileex","base.movefileex","fs.movefileex","rename file [Files]","winbase/MoveFileEx","winbase/MoveFileExA","winbase/MoveFileExW"]
+description: Moves an existing file or directory, including its children, with various move options.
+helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_FAIL_IF_NOT_TRACKABLE","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileEx","MoveFileEx function [Files]","MoveFileExA","MoveFileExW","_win32_movefileex","base.movefileex","fs.movefileex","rename file [Files]","winbase/MoveFileEx","winbase/MoveFileExA","winbase/MoveFileExW"]
 old-location: fs\movefileex.htm
 tech.root: FileIO
 ms.assetid: 5fb4f897-66ed-49d7-913a-fb6e7cecdfa3
@@ -248,7 +249,7 @@ If the <i>dwFlags</i> parameter specifies
      <b>MOVEFILE_DELAY_UNTIL_REBOOT</b>, 
      <b>MoveFileEx</b> fails if it cannot access the registry. The 
      function stores the locations of the files to be renamed at restart in the following registry value:
-     <b>HKEY_LOCAL_MACHINE</b>\<b>SYSTEM</b>\<b>CurrentControlSet</b>\<b>Control</b>\<b>Session Manager</b>\<b>PendingFileRenameOperations</b>
+     <b>HKEY_LOCAL_MACHINE</b>\\<b>SYSTEM</b>\\<b>CurrentControlSet</b>\\<b>Control</b>\\<b>Session Manager</b>\\<b>PendingFileRenameOperations</b>
 
 
 

--- a/sdk-api-src/content/winbase/nf-winbase-movefileexw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefileexw.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winbase.MoveFileExW
 title: MoveFileExW function (winbase.h)
-description: Moves an existing file or directory, including its children, with various move options.helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_FAIL_IF_NOT_TRACKABLE","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileEx","MoveFileEx function [Files]","MoveFileExA","MoveFileExW","_win32_movefileex","base.movefileex","fs.movefileex","rename file [Files]","winbase/MoveFileEx","winbase/MoveFileExA","winbase/MoveFileExW"]
+description: Moves an existing file or directory, including its children, with various move options.
+helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_FAIL_IF_NOT_TRACKABLE","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileEx","MoveFileEx function [Files]","MoveFileExA","MoveFileExW","_win32_movefileex","base.movefileex","fs.movefileex","rename file [Files]","winbase/MoveFileEx","winbase/MoveFileExA","winbase/MoveFileExW"]
 old-location: fs\movefileex.htm
 tech.root: FileIO
 ms.assetid: 5fb4f897-66ed-49d7-913a-fb6e7cecdfa3
@@ -249,7 +250,7 @@ If the <i>dwFlags</i> parameter specifies
      <b>MOVEFILE_DELAY_UNTIL_REBOOT</b>, 
      <b>MoveFileEx</b> fails if it cannot access the registry. The 
      function stores the locations of the files to be renamed at restart in the following registry value:
-     <b>HKEY_LOCAL_MACHINE</b>\<b>SYSTEM</b>\<b>CurrentControlSet</b>\<b>Control</b>\<b>Session Manager</b>\<b>PendingFileRenameOperations</b>
+     <b>HKEY_LOCAL_MACHINE</b>\\<b>SYSTEM</b>\\<b>CurrentControlSet</b>\\<b>Control</b>\\<b>Session Manager</b>\\<b>PendingFileRenameOperations</b>
 
 
 

--- a/sdk-api-src/content/winbase/nf-winbase-movefiletransacteda.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefiletransacteda.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winbase.MoveFileTransactedA
 title: MoveFileTransactedA function (winbase.h)
-description: Moves an existing file or a directory, including its children, as a transacted operation.helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileTransacted","MoveFileTransacted function [Files]","MoveFileTransactedA","MoveFileTransactedW","fs.movefiletransacted","rename file [Files]","winbase/MoveFileTransacted","winbase/MoveFileTransactedA","winbase/MoveFileTransactedW"]
+description: Moves an existing file or a directory, including its children, as a transacted operation.
+helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileTransacted","MoveFileTransacted function [Files]","MoveFileTransactedA","MoveFileTransactedW","fs.movefiletransacted","rename file [Files]","winbase/MoveFileTransacted","winbase/MoveFileTransactedA","winbase/MoveFileTransactedW"]
 old-location: fs\movefiletransacted.htm
 tech.root: FileIO
 ms.assetid: 466d733b-30d2-4297-a0e6-77038f1a21d5
@@ -243,7 +244,7 @@ If the <i>dwFlags</i> parameter specifies
     <b>MoveFileTransacted</b> fails if it cannot access the registry. The 
     function transactionally stores the locations of the files to be renamed at restart in the following registry 
     value:
-    <b>HKEY_LOCAL_MACHINE</b>\<b>SYSTEM</b>\<b>CurrentControlSet</b>\<b>Control</b>\<b>Session Manager</b>\<b>PendingFileRenameOperations</b>
+    <b>HKEY_LOCAL_MACHINE</b>\\<b>SYSTEM</b>\\<b>CurrentControlSet</b>\\<b>Control</b>\\<b>Session Manager</b>\\<b>PendingFileRenameOperations</b>
 
 
 

--- a/sdk-api-src/content/winbase/nf-winbase-movefiletransactedw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefiletransactedw.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winbase.MoveFileTransactedW
 title: MoveFileTransactedW function (winbase.h)
-description: Moves an existing file or a directory, including its children, as a transacted operation.helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileTransacted","MoveFileTransacted function [Files]","MoveFileTransactedA","MoveFileTransactedW","fs.movefiletransacted","rename file [Files]","winbase/MoveFileTransacted","winbase/MoveFileTransactedA","winbase/MoveFileTransactedW"]
+description: Moves an existing file or a directory, including its children, as a transacted operation.
+helpviewer_keywords: ["MOVEFILE_COPY_ALLOWED","MOVEFILE_CREATE_HARDLINK","MOVEFILE_DELAY_UNTIL_REBOOT","MOVEFILE_REPLACE_EXISTING","MOVEFILE_WRITE_THROUGH","MoveFileTransacted","MoveFileTransacted function [Files]","MoveFileTransactedA","MoveFileTransactedW","fs.movefiletransacted","rename file [Files]","winbase/MoveFileTransacted","winbase/MoveFileTransactedA","winbase/MoveFileTransactedW"]
 old-location: fs\movefiletransacted.htm
 tech.root: FileIO
 ms.assetid: 466d733b-30d2-4297-a0e6-77038f1a21d5
@@ -243,7 +244,7 @@ If the <i>dwFlags</i> parameter specifies
     <b>MoveFileTransacted</b> fails if it cannot access the registry. The 
     function transactionally stores the locations of the files to be renamed at restart in the following registry 
     value:
-    <b>HKEY_LOCAL_MACHINE</b>\<b>SYSTEM</b>\<b>CurrentControlSet</b>\<b>Control</b>\<b>Session Manager</b>\<b>PendingFileRenameOperations</b>
+    <b>HKEY_LOCAL_MACHINE</b>\\<b>SYSTEM</b>\\<b>CurrentControlSet</b>\\<b>Control</b>\\<b>Session Manager</b>\\<b>PendingFileRenameOperations</b>
 
 
 


### PR DESCRIPTION
This PR fixes incorrect markdown related to registry paths.

The markdown in the registry path was not correct causing wrong rendering:
![image](https://user-images.githubusercontent.com/1299179/80911325-82756d80-8d2d-11ea-8fc4-c54f343c89c3.png)
