### PR TITLE
Edited example to be C++ Standard conformant

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-createcommittedresource.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-createcommittedresource.md
@@ -132,10 +132,12 @@ The <a href="/windows/win32/direct3d12/working-samples">D3D12Bundles</a> sample 
 Create a vertex buffer.
 
 ```cpp
+auto heapProperties = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+auto resourceDesc = CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize);
 ThrowIfFailed(m_device->CreateCommittedResource(
-    &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+    &heapProperties,
     D3D12_HEAP_FLAG_NONE,
-    &CD3DX12_RESOURCE_DESC::Buffer(SampleAssets::VertexDataSize),
+    &resourceDesc,
     D3D12_RESOURCE_STATE_COPY_DEST,
     nullptr,
     IID_PPV_ARGS(&m_vertexBuffer)));


### PR DESCRIPTION
Since CreateCommittedResource taking pointers as arguments, old example uses &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT) call, which returns an instance of D3DX12_HEAP_PROPERTIES).

For address-of operator, "The operand shall be **an lvalue** or a qualified-id.", but "the result of calling a function whose return type is not a reference is a **prvalue**". Current example's code relies on Microsoft's language extension, and is non-conformant to C++ Standard. Thus current code will not compile with **/Za** (disabling C extensions) and **/permissive-** flags.

p.s. Looking forward for other places in documentation where address of non-lvalue is used.