### PR TITLE
Fixes to formatting in IOCTL documentation - Part 2

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_compression.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_compression.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.FSCTL_SET_COMPRESSION
 title: FSCTL_SET_COMPRESSION
-description: Sets the compression state of a file or directory on a volume whose file system supports per-file and per-directory compression.helpviewer_keywords: ["COMPRESSION_FORMAT_DEFAULT","COMPRESSION_FORMAT_LZNT1","COMPRESSION_FORMAT_NONE","FSCTL_SET_COMPRESSION","FSCTL_SET_COMPRESSION control","FSCTL_SET_COMPRESSION control code [Files]","_win32_fsctl_set_compression","all other values","base.fsctl_set_compression","fs.fsctl_set_compression","winioctl/FSCTL_SET_COMPRESSION"]
+description: Sets the compression state of a file or directory on a volume whose file system supports per-file and per-directory compression.
+helpviewer_keywords: ["COMPRESSION_FORMAT_DEFAULT","COMPRESSION_FORMAT_LZNT1","COMPRESSION_FORMAT_NONE","FSCTL_SET_COMPRESSION","FSCTL_SET_COMPRESSION control","FSCTL_SET_COMPRESSION control code [Files]","_win32_fsctl_set_compression","all other values","base.fsctl_set_compression","fs.fsctl_set_compression","winioctl/FSCTL_SET_COMPRESSION"]
 old-location: fs\fsctl_set_compression.htm
 tech.root: FileIO
 ms.assetid: e6fb29ed-f4f4-4507-8312-d771ffb00256
@@ -44,100 +45,46 @@ req.redist:
 
 # FSCTL_SET_COMPRESSION IOCTL
 
-
 ## -description
 
+Sets the compression state of a file or directory on a volume whose file system supports per-file and per-directory compression. You can use **FSCTL_SET_COMPRESSION** to compress or uncompress a file or directory on such a volume.
 
-Sets the compression state of a file or directory on a volume whose file system supports per-file and 
-    per-directory compression. You can use 
-    <b>FSCTL_SET_COMPRESSION</b> to compress or uncompress a 
-    file or directory on such a volume.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE) hDevice,              // handle to file or directory
-                 FSCTL_SET_COMPRESSION,         // dwIoControlCode
-                 (LPVOID) lpInBuffer,           // input buffer
-                 (DWORD) nInBufferSize,         // size of input buffer
-                 NULL,                          // lpOutBuffer
-                 0,                             // nOutBufferSize
-                 (LPDWORD) lpBytesReturned,     // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped ); // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to file or directory
+  FSCTL_SET_COMPRESSION,            // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -145,97 +92,33 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
-
-
-
 ## -remarks
 
+The LZNT1 compression algorithm is the only compression algorithm implemented. As a result, the LZNT1 compression algorithm is used as the DEFAULT compression method.
 
+If the file system of the volume containing the specified file or directory does not support per-file or per-directory compression, the operation fails.
 
-The LZNT1 compression algorithm is the only compression algorithm implemented. As a result, the LZNT1 
-    compression algorithm is used as the DEFAULT compression method.
+The compression state change of the file or directory occurs synchronously with the call to [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md).
 
-If the file system of the volume containing the specified file or directory does not support per-file or 
-    per-directory compression, the operation fails.
+To retrieve the compression state of a file or directory, use the [FSCTL_GET_COMPRESSION](ni-winioctl-fsctl_get_compression.md) control code.
 
-The compression state change of the file or directory occurs synchronously with the call to 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>.
+To retrieve the compression attribute of a file or directory, use the [GetFileAttributes](../fileapi/nf-fileapi-getfileattributesa.md) function. The compression attribute indicates whether a file or directory is compressed. The compression state indicates whether a file or directory is compressed and, if it is, the format of the compressed data.
 
-To retrieve the compression state of a file or directory, use the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-fsctl_get_compression">FSCTL_GET_COMPRESSION</a> control code.
+Directories are not actually compressed by this operation. Rather, the operation sets the default state for files created in the directory to be compressed.
 
-To retrieve the compression attribute of a file or directory, use the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/fileapi/nf-fileapi-getfileattributesa">GetFileAttributes</a> function. The compression attribute 
-    indicates whether a file or directory is compressed. The compression state indicates whether a file or directory 
-    is compressed and, if it is, the format of the compressed data.
-
-Directories are not actually compressed by this operation. Rather, the operation sets the default state for 
-    files created in the directory to be compressed.
-
-Note that the time stamps may not be updated correctly for a remote file. To ensure consistent results, use 
-    unbuffered I/O.
+Note that the time stamps may not be updated correctly for a remote file. To ensure consistent results, use unbuffered I/O.
 
 File compression is supported for files of a maximum uncompressed size of 30 gigabytes.
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-Yes
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-See comment
-
-</td>
-</tr>
-<tr>
-<td>
-Resilient File System (ReFS)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-</table>
- 
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | Yes
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | See comment
+Resilient File System (ReFS) | No
 
 CsvFs does not support making a directory compressed. CsvFs allows making file compressed only when the file is opened exclusively by a node. SMB 3.0 Transparent Failover and Scale-Out does not support NTFS compressed files. The FSCTL call is not blocked, but is unsupported."
 
@@ -248,35 +131,11 @@ For more information about transactions, see
       <a href="https://docs.microsoft.com/windows/desktop/FileIO/transactional-ntfs-portal">Transactional NTFS</a>.
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-fsctl_get_compression">FSCTL_GET_COMPRESSION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/file-compression-and-decompression">File Compression and Decompression</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/file-management-control-codes">File Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/fileapi/nf-fileapi-getfileattributesa">GetFileAttributes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/transactional-ntfs-portal">Transactional NTFS</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [FSCTL_GET_COMPRESSION](ni-winioctl-fsctl_get_compression.md)
+* [File Compression and Decompression](https://docs.microsoft.com/windows/desktop/FileIO/file-compression-and-decompression)
+* [File Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/file-management-control-codes)
+* [GetFileAttributes](../fileapi/nf-fileapi-getfileattributesa.md)
+* [Transactional NTFS](https://docs.microsoft.com/windows/desktop/FileIO/transactional-ntfs-portal)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_exchange_medium.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_exchange_medium.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_EXCHANGE_MEDIUM
 title: IOCTL_CHANGER_EXCHANGE_MEDIUM
-description: Moves a piece of media from a source element to one destination, and the piece of media originally in the first destination to a second destination.helpviewer_keywords: ["IOCTL_CHANGER_EXCHANGE_MEDIUM","IOCTL_CHANGER_EXCHANGE_MEDIUM control","IOCTL_CHANGER_EXCHANGE_MEDIUM control code","_win32_ioctl_changer_exchange_medium","base.ioctl_changer_exchange_medium","winioctl/IOCTL_CHANGER_EXCHANGE_MEDIUM"]
+description: Moves a piece of media from a source element to one destination, and the piece of media originally in the first destination to a second destination.
+helpviewer_keywords: ["IOCTL_CHANGER_EXCHANGE_MEDIUM","IOCTL_CHANGER_EXCHANGE_MEDIUM control","IOCTL_CHANGER_EXCHANGE_MEDIUM control code","_win32_ioctl_changer_exchange_medium","base.ioctl_changer_exchange_medium","winioctl/IOCTL_CHANGER_EXCHANGE_MEDIUM"]
 old-location: base\ioctl_changer_exchange_medium.htm
 tech.root: devio
 ms.assetid: 40550df0-9da4-4b02-bd57-23eae78c68df
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_EXCHANGE_MEDIUM IOCTL
 
-
 ## -description
-
 
 Moves a piece of media from a source element to one destination, and the piece of media originally in the first destination to a second destination.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_CHANGER_EXCHANGE_MEDIUM, // dwIoControlCode(LPVOID) lpInBuffer,           // input buffer
-  (DWORD) nInBufferSize,         // size of input buffer
-  NULL,                          // lpOutBuffer0,                             // nOutBufferSize(LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_CHANGER_EXCHANGE_MEDIUM,    // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,32 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 To swap two pieces of media, specify the source as the value for the second destination.
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_exchange_medium">CHANGER_EXCHANGE_MEDIUM</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_EXCHANGE_MEDIUM](ns-winioctl-changer_exchange_medium.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_element_status.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_element_status.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_GET_ELEMENT_STATUS
 title: IOCTL_CHANGER_GET_ELEMENT_STATUS
-description: Retrieves the status of all elements or a specified number of elements of a particular type.helpviewer_keywords: ["IOCTL_CHANGER_GET_ELEMENT_STATUS","IOCTL_CHANGER_GET_ELEMENT_STATUS control","IOCTL_CHANGER_GET_ELEMENT_STATUS control code","_win32_ioctl_changer_get_element_status","base.ioctl_changer_get_element_status","winioctl/IOCTL_CHANGER_GET_ELEMENT_STATUS"]
+description: Retrieves the status of all elements or a specified number of elements of a particular type.
+helpviewer_keywords: ["IOCTL_CHANGER_GET_ELEMENT_STATUS","IOCTL_CHANGER_GET_ELEMENT_STATUS control","IOCTL_CHANGER_GET_ELEMENT_STATUS control code","_win32_ioctl_changer_get_element_status","base.ioctl_changer_get_element_status","winioctl/IOCTL_CHANGER_GET_ELEMENT_STATUS"]
 old-location: base\ioctl_changer_get_element_status.htm
 tech.root: devio
 ms.assetid: b5266a22-1f7b-423d-b3c1-7e455d87dd2b
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_GET_ELEMENT_STATUS IOCTL
 
-
 ## -description
-
 
 Retrieves the status of all elements or a specified number of elements of a particular type.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_CHANGER_GET_ELEMENT_STATUS, // dwIoControlCode(LPVOID) lpInBuffer,              // input buffer
+  IOCTL_CHANGER_GET_ELEMENT_STATUS, // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
   (DWORD) nInBufferSize,            // size of input buffer
   (LPVOID) lpOutBuffer,             // output buffer
   (DWORD) nOutBufferSize,           // size of output buffer
   (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,31 +94,10 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_element_status">CHANGER_ELEMENT_STATUS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_element_status_ex">CHANGER_ELEMENT_STATUS_EX</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_read_element_status">CHANGER_READ_ELEMENT_STATUS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_ELEMENT_STATUS](ns-winioctl-changer_element_status.md)
+* [CHANGER_ELEMENT_STATUS_EX](ns-winioctl-changer_element_status_ex.md)
+* [CHANGER_READ_ELEMENT_STATUS](ns-winioctl-changer_read_element_status.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_parameters.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_parameters.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_GET_PARAMETERS
 title: IOCTL_CHANGER_GET_PARAMETERS
-description: Retrieves the parameters of the specified device.helpviewer_keywords: ["IOCTL_CHANGER_GET_PARAMETERS","IOCTL_CHANGER_GET_PARAMETERS control","IOCTL_CHANGER_GET_PARAMETERS control code","_win32_ioctl_changer_get_parameters","base.ioctl_changer_get_parameters","winioctl/IOCTL_CHANGER_GET_PARAMETERS"]
+description: Retrieves the parameters of the specified device.
+helpviewer_keywords: ["IOCTL_CHANGER_GET_PARAMETERS","IOCTL_CHANGER_GET_PARAMETERS control","IOCTL_CHANGER_GET_PARAMETERS control code","_win32_ioctl_changer_get_parameters","base.ioctl_changer_get_parameters","winioctl/IOCTL_CHANGER_GET_PARAMETERS"]
 old-location: base\ioctl_changer_get_parameters.htm
 tech.root: devio
 ms.assetid: bd442970-1056-426f-810e-4e28286c65d2
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_GET_PARAMETERS IOCTL
 
-
 ## -description
-
 
 Retrieves the parameters of the specified device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
-  IOCTL_CHANGER_GET_PARAMETERS, // dwIoControlCodeNULL,                         // lpInBuffer0,                            // nInBufferSize(LPVOID) lpOutBuffer,         // output buffer
+  IOCTL_CHANGER_GET_PARAMETERS, // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  (LPVOID) lpOutBuffer,         // output buffer
   (DWORD) nOutBufferSize,       // size of output buffer
   (LPDWORD) lpBytesReturned,    // number of bytes returned
   (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-get_changer_parameters">GET_CHANGER_PARAMETERS</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [GET_CHANGER_PARAMETERS](ns-winioctl-get_changer_parameters.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_product_data.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_product_data.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_GET_PRODUCT_DATA
 title: IOCTL_CHANGER_GET_PRODUCT_DATA
-description: Retrieves the product data for the specified device.helpviewer_keywords: ["IOCTL_CHANGER_GET_PRODUCT_DATA","IOCTL_CHANGER_GET_PRODUCT_DATA control","IOCTL_CHANGER_GET_PRODUCT_DATA control code","_win32_ioctl_changer_get_product_data","base.ioctl_changer_get_product_data","winioctl/IOCTL_CHANGER_GET_PRODUCT_DATA"]
+description: Retrieves the product data for the specified device.
+helpviewer_keywords: ["IOCTL_CHANGER_GET_PRODUCT_DATA","IOCTL_CHANGER_GET_PRODUCT_DATA control","IOCTL_CHANGER_GET_PRODUCT_DATA control code","_win32_ioctl_changer_get_product_data","base.ioctl_changer_get_product_data","winioctl/IOCTL_CHANGER_GET_PRODUCT_DATA"]
 old-location: base\ioctl_changer_get_product_data.htm
 tech.root: devio
 ms.assetid: 60744666-fb37-4263-8f4a-e7e043e6b71e
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_GET_PRODUCT_DATA IOCTL
 
-
 ## -description
-
 
 Retrieves the product data for the specified device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,               // handle to device
-  IOCTL_CHANGER_GET_PRODUCT_DATA, // dwIoControlCodeNULL,                           // lpInBuffer0,                              // nInBufferSize(LPVOID) lpOutBuffer,           // output buffer
-  (DWORD) nOutBufferSize,         // size of output buffer
-  (LPDWORD) lpBytesReturned,      // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped     // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_CHANGER_GET_PRODUCT_DATA,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_product_data">CHANGER_PRODUCT_DATA</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_PRODUCT_DATA](ns-winioctl-changer_product_data.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_status.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_get_status.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_GET_STATUS
 title: IOCTL_CHANGER_GET_STATUS
-description: Retrieves the current status of the specified device.helpviewer_keywords: ["IOCTL_CHANGER_GET_STATUS","IOCTL_CHANGER_GET_STATUS control","IOCTL_CHANGER_GET_STATUS control code","_win32_ioctl_changer_get_status","base.ioctl_changer_get_status","winioctl/IOCTL_CHANGER_GET_STATUS"]
+description: Retrieves the current status of the specified device.
+helpviewer_keywords: ["IOCTL_CHANGER_GET_STATUS","IOCTL_CHANGER_GET_STATUS control","IOCTL_CHANGER_GET_STATUS control code","_win32_ioctl_changer_get_status","base.ioctl_changer_get_status","winioctl/IOCTL_CHANGER_GET_STATUS"]
 old-location: base\ioctl_changer_get_status.htm
 tech.root: devio
 ms.assetid: 6073230e-0ee7-40be-8fb5-1dd90c01de10
@@ -44,89 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_GET_STATUS IOCTL
 
-
 ## -description
-
 
 Retrieves the current status of the specified device.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-    function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl( (HANDLE) hDevice,              // handle to device
-                      IOCTL_CHANGER_GET_STATUS,      // dwIoControlCodeNULL,                          // lpInBuffer0,                             // nInBufferSizeNULL,                          // lpOutBuffer0,                             // nOutBufferSize(LPDWORD) lpBytesReturned,     // number of bytes returned
-                      (LPOVERLAPPED) lpOverlapped ); // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_CHANGER_GET_STATUS,     // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -135,19 +94,7 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_initialize_element_status.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_initialize_element_status.md
@@ -45,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_INITIALIZE_ELEMENT_STATUS IOCTL
 
-
 ## -description
-
 
 Initializes the status of all elements or the specified elements of a particular type.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                        // handle to device
-  IOCTL_CHANGER_INITIALIZE_ELEMENT_STATUS, // dwIoControlCode(LPVOID) lpInBuffer,                     // input buffer
-  (DWORD) nInBufferSize,                   // size of input buffer
-  NULL,                                    // lpOutBuffer0,                                       // nOutBufferSize(LPDWORD) lpBytesReturned,               // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped              // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                         // handle to device
+  IOCTL_CHANGER_INITIALIZE_ELEMENT_STATUS,  // dwIoControlCode
+  (LPVOID) lpInBuffer,                      // input buffer
+  (DWORD) nInBufferSize,                    // size of input buffer
+  NULL,                                     // lpOutBuffer
+  0,                                        // nOutBufferSize
+  (LPDWORD) lpBytesReturned,                // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped               // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="/windows/win32/api/winioctl/ni-winioctl-ioctl_changer_initialize_element_status">CHANGER_INITIALIZE_ELEMENT_STATUS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_INITIALIZE_ELEMENT_STATUS](ni-winioctl-ioctl_changer_initialize_element_status.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_move_medium.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_move_medium.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_MOVE_MEDIUM
 title: IOCTL_CHANGER_MOVE_MEDIUM
-description: Moves a piece of media to a destination.helpviewer_keywords: ["IOCTL_CHANGER_MOVE_MEDIUM","IOCTL_CHANGER_MOVE_MEDIUM control","IOCTL_CHANGER_MOVE_MEDIUM control code","_win32_ioctl_changer_move_medium","base.ioctl_changer_move_medium","winioctl/IOCTL_CHANGER_MOVE_MEDIUM"]
+description: Moves a piece of media to a destination.
+helpviewer_keywords: ["IOCTL_CHANGER_MOVE_MEDIUM","IOCTL_CHANGER_MOVE_MEDIUM control","IOCTL_CHANGER_MOVE_MEDIUM control code","_win32_ioctl_changer_move_medium","base.ioctl_changer_move_medium","winioctl/IOCTL_CHANGER_MOVE_MEDIUM"]
 old-location: base\ioctl_changer_move_medium.htm
 tech.root: devio
 ms.assetid: 73fa826c-ef7f-4341-838e-73e025d8d1c1
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_MOVE_MEDIUM IOCTL
 
-
 ## -description
-
 
 Moves a piece of media to a destination.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
-  IOCTL_CHANGER_MOVE_MEDIUM,    // dwIoControlCode(LPVOID) lpInBuffer,          // input buffer
+  IOCTL_CHANGER_MOVE_MEDIUM,    // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
   (DWORD) nInBufferSize,        // size of input buffer
-  NULL,                         // lpOutBuffer0,                            // nOutBufferSize(LPDWORD) lpBytesReturned,    // number of bytes returned
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
   (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_move_medium">CHANGER_MOVE_MEDIUM</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_MOVE_MEDIUM](ns-winioctl-changer_move_medium.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_query_volume_tags.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_query_volume_tags.md
@@ -45,95 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_QUERY_VOLUME_TAGS IOCTL
 
-
 ## -description
-
 
 Retrieves the volume tag information for the specified elements.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_CHANGER_QUERY_VOLUME_TAGS, // dwIoControlCode(LPVOID) lpInBuffer,             // input buffer
-  (DWORD) nInBufferSize,           // size of input buffer
-  (LPVOID) lpOutBuffer,            // output buffer
-  (DWORD) nOutBufferSize,          // size of output buffer
-  (LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_CHANGER_QUERY_VOLUME_TAGS,  // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -142,27 +94,9 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="/windows/win32/api/winioctl/ns-winioctl-changer_send_volume_tag_information">CHANGER_SEND_VOLUME_TAG_INFORMATION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-read_element_address_info">READ_ELEMENT_ADDRESS_INFO</a>
- 
-
- 
-
+* [CHANGER_SEND_VOLUME_TAG_INFORMATION](ns-winioctl-changer_send_volume_tag_information.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [READ_ELEMENT_ADDRESS_INFO](ns-winioctl-read_element_address_info.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_reinitialize_transport.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_reinitialize_transport.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_REINITIALIZE_TRANSPORT
 title: IOCTL_CHANGER_REINITIALIZE_TRANSPORT
-description: Physically recalibrates a transport element. Recalibration may involve returning the transport to its home position.helpviewer_keywords: ["IOCTL_CHANGER_REINITIALIZE_TRANSPORT","IOCTL_CHANGER_REINITIALIZE_TRANSPORT control","IOCTL_CHANGER_REINITIALIZE_TRANSPORT control code","_win32_ioctl_changer_reinitialize_transport","base.ioctl_changer_reinitialize_transport","winioctl/IOCTL_CHANGER_REINITIALIZE_TRANSPORT"]
+description: Physically recalibrates a transport element. Recalibration may involve returning the transport to its home position.
+helpviewer_keywords: ["IOCTL_CHANGER_REINITIALIZE_TRANSPORT","IOCTL_CHANGER_REINITIALIZE_TRANSPORT control","IOCTL_CHANGER_REINITIALIZE_TRANSPORT control code","_win32_ioctl_changer_reinitialize_transport","base.ioctl_changer_reinitialize_transport","winioctl/IOCTL_CHANGER_REINITIALIZE_TRANSPORT"]
 old-location: base\ioctl_changer_reinitialize_transport.htm
 tech.root: devio
 ms.assetid: 0745ee19-34f3-44c8-a52d-fb47448f0084
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_REINITIALIZE_TRANSPORT IOCTL
 
-
 ## -description
-
 
 Physically recalibrates a transport element. Recalibration may involve returning the transport to its home position.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                     // handle to device
-  IOCTL_CHANGER_REINITIALIZE_TRANSPORT, // dwIoControlCode(LPVOID) lpInBuffer,                  // input buffer
+  IOCTL_CHANGER_REINITIALIZE_TRANSPORT, // dwIoControlCode
+  (LPVOID) lpInBuffer,                  // input buffer
   (DWORD) nInBufferSize,                // size of input buffer
-  NULL,                                 // lpOutBuffer0,                                    // nOutBufferSize(LPDWORD) lpBytesReturned,            // number of bytes returned
+  NULL,                                 // lpOutBuffer
+  0,                                    // nOutBufferSize
+  (LPDWORD) lpBytesReturned,            // number of bytes returned
   (LPOVERLAPPED) lpOverlapped           // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_element">CHANGER_ELEMENT</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_ELEMENT](ns-winioctl-changer_element.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_set_access.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_set_access.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_SET_ACCESS
 title: IOCTL_CHANGER_SET_ACCESS
-description: Sets the state of the device's insert/eject port, door, or keypad.helpviewer_keywords: ["IOCTL_CHANGER_SET_ACCESS","IOCTL_CHANGER_SET_ACCESS control","IOCTL_CHANGER_SET_ACCESS control code","_win32_ioctl_changer_set_access","base.ioctl_changer_set_access","winioctl/IOCTL_CHANGER_SET_ACCESS"]
+description: Sets the state of the device's insert/eject port, door, or keypad.
+helpviewer_keywords: ["IOCTL_CHANGER_SET_ACCESS","IOCTL_CHANGER_SET_ACCESS control","IOCTL_CHANGER_SET_ACCESS control code","_win32_ioctl_changer_set_access","base.ioctl_changer_set_access","winioctl/IOCTL_CHANGER_SET_ACCESS"]
 old-location: base\ioctl_changer_set_access.htm
 tech.root: devio
 ms.assetid: 567817d5-60cd-494c-94d9-0899e1142242
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_SET_ACCESS IOCTL
 
-
 ## -description
-
 
 Sets the state of the device's insert/eject port, door, or keypad.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
-  IOCTL_CHANGER_SET_ACCESS,     // dwIoControlCode(LPVOID) lpInBuffer,          // input buffer
+  IOCTL_CHANGER_SET_ACCESS,     // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
   (DWORD) nInBufferSize,        // size of input buffer
-  NULL,                         // lpOutBuffer0,                            // nOutBufferSize(LPDWORD) lpBytesReturned,    // number of bytes returned
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
   (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_set_access">CHANGER_SET_ACCESS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_SET_ACCESS](ns-winioctl-changer_set_access.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_set_position.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_changer_set_position.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_CHANGER_SET_POSITION
 title: IOCTL_CHANGER_SET_POSITION
-description: Sets the changer's robotic transport mechanism to the specified element address. This optimizes moving or exchanging media by positioning the transport beforehand.helpviewer_keywords: ["IOCTL_CHANGER_SET_POSITION","IOCTL_CHANGER_SET_POSITION control","IOCTL_CHANGER_SET_POSITION control code","_win32_ioctl_changer_set_position","base.ioctl_changer_set_position","winioctl/IOCTL_CHANGER_SET_POSITION"]
+description: Sets the changer's robotic transport mechanism to the specified element address. This optimizes moving or exchanging media by positioning the transport beforehand.
+helpviewer_keywords: ["IOCTL_CHANGER_SET_POSITION","IOCTL_CHANGER_SET_POSITION control","IOCTL_CHANGER_SET_POSITION control code","_win32_ioctl_changer_set_position","base.ioctl_changer_set_position","winioctl/IOCTL_CHANGER_SET_POSITION"]
 old-location: base\ioctl_changer_set_position.htm
 tech.root: devio
 ms.assetid: 1c3348d5-6d22-40cb-bf4f-e843819884b9
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_CHANGER_SET_POSITION IOCTL
 
-
 ## -description
-
 
 Sets the changer's robotic transport mechanism to the specified element address. This optimizes moving or exchanging media by positioning the transport beforehand.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
-  IOCTL_CHANGER_SET_POSITION,   // dwIoControlCode(LPVOID) lpInBuffer,          // input buffer
+  IOCTL_CHANGER_SET_POSITION,   // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
   (DWORD) nInBufferSize,        // size of input buffer
-  NULL,                         // lpOutBuffer0,                            // nOutBufferSize(LPDWORD) lpBytesReturned,    // number of bytes returned
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
   (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-changer_set_position">CHANGER_SET_POSITION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [CHANGER_SET_POSITION](ns-winioctl-changer_set_position.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_create_disk.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_create_disk.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_CREATE_DISK
 title: IOCTL_DISK_CREATE_DISK
-description: Initializes the specified disk and disk partition table using the information in the CREATE_DISK structure.helpviewer_keywords: ["IOCTL_DISK_CREATE_DISK","IOCTL_DISK_CREATE_DISK control","IOCTL_DISK_CREATE_DISK control code [Files]","_win32_ioctl_disk_create_disk","base.ioctl_disk_create_disk","fs.ioctl_disk_create_disk","winioctl/IOCTL_DISK_CREATE_DISK"]
+description: Initializes the specified disk and disk partition table using the information in the CREATE_DISK structure.
+helpviewer_keywords: ["IOCTL_DISK_CREATE_DISK","IOCTL_DISK_CREATE_DISK control","IOCTL_DISK_CREATE_DISK control code [Files]","_win32_ioctl_disk_create_disk","base.ioctl_disk_create_disk","fs.ioctl_disk_create_disk","winioctl/IOCTL_DISK_CREATE_DISK"]
 old-location: fs\ioctl_disk_create_disk.htm
 tech.root: FileIO
 ms.assetid: c8215a00-ea39-4268-bb66-68cf3d37baef
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_CREATE_DISK IOCTL
 
-
 ## -description
 
+Initializes the specified disk and disk partition table using the information in the [CREATE_DISK](ns-winioctl-create_disk.md) structure.
 
-Initializes the specified disk and disk partition table using the information in the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-create_disk">CREATE_DISK</a> structure.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl( (HANDLE) hDevice,              // handle to device
-                      IOCTL_DISK_CREATE_DISK,        // dwIoControlCode(LPVOID) lpInBuffer,           // input buffer
-                      (DWORD) nInBufferSize,         // size of input buffer
-                      (LPVOID) NULL,                 // lpOutBuffer(DWORD) 0,                     // nOutBufferSize(LPDWORD) lpBytesReturned,     // number of bytes returned
-                      (LPOVERLAPPED) lpOverlapped ); // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_CREATE_DISK,       // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
+  (DWORD) nInBufferSize,        // size of input buffer
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,38 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-When specifying a GUID partition table (GPT) as the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ne-winioctl-partition_style">PARTITION_STYLE</a> of the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-create_disk">CREATE_DISK</a> structure, an application should wait for the 
-    MSR partition arrival before sending the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_drive_layout_ex">IOCTL_DISK_SET_DRIVE_LAYOUT_EX</a> control code. 
-    For more information about device notification, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-registerdevicenotificationa">RegisterDeviceNotification</a>.
-
-
+When specifying a GUID partition table (GPT) as the [PARTITION_STYLE](./ne-winioctl-partition_style.md) of the [CREATE_DISK](ns-winioctl-create_disk.md) structure, an application should wait for the MSR partition arrival before sending the [IOCTL_DISK_SET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_set_drive_layout_ex.md) control code. For more information about device notification, see [RegisterDeviceNotification](../winuser/nf-winuser-registerdevicenotificationa.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-create_disk">CREATE_DISK</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
- 
-
- 
-
+* [CREATE_DISK](ns-winioctl-create_disk.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_delete_drive_layout.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_delete_drive_layout.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_DELETE_DRIVE_LAYOUT
 title: IOCTL_DISK_DELETE_DRIVE_LAYOUT
-description: Removes the boot signature from the master boot record, so that the disk will be formatted from sector zero to the end of the disk.helpviewer_keywords: ["IOCTL_DISK_DELETE_DRIVE_LAYOUT","IOCTL_DISK_DELETE_DRIVE_LAYOUT control","IOCTL_DISK_DELETE_DRIVE_LAYOUT control code [Files]","base.ioctl_disk_delete_drive_layout","fs.ioctl_disk_delete_drive_layout","winioctl/IOCTL_DISK_DELETE_DRIVE_LAYOUT"]
+description: Removes the boot signature from the master boot record, so that the disk will be formatted from sector zero to the end of the disk.
+helpviewer_keywords: ["IOCTL_DISK_DELETE_DRIVE_LAYOUT","IOCTL_DISK_DELETE_DRIVE_LAYOUT control","IOCTL_DISK_DELETE_DRIVE_LAYOUT control code [Files]","base.ioctl_disk_delete_drive_layout","fs.ioctl_disk_delete_drive_layout","winioctl/IOCTL_DISK_DELETE_DRIVE_LAYOUT"]
 old-location: fs\ioctl_disk_delete_drive_layout.htm
 tech.root: FileIO
 ms.assetid: b790e1f8-9371-4ff9-a820-3ea1af29cc6b
@@ -44,91 +45,46 @@ req.redist:
 
 # IOCTL_DISK_DELETE_DRIVE_LAYOUT IOCTL
 
-
 ## -description
-
 
 Removes the boot signature from the master boot record, so that the disk will be formatted from sector zero to the end of the disk. Partition information is no longer stored in sector zero.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,               // handle to device
-  IOCTL_DISK_DELETE_DRIVE_LAYOUT, // dwIoControlCodeNULL,                           // lpInBuffer0,                              // nInBufferSizeNULL,                           // lpOutBuffer0,                              // nOutBufferSize(LPDWORD) lpBytesReturned,      // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped     // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_DELETE_DRIVE_LAYOUT,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,20 +93,7 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk
-    Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_format_tracks.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_format_tracks.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_FORMAT_TRACKS
 title: IOCTL_DISK_FORMAT_TRACKS
-description: Formats a specified, contiguous set of tracks on a floppy disk. To provide additional parameters, use IOCTL_DISK_FORMAT_TRACKS_EXinstead.helpviewer_keywords: ["IOCTL_DISK_FORMAT_TRACKS","IOCTL_DISK_FORMAT_TRACKS control","IOCTL_DISK_FORMAT_TRACKS control code [Files]","_win32_ioctl_disk_format_tracks","base.ioctl_disk_format_tracks","fs.ioctl_disk_format_tracks","winioctl/IOCTL_DISK_FORMAT_TRACKS"]
+description: Formats a specified, contiguous set of tracks on a floppy disk. To provide additional parameters, use IOCTL_DISK_FORMAT_TRACKS_EXinstead.
+helpviewer_keywords: ["IOCTL_DISK_FORMAT_TRACKS","IOCTL_DISK_FORMAT_TRACKS control","IOCTL_DISK_FORMAT_TRACKS control code [Files]","_win32_ioctl_disk_format_tracks","base.ioctl_disk_format_tracks","fs.ioctl_disk_format_tracks","winioctl/IOCTL_DISK_FORMAT_TRACKS"]
 old-location: fs\ioctl_disk_format_tracks.htm
 tech.root: FileIO
 ms.assetid: 9d6e0865-4b4d-4334-855b-3fbd26832591
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_DISK_FORMAT_TRACKS IOCTL
 
-
 ## -description
 
+Formats a specified, contiguous set of tracks on a floppy disk. To provide additional parameters, use [IOCTL_DISK_FORMAT_TRACKS_EX](ni-winioctl-ioctl_disk_format_tracks_ex.md) instead.
 
-Formats a specified, contiguous set of tracks on a floppy disk. To provide additional parameters, use <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_format_tracks_ex">IOCTL_DISK_FORMAT_TRACKS_EX</a>instead.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_FORMAT_TRACKS,    // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer 
-  (LPVOID) lpOutBuffer,        // output buffer
-  (DWORD) nOutBufferSize,      // size of output buffer
-  (LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_FORMAT_TRACKS,     // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer 
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,27 +94,9 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-format_parameters">FORMAT_PARAMETERS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_format_tracks_ex">IOCTL_DISK_FORMAT_TRACKS_EX</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [FORMAT_PARAMETERS](ns-winioctl-format_parameters.md)
+* [IOCTL_DISK_FORMAT_TRACKS_EX](ni-winioctl-ioctl_disk_format_tracks_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_format_tracks_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_format_tracks_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_FORMAT_TRACKS_EX
 title: IOCTL_DISK_FORMAT_TRACKS_EX
-description: Formats a specified, contiguous set of tracks on a floppy disk.helpviewer_keywords: ["IOCTL_DISK_FORMAT_TRACKS_EX","IOCTL_DISK_FORMAT_TRACKS_EX control","IOCTL_DISK_FORMAT_TRACKS_EX control code [Files]","_win32_ioctl_disk_format_tracks_ex","base.ioctl_disk_format_tracks_ex","fs.ioctl_disk_format_tracks_ex","winioctl/IOCTL_DISK_FORMAT_TRACKS_EX"]
+description: Formats a specified, contiguous set of tracks on a floppy disk.
+helpviewer_keywords: ["IOCTL_DISK_FORMAT_TRACKS_EX","IOCTL_DISK_FORMAT_TRACKS_EX control","IOCTL_DISK_FORMAT_TRACKS_EX control code [Files]","_win32_ioctl_disk_format_tracks_ex","base.ioctl_disk_format_tracks_ex","fs.ioctl_disk_format_tracks_ex","winioctl/IOCTL_DISK_FORMAT_TRACKS_EX"]
 old-location: fs\ioctl_disk_format_tracks_ex.htm
 tech.root: FileIO
 ms.assetid: 50ca069e-efc5-46d8-bf8f-ff44e1593a76
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_DISK_FORMAT_TRACKS_EX IOCTL
 
-
 ## -description
-
 
 Formats a specified, contiguous set of tracks on a floppy disk.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_FORMAT_TRACKS_EX, // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer
-  (LPVOID) lpOutBuffer,        // output buffer
-  (DWORD) nOutBufferSize,      // size of output buffer
-  (LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_FORMAT_TRACKS_EX,  // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,36 +94,17 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 This device I/O control operation is for floppy disk devices only.
 
 It is impossible to determine how many bad track numbers will be returned by this control code, so you should set the size of the array pointed to by the <i>lpOutBuffer</i> parameter to the following:
 
-<code>(total number of tracks on the floppy disk) * sizeof(BAD_TRACK_NUMBER)</code>.
-
-
+`(total number of tracks on the floppy disk) * sizeof(BAD_TRACK_NUMBER)`
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-format_ex_parameters">FORMAT_EX_PARAMETERS</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [FORMAT_EX_PARAMETERS](ns-winioctl-format_ex_parameters.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_cache_information.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_cache_information.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_CACHE_INFORMATION
 title: IOCTL_DISK_GET_CACHE_INFORMATION
-description: Retrieves the disk cache configuration data.helpviewer_keywords: ["IOCTL_DISK_GET_CACHE_INFORMATION","IOCTL_DISK_GET_CACHE_INFORMATION control","IOCTL_DISK_GET_CACHE_INFORMATION control code [Files]","base.ioctl_disk_get_cache_information","fs.ioctl_disk_get_cache_information","winioctl/IOCTL_DISK_GET_CACHE_INFORMATION"]
+description: Retrieves the disk cache configuration data.
+helpviewer_keywords: ["IOCTL_DISK_GET_CACHE_INFORMATION","IOCTL_DISK_GET_CACHE_INFORMATION control","IOCTL_DISK_GET_CACHE_INFORMATION control code [Files]","base.ioctl_disk_get_cache_information","fs.ioctl_disk_get_cache_information","winioctl/IOCTL_DISK_GET_CACHE_INFORMATION"]
 old-location: fs\ioctl_disk_get_cache_information.htm
 tech.root: FileIO
 ms.assetid: 025a92e8-6169-4d7e-9029-f22acb2bdc9f
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_GET_CACHE_INFORMATION IOCTL
 
-
 ## -description
-
 
 Retrieves the disk cache configuration data.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_DISK_GET_CACHE_INFORMATION, // dwIoControlCodeNULL,                             // lpInBuffer0,                                // nInBufferSize(LPVOID) lpOutBuffer,             // output buffer
+  IOCTL_DISK_GET_CACHE_INFORMATION, // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
   (DWORD) nOutBufferSize,           // size of output buffer
   (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,36 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-To set the disk cache information, use the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_cache_information">IOCTL_DISK_SET_CACHE_INFORMATION</a> control code.
-
-
+To set the disk cache information, use the [IOCTL_DISK_SET_CACHE_INFORMATION](ni-winioctl-ioctl_disk_set_cache_information.md) control code.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_cache_information">DISK_CACHE_INFORMATION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_cache_information">IOCTL_DISK_SET_CACHE_INFORMATION</a>
- 
-
- 
-
+* [DISK_CACHE_INFORMATION](ns-winioctl-disk_cache_information.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_SET_CACHE_INFORMATION](ni-winioctl-ioctl_disk_set_cache_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_disk_attributes.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_disk_attributes.md
@@ -45,97 +45,46 @@ req.redist:
 
 # IOCTL_DISK_GET_DISK_ATTRIBUTES IOCTL
 
-
 ## -description
-
 
 Retrieves the attributes of the specified disk device.
 
-To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE)       hDevice,         // handle to device 
-                 IOCTL_DISK_GET_DISK_ATTRIBUTES, // dwIoControlCode
-                 (LPVOID)       NULL,            // lpInBuffer 
-                 (DWORD)        0,               // nInBufferSize 
-                 (LPVOID)       lpOutBuffer,     // output buffer:GET_DISK_ATTRIBUTES
-                 (DWORD)        nOutBufferSize,  // size of output buffer
-                 (LPDWORD)      lpBytesReturned, // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_GET_DISK_ATTRIBUTES,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer: GET_DISK_ATTRIBUTES
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -144,27 +93,9 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-get_disk_attributes">GET_DISK_ATTRIBUTES</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_disk_attributes">IOCTL_DISK_SET_DISK_ATTRIBUTES</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [GET_DISK_ATTRIBUTES](ns-winioctl-get_disk_attributes.md)
+* [IOCTL_DISK_SET_DISK_ATTRIBUTES](ni-winioctl-ioctl_disk_set_disk_attributes.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_geometry.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_geometry.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_DRIVE_GEOMETRY
 title: IOCTL_DISK_GET_DRIVE_GEOMETRY
-description: Retrieves information about the physical disk's geometry:\_type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector.helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_GEOMETRY","IOCTL_DISK_GET_DRIVE_GEOMETRY control","IOCTL_DISK_GET_DRIVE_GEOMETRY control code [Files]","_win32_ioctl_disk_get_drive_geometry","base.ioctl_disk_get_drive_geometry","fs.ioctl_disk_get_drive_geometry","winioctl/IOCTL_DISK_GET_DRIVE_GEOMETRY"]
+description: Retrieves information about the physical disk's geometry:\_type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector.
+helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_GEOMETRY","IOCTL_DISK_GET_DRIVE_GEOMETRY control","IOCTL_DISK_GET_DRIVE_GEOMETRY control code [Files]","_win32_ioctl_disk_get_drive_geometry","base.ioctl_disk_get_drive_geometry","fs.ioctl_disk_get_drive_geometry","winioctl/IOCTL_DISK_GET_DRIVE_GEOMETRY"]
 old-location: fs\ioctl_disk_get_drive_geometry.htm
 tech.root: FileIO
 ms.assetid: 574efc29-112b-42fe-ad1b-72543f20e831
@@ -55,14 +56,14 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 
 ```cpp
 BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_DISK_GET_DRIVE_GEOMETRY, //dwIoControlCode
-  NULL,                          //lpInBuffer
-  0,                             // nInBufferSize
-  (LPVOID) lpOutBuffer,          // output buffer
-  (DWORD) nOutBufferSize,        // size of output buffer
-  (LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_GET_DRIVE_GEOMETRY,    // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
 );
 ```
 
@@ -112,4 +113,8 @@ If the operation fails or is pending, the return value is zero. To get extended 
 
 ## -see-also
 
-[DISK_GEOMETRY](ns-winioctl-disk_geometry.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes), [IOCTL_DISK_GET_DRIVE_GEOMETRY_EX](ni-winioctl-ioctl_disk_get_drive_geometry_ex.md), [IOCTL_STORAGE_GET_MEDIA_TYPES](ni-winioctl-ioctl_storage_get_media_types.md)
+* [DISK_GEOMETRY](ns-winioctl-disk_geometry.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_DRIVE_GEOMETRY_EX](ni-winioctl-ioctl_disk_get_drive_geometry_ex.md)
+* [IOCTL_STORAGE_GET_MEDIA_TYPES](ni-winioctl-ioctl_storage_get_media_types.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_geometry_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_geometry_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_DRIVE_GEOMETRY_EX
 title: IOCTL_DISK_GET_DRIVE_GEOMETRY_EX
-description: Retrieves extended information about the physical disk's geometry:\_type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector.helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_GEOMETRY_EX","IOCTL_DISK_GET_DRIVE_GEOMETRY_EX control","IOCTL_DISK_GET_DRIVE_GEOMETRY_EX control code [Files]","_win32_ioctl_disk_get_drive_geometry_ex","base.ioctl_disk_get_drive_geometry_ex","fs.ioctl_disk_get_drive_geometry_ex","winioctl/IOCTL_DISK_GET_DRIVE_GEOMETRY_EX"]
+description: Retrieves extended information about the physical disk's geometry:\_type, number of cylinders, tracks per cylinder, sectors per track, and bytes per sector.
+helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_GEOMETRY_EX","IOCTL_DISK_GET_DRIVE_GEOMETRY_EX control","IOCTL_DISK_GET_DRIVE_GEOMETRY_EX control code [Files]","_win32_ioctl_disk_get_drive_geometry_ex","base.ioctl_disk_get_drive_geometry_ex","fs.ioctl_disk_get_drive_geometry_ex","winioctl/IOCTL_DISK_GET_DRIVE_GEOMETRY_EX"]
 old-location: fs\ioctl_disk_get_drive_geometry_ex.htm
 tech.root: FileIO
 ms.assetid: 8a0667c8-b182-4851-af8e-411d95da0e3b
@@ -53,8 +54,8 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 ```cpp
 BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, //dwIoControlCode
-  NULL,                             //lpInBuffer
+  IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, // dwIoControlCode
+  NULL,                             // lpInBuffer
   0,                                // nInBufferSize
   (LPVOID) lpOutBuffer,             // output buffer
   (DWORD) nOutBufferSize,           // size of output buffer
@@ -113,4 +114,6 @@ If the operation fails, or is pending, the return value is zero. To get extended
 
 ## -see-also
 
-[DISK_GEOMETRY_EX](ns-winioctl-disk_geometry_ex.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [DISK_GEOMETRY_EX](ns-winioctl-disk_geometry_ex.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_layout.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_layout.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_DRIVE_LAYOUT
 title: IOCTL_DISK_GET_DRIVE_LAYOUT
-description: Retrieves information for each entry in the partition tables for a disk.helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_LAYOUT","IOCTL_DISK_GET_DRIVE_LAYOUT control","IOCTL_DISK_GET_DRIVE_LAYOUT control code [Files]","_win32_ioctl_disk_get_drive_layout","base.ioctl_disk_get_drive_layout","fs.ioctl_disk_get_drive_layout","winioctl/IOCTL_DISK_GET_DRIVE_LAYOUT"]
+description: Retrieves information for each entry in the partition tables for a disk.
+helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_LAYOUT","IOCTL_DISK_GET_DRIVE_LAYOUT control","IOCTL_DISK_GET_DRIVE_LAYOUT control code [Files]","_win32_ioctl_disk_get_drive_layout","base.ioctl_disk_get_drive_layout","fs.ioctl_disk_get_drive_layout","winioctl/IOCTL_DISK_GET_DRIVE_LAYOUT"]
 old-location: fs\ioctl_disk_get_drive_layout.htm
 tech.root: FileIO
 ms.assetid: 6c1bc445-3cd1-4f86-a36b-f74ad8f4d2e5
@@ -55,14 +56,14 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 
 ```cpp
 BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_DISK_GET_DRIVE_LAYOUT,   //dwIoControlCode
-  NULL,                          //lpInBuffer
-  0,                             // nInBufferSize
-  (LPVOID) lpOutBuffer,          // output buffer
-  (DWORD) nOutBufferSize,        // size of output buffer
-  (LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_GET_DRIVE_LAYOUT,  // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
 );
 ```
 
@@ -118,4 +119,8 @@ This operation retrieves information for each primary partition as well as each 
 
 ## -see-also
 
-[DRIVE_LAYOUT_INFORMATION](ns-winioctl-drive_layout_information.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes), [IOCTL_DISK_GET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_get_drive_layout_ex.md), [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md)
+* [DRIVE_LAYOUT_INFORMATION](ns-winioctl-drive_layout_information.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_get_drive_layout_ex.md)
+* [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_layout_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_drive_layout_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_DRIVE_LAYOUT_EX
 title: IOCTL_DISK_GET_DRIVE_LAYOUT_EX
-description: Retrieves extended information for each entry in the partition tables for a disk.helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_LAYOUT_EX","IOCTL_DISK_GET_DRIVE_LAYOUT_EX control","IOCTL_DISK_GET_DRIVE_LAYOUT_EX control code [Files]","_win32_ioctl_disk_get_drive_layout_ex","base.ioctl_disk_get_drive_layout_ex","fs.ioctl_disk_get_drive_layout_ex","winioctl/IOCTL_DISK_GET_DRIVE_LAYOUT_EX"]
+description: Retrieves extended information for each entry in the partition tables for a disk.
+helpviewer_keywords: ["IOCTL_DISK_GET_DRIVE_LAYOUT_EX","IOCTL_DISK_GET_DRIVE_LAYOUT_EX control","IOCTL_DISK_GET_DRIVE_LAYOUT_EX control code [Files]","_win32_ioctl_disk_get_drive_layout_ex","base.ioctl_disk_get_drive_layout_ex","fs.ioctl_disk_get_drive_layout_ex","winioctl/IOCTL_DISK_GET_DRIVE_LAYOUT_EX"]
 old-location: fs\ioctl_disk_get_drive_layout_ex.htm
 tech.root: FileIO
 ms.assetid: 21507182-5a33-4e58-b5ed-3724feefa4ed
@@ -52,14 +53,14 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 
 ```cpp
 BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_DISK_GET_DRIVE_LAYOUT_EX, //dwIoControlCode
-  NULL,                          //lpInBuffer
-  0,                             // nInBufferSize
-  (LPVOID) lpOutBuffer,          // output buffer
-  (DWORD) nOutBufferSize,        // size of output buffer
-  (LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_GET_DRIVE_LAYOUT_EX,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
 );
 ```
 
@@ -115,4 +116,7 @@ This operation retrieves information for each primary partition as well as each 
 
 ## -see-also
 
-[DRIVE_LAYOUT_INFORMATION_EX](ns-winioctl-drive_layout_information_ex.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes), [IOCTL_DISK_SET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_set_drive_layout_ex.md)
+* [DRIVE_LAYOUT_INFORMATION_EX](ns-winioctl-drive_layout_information_ex.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_SET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_set_drive_layout_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_length_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_length_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_LENGTH_INFO
 title: IOCTL_DISK_GET_LENGTH_INFO
-description: Retrieves the length of the specified disk, volume, or partition.helpviewer_keywords: ["IOCTL_DISK_GET_LENGTH_INFO","IOCTL_DISK_GET_LENGTH_INFO control","IOCTL_DISK_GET_LENGTH_INFO control code [Files]","_win32_ioctl_disk_get_length_info","base.ioctl_disk_get_length_info","fs.ioctl_disk_get_length_info","winioctl/IOCTL_DISK_GET_LENGTH_INFO"]
+description: Retrieves the length of the specified disk, volume, or partition.
+helpviewer_keywords: ["IOCTL_DISK_GET_LENGTH_INFO","IOCTL_DISK_GET_LENGTH_INFO control","IOCTL_DISK_GET_LENGTH_INFO control code [Files]","_win32_ioctl_disk_get_length_info","base.ioctl_disk_get_length_info","fs.ioctl_disk_get_length_info","winioctl/IOCTL_DISK_GET_LENGTH_INFO"]
 old-location: fs\ioctl_disk_get_length_info.htm
 tech.root: FileIO
 ms.assetid: 8d4bd6e3-f0f3-40d6-b0ba-75155282f64a
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_GET_LENGTH_INFO IOCTL
 
-
 ## -description
-
 
 Retrieves the length of the specified disk, volume, or partition.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_DISK_GET_LENGTH_INFO,    // dwIoControlCodeNULL,                          // lpInBuffer0,                             // nInBufferSize(LPVOID) lpOutBuffer,          // output buffer
-  (DWORD) nOutBufferSize,        // size of output buffer
-  (LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_GET_LENGTH_INFO,   // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,36 +94,15 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+Volume handles do not have access to the full volume. To read or write to the last few sectors of a volume, you must call [FSCTL_ALLOW_EXTENDED_DASD_IO](ni-winioctl-fsctl_allow_extended_dasd_io.md), which instructs the file system to not perform any boundary checks.
 
-
-Volume handles do not have access to the full volume. To read or write to the last few sectors of a volume, you must call <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-fsctl_allow_extended_dasd_io">FSCTL_ALLOW_EXTENDED_DASD_IO</a>, which instructs the file system to not perform any boundary checks.
-
-
-This operation should be used instead of 
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex">IOCTL_DISK_GET_PARTITION_INFO_EX</a> for volumes that do not have partition info—such as partition type or number of hidden sectors.
-
-
+This operation should be used instead of [IOCTL_DISK_GET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_get_partition_info_ex.md) for volumes that do not have partition info—such as partition type or number of hidden sectors.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-get_length_information">GET_LENGTH_INFORMATION</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [GET_LENGTH_INFORMATION](ns-winioctl-get_length_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_partition_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_partition_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_PARTITION_INFO
 title: IOCTL_DISK_GET_PARTITION_INFO
-description: Retrieves information about the type, size, and nature of a disk partition.helpviewer_keywords: ["IOCTL_DISK_GET_PARTITION_INFO","IOCTL_DISK_GET_PARTITION_INFO control","IOCTL_DISK_GET_PARTITION_INFO control code [Files]","_win32_ioctl_disk_get_partition_info","base.ioctl_disk_get_partition_info","fs.ioctl_disk_get_partition_info","winioctl/IOCTL_DISK_GET_PARTITION_INFO"]
+description: Retrieves information about the type, size, and nature of a disk partition.
+helpviewer_keywords: ["IOCTL_DISK_GET_PARTITION_INFO","IOCTL_DISK_GET_PARTITION_INFO control","IOCTL_DISK_GET_PARTITION_INFO control code [Files]","_win32_ioctl_disk_get_partition_info","base.ioctl_disk_get_partition_info","fs.ioctl_disk_get_partition_info","winioctl/IOCTL_DISK_GET_PARTITION_INFO"]
 old-location: fs\ioctl_disk_get_partition_info.htm
 tech.root: FileIO
 ms.assetid: 24053a1a-8cf8-4aa8-a611-15c9fae0a36d
@@ -44,93 +45,49 @@ req.redist:
 
 # IOCTL_DISK_GET_PARTITION_INFO IOCTL
 
-
 ## -description
 
-
 Retrieves information about the type, size, and nature of a disk partition.
-<div class="alert"><b>Note</b>  <b>IOCTL_DISK_GET_PARTITION_INFO</b> is superseded by 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex">IOCTL_DISK_GET_PARTITION_INFO_EX</a>, which 
-    retrieves partition information for AT and Extensible Firmware Interface (EFI) partitions.</div><div> </div>To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl( (HANDLE) hDevice,                // handle to a partition
-                      IOCTL_DISK_GET_PARTITION_INFO,   // dwIoControlCode(LPVOID) NULL,                   // lpInBuffer(DWORD) 0,                       // nInBufferSize(LPVOID) lpOutBuffer,            // output buffer
-                      (DWORD) nOutBufferSize,          // size of output buffer
-                      (LPDWORD) lpBytesReturned,       // number of bytes returned
-                      (LPOVERLAPPED) lpOverlapped );   // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+
+> [!NOTE]
+> **IOCTL_DISK_GET_PARTITION_INFO** is superseded by [IOCTL_DISK_GET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_get_partition_info_ex.md), which retrieves partition information for AT and Extensible Firmware Interface (EFI) partitions.
+
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to a partition
+  IOCTL_DISK_GET_PARTITION_INFO,    // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,92 +96,31 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The <b>IOCTL_DISK_GET_PARTITION_INFO</b> 
-    control code is only supported on MBR-formatted disks.
+The **IOCTL_DISK_GET_PARTITION_INFO** control code is only supported on MBR-formatted disks.
 
 The disk support can be summarized as follows.
 
-<table>
-<tr>
-<th>Disk type</th>
-<th>IOCTL_DISK_GET_PARTITION_INFO</th>
-<th>IOCTL_DISK_GET_PARTITION_INFO_EX</th>
-</tr>
-<tr>
-<td>Basic master boot record (MBR)</td>
-<td>Yes</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Basic GUID partition table (GPT)</td>
-<td>No</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic MBR boot/system</td>
-<td>Yes</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic MBR data</td>
-<td>Yes</td>
-<td>No</td>
-</tr>
-<tr>
-<td>Dynamic GPT boot/system</td>
-<td>No</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic GPT data</td>
-<td>No</td>
-<td>No</td>
-</tr>
-</table>
- 
+Disk type | IOCTL_DISK_GET_PARTITION_INFO | IOCTL_DISK_GET_PARTITION_INFO_EX
+----------|-------------------------------|---------------------------------
+Basic master boot record (MBR) | Yes | Yes
+Basic GUID partition table (GPT) | No | Yes
+Dynamic MBR boot/system | Yes | Yes
+Dynamic MBR data | Yes | No
+Dynamic GPT boot/system | No | Yes
+Dynamic GPT data | No | No
 
 Currently, GPT is supported only on 64-bit systems.
 
-If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. 
-    For more information, see the Remarks section of 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_drive_layout">IOCTL_DISK_SET_DRIVE_LAYOUT</a>.
-
-
+If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/file-system-recognition">File System Recognition</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex">IOCTL_DISK_GET_PARTITION_INFO_EX</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_partition_info">IOCTL_DISK_SET_PARTITION_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-partition_information">PARTITION_INFORMATION</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [File System Recognition](https://docs.microsoft.com/windows/desktop/FileIO/file-system-recognition)
+* [IOCTL_DISK_GET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_get_partition_info_ex.md)
+* [IOCTL_DISK_SET_PARTITION_INFO](ni-winioctl-ioctl_disk_set_partition_info.md)
+* [PARTITION_INFORMATION](ns-winioctl-partition_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GET_PARTITION_INFO_EX
 title: IOCTL_DISK_GET_PARTITION_INFO_EX
-description: Retrieves extended information about the type, size, and nature of a disk partition.helpviewer_keywords: ["IOCTL_DISK_GET_PARTITION_INFO_EX","IOCTL_DISK_GET_PARTITION_INFO_EX control","IOCTL_DISK_GET_PARTITION_INFO_EX control code [Files]","_win32_ioctl_disk_get_partition_info_ex","base.ioctl_disk_get_partition_info_ex","fs.ioctl_disk_get_partition_info_ex","winioctl/IOCTL_DISK_GET_PARTITION_INFO_EX"]
+description: Retrieves extended information about the type, size, and nature of a disk partition.
+helpviewer_keywords: ["IOCTL_DISK_GET_PARTITION_INFO_EX","IOCTL_DISK_GET_PARTITION_INFO_EX control","IOCTL_DISK_GET_PARTITION_INFO_EX control code [Files]","_win32_ioctl_disk_get_partition_info_ex","base.ioctl_disk_get_partition_info_ex","fs.ioctl_disk_get_partition_info_ex","winioctl/IOCTL_DISK_GET_PARTITION_INFO_EX"]
 old-location: fs\ioctl_disk_get_partition_info_ex.htm
 tech.root: FileIO
 ms.assetid: f84f8be6-2b01-4a20-8669-cb1a55c32907
@@ -44,94 +45,47 @@ req.redist:
 
 # IOCTL_DISK_GET_PARTITION_INFO_EX IOCTL
 
-
 ## -description
 
+Retrieves extended information about the type, size, and nature of a disk partition.
 
-Retrieves extended information about the type, size, and nature of a disk 
-    partition.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-    function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to a partition
-  IOCTL_DISK_GET_PARTITION_INFO_EX, // dwIoControlCodeNULL,                             // lpInBuffer0,                                // nInBufferSize(LPVOID) lpOutBuffer,             // output buffer
+  IOCTL_DISK_GET_PARTITION_INFO_EX, // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
   (DWORD) nOutBufferSize,           // size of output buffer
   (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,88 +94,30 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The <b>IOCTL_DISK_GET_PARTITION_INFO_EX</b> 
-    control code is supported on basic disks. It is only supported on dynamic disks that are boot or system disks, or have retained 
-    entries in the partition table. The <a href="https://technet.microsoft.com/library/26a4a166-95fa-4faf-95bc-2d5345f4a57a">DiskPart.exe</a> command <b>RETAIN</b> can be used to do 
-    this for other dynamic simple partitions.
+The **IOCTL_DISK_GET_PARTITION_INFO_EX** control code is supported on basic disks. It is only supported on dynamic disks that are boot or system disks, or have retained entries in the partition table. The [DiskPart.exe](https://technet.microsoft.com/library/26a4a166-95fa-4faf-95bc-2d5345f4a57a) command **RETAIN** can be used to do this for other dynamic simple partitions.
 
 The disk support can be summarized as follows.
 
-<table>
-<tr>
-<th>Disk type</th>
-<th>IOCTL_DISK_GET_PARTITION_INFO</th>
-<th>IOCTL_DISK_GET_PARTITION_INFO_EX</th>
-</tr>
-<tr>
-<td>Basic master boot record (MBR)</td>
-<td>Yes</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Basic GUID partition table (GPT)</td>
-<td>No</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic MBR boot/system</td>
-<td>Yes</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic MBR data</td>
-<td>Yes</td>
-<td>No</td>
-</tr>
-<tr>
-<td>Dynamic GPT boot/system</td>
-<td>No</td>
-<td>Yes</td>
-</tr>
-<tr>
-<td>Dynamic GPT data</td>
-<td>No</td>
-<td>No</td>
-</tr>
-</table>
- 
+Disk type | IOCTL_DISK_GET_PARTITION_INFO | IOCTL_DISK_GET_PARTITION_INFO_EX
+----------|-------------------------------|---------------------------------
+Basic master boot record (MBR) | Yes | Yes
+Basic GUID partition table (GPT) | No | Yes
+Dynamic MBR boot/system | Yes | Yes
+Dynamic MBR data | Yes | No
+Dynamic GPT boot/system | No | Yes
+Dynamic GPT data | No | No
 
 Currently, GPT is supported only on 64-bit systems.
 
-If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_drive_layout">IOCTL_DISK_SET_DRIVE_LAYOUT</a>.
-
-
+If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/file-system-recognition">File System Recognition</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_partition_info_ex">IOCTL_DISK_SET_PARTITION_INFO_EX</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-partition_information_ex">PARTITION_INFORMATION_EX</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [File System Recognition](https://docs.microsoft.com/windows/desktop/FileIO/file-system-recognition)
+* [IOCTL_DISK_SET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_set_partition_info_ex.md)
+* [PARTITION_INFORMATION_EX](ns-winioctl-partition_information_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_grow_partition.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_grow_partition.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_GROW_PARTITION
 title: IOCTL_DISK_GROW_PARTITION
-description: Enlarges the specified partition.helpviewer_keywords: ["IOCTL_DISK_GROW_PARTITION","IOCTL_DISK_GROW_PARTITION control","IOCTL_DISK_GROW_PARTITION control code [Files]","base.ioctl_disk_grow_partition","fs.ioctl_disk_grow_partition","winioctl/IOCTL_DISK_GROW_PARTITION"]
+description: Enlarges the specified partition.
+helpviewer_keywords: ["IOCTL_DISK_GROW_PARTITION","IOCTL_DISK_GROW_PARTITION control","IOCTL_DISK_GROW_PARTITION control code [Files]","base.ioctl_disk_grow_partition","fs.ioctl_disk_grow_partition","winioctl/IOCTL_DISK_GROW_PARTITION"]
 old-location: fs\ioctl_disk_grow_partition.htm
 tech.root: FileIO
 ms.assetid: bbcb0bee-a507-4abb-83df-328f3aa6caaa
@@ -44,94 +45,47 @@ req.redist:
 
 # IOCTL_DISK_GROW_PARTITION IOCTL
 
-
 ## -description
-
 
 Enlarges the specified partition.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_GROW_PARTITION,   // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer
-  (DWORD) nInBufferSize,       // size of the input buffer
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize 
-  (LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_GROW_PARTITION,    // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
+  (DWORD) nInBufferSize,        // size of the input buffer
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize 
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,36 +94,17 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 You can extend or shrink a live partition, and the partition can be open for sharing during the extend or shrink operation. 
 
 You do not need to lock a partition that you are extending, nor do you need to shut down other applications or services during the extend operation.
 
-For more information, see <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_grow_partition">DISK_GROW_PARTITION</a>.
-
-
+For more information, see [DISK_GROW_PARTITION](ns-winioctl-disk_grow_partition.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_grow_partition">DISK_GROW_PARTITION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
- 
-
- 
-
+* [DISK_GROW_PARTITION](ns-winioctl-disk_grow_partition.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_is_writable.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_is_writable.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_IS_WRITABLE
 title: IOCTL_DISK_IS_WRITABLE
-description: Determines whether the specified disk is writable.helpviewer_keywords: ["IOCTL_DISK_IS_WRITABLE","IOCTL_DISK_IS_WRITABLE control","IOCTL_DISK_IS_WRITABLE control code [Files]","base.ioctl_disk_is_writable","fs.ioctl_disk_is_writable","winioctl/IOCTL_DISK_IS_WRITABLE"]
+description: Determines whether the specified disk is writable.
+helpviewer_keywords: ["IOCTL_DISK_IS_WRITABLE","IOCTL_DISK_IS_WRITABLE control","IOCTL_DISK_IS_WRITABLE control code [Files]","base.ioctl_disk_is_writable","fs.ioctl_disk_is_writable","winioctl/IOCTL_DISK_IS_WRITABLE"]
 old-location: fs\ioctl_disk_is_writable.htm
 tech.root: FileIO
 ms.assetid: 0b56ea0d-95ae-4306-9866-b4b5e985ed43
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_DISK_IS_WRITABLE IOCTL
 
-
 ## -description
-
 
 Determines whether the specified disk is writable.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_IS_WRITABLE,      // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_IS_WRITABLE,       // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,19 +94,7 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_performance.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_performance.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_PERFORMANCE
 title: IOCTL_DISK_PERFORMANCE
-description: Enables performance counters that provide disk performance information.helpviewer_keywords: ["IOCTL_DISK_PERFORMANCE","IOCTL_DISK_PERFORMANCE control","IOCTL_DISK_PERFORMANCE control code [Files]","_win32_ioctl_disk_performance","base.ioctl_disk_performance","fs.ioctl_disk_performance","winioctl/IOCTL_DISK_PERFORMANCE"]
+description: Enables performance counters that provide disk performance information.
+helpviewer_keywords: ["IOCTL_DISK_PERFORMANCE","IOCTL_DISK_PERFORMANCE control","IOCTL_DISK_PERFORMANCE control code [Files]","_win32_ioctl_disk_performance","base.ioctl_disk_performance","fs.ioctl_disk_performance","winioctl/IOCTL_DISK_PERFORMANCE"]
 old-location: fs\ioctl_disk_performance.htm
 tech.root: FileIO
 ms.assetid: e182282c-17e9-442a-8742-437052cfed03
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_PERFORMANCE IOCTL
 
-
 ## -description
-
 
 Enables performance counters that provide disk performance information.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_PERFORMANCE,      // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSize(LPVOID) lpOutBuffer,        // output buffer
-  (DWORD) nOutBufferSize,      // size of output buffer
-  (LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_PERFORMANCE,       // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,36 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-To disable the  performance counters enabled by this control code, use the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_performance_off">IOCTL_DISK_PERFORMANCE_OFF</a> control code.
-
-
+To disable the  performance counters enabled by this control code, use the [IOCTL_DISK_PERFORMANCE_OFF](ni-winioctl-ioctl_disk_performance_off.md) control code.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_performance">DISK_PERFORMANCE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_performance_off">IOCTL_DISK_PERFORMANCE_OFF</a>
- 
-
- 
-
+* [DISK_PERFORMANCE](ns-winioctl-disk_performance.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_PERFORMANCE_OFF](ni-winioctl-ioctl_disk_performance_off.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_performance_off.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_performance_off.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_PERFORMANCE_OFF
 title: IOCTL_DISK_PERFORMANCE_OFF
-description: Disables the performance counters that provide disk performance information.helpviewer_keywords: ["IOCTL_DISK_PERFORMANCE_OFF","IOCTL_DISK_PERFORMANCE_OFF control","IOCTL_DISK_PERFORMANCE_OFF control code [Files]","base.ioctl_disk_performance_off","fs.ioctl_disk_performance_off","winioctl/IOCTL_DISK_PERFORMANCE_OFF"]
+description: Disables the performance counters that provide disk performance information.
+helpviewer_keywords: ["IOCTL_DISK_PERFORMANCE_OFF","IOCTL_DISK_PERFORMANCE_OFF control","IOCTL_DISK_PERFORMANCE_OFF control code [Files]","base.ioctl_disk_performance_off","fs.ioctl_disk_performance_off","winioctl/IOCTL_DISK_PERFORMANCE_OFF"]
 old-location: fs\ioctl_disk_performance_off.htm
 tech.root: FileIO
 ms.assetid: 68f4f6fb-a4f3-4fa5-8187-b2287a4271e8
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_DISK_PERFORMANCE_OFF IOCTL
 
-
 ## -description
-
 
 Disables the performance counters that provide disk performance information.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_PERFORMANCE_OFF,  // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,            	// handle to device
+  IOCTL_DISK_PERFORMANCE_OFF,	// dwIoControlCode
+  NULL,                        	// lpInBuffer
+  0,                           	// nInBufferSize
+  NULL,                        	// lpOutBuffer
+  0,                           	// nOutBufferSize
+  (LPDWORD) lpBytesReturned,   	// number of bytes returned
+  (LPOVERLAPPED) lpOverlapped  	// OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,33 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-To enable these performance counters, use the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_performance">IOCTL_DISK_PERFORMANCE</a> control code.
-
-
+To enable these performance counters, use the [IOCTL_DISK_PERFORMANCE](ni-winioctl-ioctl_disk_performance.md) control code.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk
-		  Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_performance">IOCTL_DISK_PERFORMANCE</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_PERFORMANCE](ni-winioctl-ioctl_disk_performance.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reassign_blocks.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reassign_blocks.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_REASSIGN_BLOCKS
 title: IOCTL_DISK_REASSIGN_BLOCKS
-description: Directs the disk device to map one or more blocks to its spare-block pool.helpviewer_keywords: ["IOCTL_DISK_REASSIGN_BLOCKS","IOCTL_DISK_REASSIGN_BLOCKS control","IOCTL_DISK_REASSIGN_BLOCKS control code [Files]","_win32_ioctl_disk_reassign_blocks","base.ioctl_disk_reassign_blocks","fs.ioctl_disk_reassign_blocks","winioctl/IOCTL_DISK_REASSIGN_BLOCKS"]
+description: Directs the disk device to map one or more blocks to its spare-block pool.
+helpviewer_keywords: ["IOCTL_DISK_REASSIGN_BLOCKS","IOCTL_DISK_REASSIGN_BLOCKS control","IOCTL_DISK_REASSIGN_BLOCKS control code [Files]","_win32_ioctl_disk_reassign_blocks","base.ioctl_disk_reassign_blocks","fs.ioctl_disk_reassign_blocks","winioctl/IOCTL_DISK_REASSIGN_BLOCKS"]
 old-location: fs\ioctl_disk_reassign_blocks.htm
 tech.root: FileIO
 ms.assetid: 57343bc9-9dd4-47a3-8130-07ea330eb4d3
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_REASSIGN_BLOCKS IOCTL
 
-
 ## -description
-
 
 Directs the disk device to map one or more blocks to its spare-block pool.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-    function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_REASSIGN_BLOCKS,  // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer 
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_REASSIGN_BLOCKS,   // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer 
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,48 +94,15 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks">REASSIGN_BLOCKS</a> structure that the 
-    <b>IOCTL_DISK_REASSIGN_BLOCKS</b> control code uses only 
-    supports drives where the Logical Block Address (LBA) fits into a 4-byte value (typically up to 2 TB). For larger 
-    drives the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks_ex">REASSIGN_BLOCKS_EX</a> structure that  the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_reassign_blocks_ex">IOCTL_DISK_REASSIGN_BLOCKS_EX</a> control code 
-    uses supports 8-byte LBAs. For compatibility, the 
-    <b>IOCTL_DISK_REASSIGN_BLOCKS</b> control code and 
-    <b>REASSIGN_BLOCKS</b> structure should be used where 
-    possible.
-
-
+The [REASSIGN_BLOCKS](ns-winioctl-reassign_blocks.md) structure that the **IOCTL_DISK_REASSIGN_BLOCKS** control code uses only supports drives where the Logical Block Address (LBA) fits into a 4-byte value (typically up to 2 TB). For larger drives the [REASSIGN_BLOCKS_EX](ns-winioctl-reassign_blocks_ex.md) structure that the [IOCTL_DISK_REASSIGN_BLOCKS_EX](ni-winioctl-ioctl_disk_reassign_blocks_ex.md) control code uses supports 8-byte LBAs. For compatibility, the **IOCTL_DISK_REASSIGN_BLOCKS** control code and **REASSIGN_BLOCKS** structure should be used where possible.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_reassign_blocks_ex">IOCTL_DISK_REASSIGN_BLOCKS_EX</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks">REASSIGN_BLOCKS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks_ex">REASSIGN_BLOCKS_EX</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_REASSIGN_BLOCKS_EX](ni-winioctl-ioctl_disk_reassign_blocks_ex.md)
+* [REASSIGN_BLOCKS](ns-winioctl-reassign_blocks.md)
+* [REASSIGN_BLOCKS_EX](ns-winioctl-reassign_blocks_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reassign_blocks_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reassign_blocks_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_REASSIGN_BLOCKS_EX
 title: IOCTL_DISK_REASSIGN_BLOCKS_EX
-description: Directs the disk device to map one or more blocks to its spare-block pool.helpviewer_keywords: ["IOCTL_DISK_REASSIGN_BLOCKS_EX","IOCTL_DISK_REASSIGN_BLOCKS_EX control","IOCTL_DISK_REASSIGN_BLOCKS_EX control code [Files]","base.ioctl_disk_reassign_blocks_ex","fs.ioctl_disk_reassign_blocks_ex","winioctl/IOCTL_DISK_REASSIGN_BLOCKS_EX"]
+description: Directs the disk device to map one or more blocks to its spare-block pool.
+helpviewer_keywords: ["IOCTL_DISK_REASSIGN_BLOCKS_EX","IOCTL_DISK_REASSIGN_BLOCKS_EX control","IOCTL_DISK_REASSIGN_BLOCKS_EX control code [Files]","base.ioctl_disk_reassign_blocks_ex","fs.ioctl_disk_reassign_blocks_ex","winioctl/IOCTL_DISK_REASSIGN_BLOCKS_EX"]
 old-location: fs\ioctl_disk_reassign_blocks_ex.htm
 tech.root: FileIO
 ms.assetid: 126ffefa-165b-4ca1-a905-1aebc8e790c7
@@ -44,94 +45,47 @@ req.redist:
 
 # IOCTL_DISK_REASSIGN_BLOCKS_EX IOCTL
 
-
 ## -description
-
 
 Directs the disk device to map one or more blocks to its spare-block pool.
 
-To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE) hDevice,              // handle to device 
-                 IOCTL_DISK_REASSIGN_BLOCKS_EX, // dwIoControlCode(LPVOID) lpInBuffer,           // input buffer
-                 (DWORD) nInBufferSize,         // size of input buffer 
-                 (LPVOID) NULL,                 // lpOutBuffer(DWORD) 0,                     // nOutBufferSize(LPDWORD) lpBytesReturned,     // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped ); // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_REASSIGN_BLOCKS_EX,    // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,47 +94,15 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks_ex">REASSIGN_BLOCKS_EX</a> structure that the 
-    <b>IOCTL_DISK_REASSIGN_BLOCKS_EX</b> control code 
-    uses supports 8-byte Logical Block Addresses (LBA). For compatibility, the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_reassign_blocks">IOCTL_DISK_REASSIGN_BLOCKS</a> control code and 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks">REASSIGN_BLOCKS</a> structure should be used where the 
-    LBA fits in the 4-byte LBA that  the 
-    <b>REASSIGN_BLOCKS</b> structure supports (typically drives 
-    up to 2 TB).
-
-
+The [REASSIGN_BLOCKS_EX](ns-winioctl-reassign_blocks_ex.md) structure that the **IOCTL_DISK_REASSIGN_BLOCKS_EX** control code uses supports 8-byte Logical Block Addresses (LBA). For compatibility, the [IOCTL_DISK_REASSIGN_BLOCKS](ni-winioctl-ioctl_disk_reassign_blocks.md) control code and [REASSIGN_BLOCKS](ns-winioctl-reassign_blocks.md) structure should be used where the LBA fits in the 4-byte LBA that the **REASSIGN_BLOCKS** structure supports (typically drives up to 2 TB).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_reassign_blocks">IOCTL_DISK_REASSIGN_BLOCKS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks">REASSIGN_BLOCKS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-reassign_blocks_ex">REASSIGN_BLOCKS_EX</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_REASSIGN_BLOCKS](ni-winioctl-ioctl_disk_reassign_blocks.md)
+* [REASSIGN_BLOCKS](ns-winioctl-reassign_blocks.md)
+* [REASSIGN_BLOCKS_EX](ns-winioctl-reassign_blocks_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reset_snapshot_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_reset_snapshot_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_RESET_SNAPSHOT_INFO
 title: IOCTL_DISK_RESET_SNAPSHOT_INFO
-description: Clears all Volume Shadow Copy Service (VSS) hardware-based shadow copy (also called &#0034;snapshot&#0034;) information from the disk.helpviewer_keywords: ["IOCTL_DISK_RESET_SNAPSHOT_INFO","IOCTL_DISK_RESET_SNAPSHOT_INFO control","IOCTL_DISK_RESET_SNAPSHOT_INFO control code [Files]","fs.ioctl_disk_reset_snapshot_info","winioctl/IOCTL_DISK_RESET_SNAPSHOT_INFO"]
+description: Clears all Volume Shadow Copy Service (VSS) hardware-based shadow copy (also called &#0034;snapshot&#0034;) information from the disk.
+helpviewer_keywords: ["IOCTL_DISK_RESET_SNAPSHOT_INFO","IOCTL_DISK_RESET_SNAPSHOT_INFO control","IOCTL_DISK_RESET_SNAPSHOT_INFO control code [Files]","fs.ioctl_disk_reset_snapshot_info","winioctl/IOCTL_DISK_RESET_SNAPSHOT_INFO"]
 old-location: fs\ioctl_disk_reset_snapshot_info.htm
 tech.root: FileIO
 ms.assetid: 522f469e-9630-4fa3-a157-7090c58a9856
@@ -44,92 +45,47 @@ req.redist:
 
 # IOCTL_DISK_RESET_SNAPSHOT_INFO IOCTL
 
-
 ## -description
-
 
 Clears all Volume Shadow Copy Service (VSS) hardware-based shadow copy (also called "snapshot") information from the disk.
 
-To perform this operation, call the 
-   <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,               // handle to device
-  IOCTL_DISK_RESET_SNAPSHOT_INFO, // dwIoControlCodeNULL,                           // lpInBuffer0,                              // nInBufferSizeNULL,                           // lpOutBuffer0,                              // nOutBufferSize(LPDWORD) lpBytesReturned,      // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped     // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_RESET_SNAPSHOT_INFO,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -138,26 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 The disk whose handle is used when this IOCTL is issued might be in the offline state when the IOCTL is issued. If the disk is put in the offline state by using the disk management Microsoft Management Console (MMC) snap-in, the disk will have its read-only attribute set, which will cause this IOCTL to fail. However, if the disk partition utility (Diskpart.exe) is used to put the disk in the offline state, the read-only attribute for the disk is not set. For this reason, it is best to use the disk partition utility to put a disk in the offline state.
 
-<div class="alert"><b>Note</b>  One side effect of using this IOCTL is that Disk Management tools will now report an additional partition on GPT disks of the type "UNKNOWN." This 256KB partition is created by using the IOCTL and is the shadow copy partition that is used in the restore process. The partition is expected and can be ignored by system administrators.</div>
-<div> </div>
-
+> [!NOTE]
+> One side effect of using this IOCTL is that Disk Management tools will now report an additional partition on GPT disks of the type "UNKNOWN." This 256KB partition is created by using the IOCTL and is the shadow copy partition that is used in the restore process. The partition is expected and can be ignored by system administrators.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_cache_information.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_cache_information.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_CACHE_INFORMATION
 title: IOCTL_DISK_SET_CACHE_INFORMATION
-description: Sets the disk configuration data.helpviewer_keywords: ["IOCTL_DISK_SET_CACHE_INFORMATION","IOCTL_DISK_SET_CACHE_INFORMATION control","IOCTL_DISK_SET_CACHE_INFORMATION control code [Files]","base.ioctl_disk_set_cache_information","fs.ioctl_disk_set_cache_information","winioctl/IOCTL_DISK_SET_CACHE_INFORMATION"]
+description: Sets the disk configuration data.
+helpviewer_keywords: ["IOCTL_DISK_SET_CACHE_INFORMATION","IOCTL_DISK_SET_CACHE_INFORMATION control","IOCTL_DISK_SET_CACHE_INFORMATION control code [Files]","base.ioctl_disk_set_cache_information","fs.ioctl_disk_set_cache_information","winioctl/IOCTL_DISK_SET_CACHE_INFORMATION"]
 old-location: fs\ioctl_disk_set_cache_information.htm
 tech.root: FileIO
 ms.assetid: e921da48-9435-41f0-87dd-abb383fd5208
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_SET_CACHE_INFORMATION IOCTL
 
-
 ## -description
-
 
 Sets the disk configuration data.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_DISK_SET_CACHE_INFORMATION, // dwIoControlCode(LPVOID) lpInBuffer,              // input buffer
+  IOCTL_DISK_SET_CACHE_INFORMATION, // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
   (DWORD) nInBufferSize,            // size of input buffer
-  NULL,                             // lpOutBuffer0,                                // nOutBufferSize(LPDWORD) lpBytesReturned,        // number of bytes returned
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,38 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-To retrieve the cache information, use the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_cache_information">IOCTL_DISK_GET_CACHE_INFORMATION</a> control code.
-
-
+To retrieve the cache information, use the [IOCTL_DISK_GET_CACHE_INFORMATION](ni-winioctl-ioctl_disk_get_cache_information.md) control code.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_cache_information">DISK_CACHE_INFORMATION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk
-		  Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_cache_information">IOCTL_DISK_GET_CACHE_INFORMATION</a>
- 
-
- 
-
+* [DISK_CACHE_INFORMATION](ns-winioctl-disk_cache_information.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_CACHE_INFORMATION](ni-winioctl-ioctl_disk_get_cache_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_disk_attributes.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_disk_attributes.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_DISK_ATTRIBUTES
 title: IOCTL_DISK_SET_DISK_ATTRIBUTES
-description: Sets the attributes of the specified disk device.helpviewer_keywords: ["IOCTL_DISK_SET_DISK_ATTRIBUTES","IOCTL_DISK_SET_DISK_ATTRIBUTES control","IOCTL_DISK_SET_DISK_ATTRIBUTES control code [Files]","fs.ioctl_disk_set_disk_attributes","winioctl/IOCTL_DISK_SET_DISK_ATTRIBUTES"]
+description: Sets the attributes of the specified disk device.
+helpviewer_keywords: ["IOCTL_DISK_SET_DISK_ATTRIBUTES","IOCTL_DISK_SET_DISK_ATTRIBUTES control","IOCTL_DISK_SET_DISK_ATTRIBUTES control code [Files]","fs.ioctl_disk_set_disk_attributes","winioctl/IOCTL_DISK_SET_DISK_ATTRIBUTES"]
 old-location: fs\ioctl_disk_set_disk_attributes.htm
 tech.root: FileIO
 ms.assetid: ba0e3666-8660-493c-b821-5997d577e7e2
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_DISK_SET_DISK_ATTRIBUTES IOCTL
 
-
 ## -description
-
 
 Sets the attributes of the specified disk device.
 
-To perform this operation, call the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following 
-    parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE)       hDevice,         // handle to device 
-                 IOCTL_DISK_SET_DISK_ATTRIBUTES, // dwIoControlCode(LPVOID)       lpInBuffer,      // input buffer:SET_DISK_ATTRIBUTES
-                 (DWORD)        nInBufferSize,   // size of input buffer
-                 (LPVOID)       NULL,            // lpOutBuffer 
-                 (DWORD)        0,               // nOutBufferSize(LPDWORD)      lpBytesReturned, // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_SET_DISK_ATTRIBUTES,   // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer: SET_DISK_ATTRIBUTES
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,27 +94,9 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_disk_attributes">IOCTL_DISK_GET_DISK_ATTRIBUTES</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-set_disk_attributes">SET_DISK_ATTRIBUTES</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_DISK_ATTRIBUTES](ni-winioctl-ioctl_disk_get_disk_attributes.md)
+* [SET_DISK_ATTRIBUTES](ns-winioctl-set_disk_attributes.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_drive_layout.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_drive_layout.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_DRIVE_LAYOUT
 title: IOCTL_DISK_SET_DRIVE_LAYOUT
-description: Partitions a disk as specified by drive layout and partition information data.helpviewer_keywords: ["IOCTL_DISK_SET_DRIVE_LAYOUT","IOCTL_DISK_SET_DRIVE_LAYOUT control","IOCTL_DISK_SET_DRIVE_LAYOUT control code [Files]","_win32_ioctl_disk_set_drive_layout","base.ioctl_disk_set_drive_layout","fs.ioctl_disk_set_drive_layout","winioctl/IOCTL_DISK_SET_DRIVE_LAYOUT"]
+description: Partitions a disk as specified by drive layout and partition information data.
+helpviewer_keywords: ["IOCTL_DISK_SET_DRIVE_LAYOUT","IOCTL_DISK_SET_DRIVE_LAYOUT control","IOCTL_DISK_SET_DRIVE_LAYOUT control code [Files]","_win32_ioctl_disk_set_drive_layout","base.ioctl_disk_set_drive_layout","fs.ioctl_disk_set_drive_layout","winioctl/IOCTL_DISK_SET_DRIVE_LAYOUT"]
 old-location: fs\ioctl_disk_set_drive_layout.htm
 tech.root: FileIO
 ms.assetid: 8cace6a5-666a-4d35-a557-6bf0564dbe58
@@ -57,14 +58,14 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 
 ```cpp
 BOOL DeviceIoControl(
-  (HANDLE) hDevice,              // handle to device
-  IOCTL_DISK_SET_DRIVE_LAYOUT,   //dwIoControlCode
-  (LPVOID) lpInBuffer,           // input buffer
-  (DWORD) nInBufferSize,         // size of input buffer
-  NULL,                          // lpOutBuffer
-  0,                             // nOutBufferSize
-  (LPDWORD) lpBytesReturned,     // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped    // OVERLAPPED structure
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_SET_DRIVE_LAYOUT,  // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
+  (DWORD) nInBufferSize,        // size of input buffer
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
 );
 ```
 
@@ -118,4 +119,8 @@ If the partition is on a disk formatted as type master boot record (MBR), partit
 
 ## -see-also
 
-[DRIVE_LAYOUT_INFORMATION](ns-winioctl-drive_layout_information.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes), [IOCTL_DISK_SET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_set_drive_layout_ex.md), [IOCTL_DISK_GET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_get_drive_layout.md)
+* [DRIVE_LAYOUT_INFORMATION](ns-winioctl-drive_layout_information.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_SET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_set_drive_layout_ex.md)
+* [IOCTL_DISK_GET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_get_drive_layout.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_drive_layout_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_drive_layout_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_DRIVE_LAYOUT_EX
 title: IOCTL_DISK_SET_DRIVE_LAYOUT_EX
-description: Partitions a disk according to the specified drive layout and partition information data.helpviewer_keywords: ["IOCTL_DISK_SET_DRIVE_LAYOUT_EX","IOCTL_DISK_SET_DRIVE_LAYOUT_EX control","IOCTL_DISK_SET_DRIVE_LAYOUT_EX control code [Files]","_win32_ioctl_disk_set_drive_layout_ex","base.ioctl_disk_set_drive_layout_ex","fs.ioctl_disk_set_drive_layout_ex","winioctl/IOCTL_DISK_SET_DRIVE_LAYOUT_EX"]
+description: Partitions a disk according to the specified drive layout and partition information data.
+helpviewer_keywords: ["IOCTL_DISK_SET_DRIVE_LAYOUT_EX","IOCTL_DISK_SET_DRIVE_LAYOUT_EX control","IOCTL_DISK_SET_DRIVE_LAYOUT_EX control code [Files]","_win32_ioctl_disk_set_drive_layout_ex","base.ioctl_disk_set_drive_layout_ex","fs.ioctl_disk_set_drive_layout_ex","winioctl/IOCTL_DISK_SET_DRIVE_LAYOUT_EX"]
 old-location: fs\ioctl_disk_set_drive_layout_ex.htm
 tech.root: FileIO
 ms.assetid: a600e841-c692-4aa4-bea2-a33931d9b007
@@ -52,14 +53,14 @@ To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapise
 
 ```cpp
 BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_DISK_SET_DRIVE_LAYOUT_EX,  //dwIoControlCode
-  (LPVOID) lpInBuffer,             // input buffer
-  (DWORD) nInBufferSize,           // size of input buffer
-  NULL,                            // lpOutBuffer
-  0,                               // nOutBufferSize
-  (LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_SET_DRIVE_LAYOUT_EX,   // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
 );
 ```
 
@@ -117,4 +118,7 @@ If the partition is on a disk formatted as type master boot record (MBR), partit
 
 ## -see-also
 
-[DRIVE_LAYOUT_INFORMATION_EX](ns-winioctl-drive_layout_information_ex.md), [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md), [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes), [IOCTL_DISK_GET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_get_drive_layout_ex.md)
+* [DRIVE_LAYOUT_INFORMATION_EX](ns-winioctl-drive_layout_information_ex.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_DRIVE_LAYOUT_EX](ni-winioctl-ioctl_disk_get_drive_layout_ex.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_partition_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_partition_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_PARTITION_INFO
 title: IOCTL_DISK_SET_PARTITION_INFO
-description: Sets partition information for the specified disk partition.helpviewer_keywords: ["IOCTL_DISK_SET_PARTITION_INFO","IOCTL_DISK_SET_PARTITION_INFO control","IOCTL_DISK_SET_PARTITION_INFO control code [Files]","_win32_ioctl_disk_set_partition_info","base.ioctl_disk_set_partition_info","fs.ioctl_disk_set_partition_info","winioctl/IOCTL_DISK_SET_PARTITION_INFO"]
+description: Sets partition information for the specified disk partition.
+helpviewer_keywords: ["IOCTL_DISK_SET_PARTITION_INFO","IOCTL_DISK_SET_PARTITION_INFO control","IOCTL_DISK_SET_PARTITION_INFO control code [Files]","_win32_ioctl_disk_set_partition_info","base.ioctl_disk_set_partition_info","fs.ioctl_disk_set_partition_info","winioctl/IOCTL_DISK_SET_PARTITION_INFO"]
 old-location: fs\ioctl_disk_set_partition_info.htm
 tech.root: FileIO
 ms.assetid: 868cad92-fa88-4a5a-98bb-92e73c115a22
@@ -48,92 +49,52 @@ req.redist:
 ## -description
 
 
+# IOCTL_DISK_SET_PARTITION_INFO IOCTL
+
+## -description
+
+> [!NOTE]
+> **IOCTL_DISK_SET_PARTITION_INFO** has been superseded by [**IOCTL_DISK_SET_PARTITION_INFO_EX**](ni-winioctl-ioctl_disk_set_partition_info_ex.md), which retrieves layout information for AT and EFI (Extensible Firmware Interface) partitions.
+
 Sets partition information for the specified disk partition.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-<b>IOCTL_DISK_SET_PARTITION_INFO</b> has been superseded by 
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_partition_info_ex">IOCTL_DISK_SET_PARTITION_INFO_EX</a>, which retrieves layout information for AT and EFI (Extensible Firmware Interface) partitions.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_DISK_SET_PARTITION_INFO,   // dwIoControlCode(LPVOID) lpInBuffer,             // input buffer 
-  (DWORD) nInBufferSize,           // size of input buffer 
-  NULL,                            // lpOutBuffer0,                               // nOutBufferSize(LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_DISK_SET_PARTITION_INFO,    // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer 
+  (DWORD) nInBufferSize,            // size of input buffer 
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -142,40 +103,15 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_drive_layout">IOCTL_DISK_SET_DRIVE_LAYOUT</a>.
-
-
+If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_partition_info">IOCTL_DISK_GET_PARTITION_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_partition_info_ex">IOCTL_DISK_SET_PARTITION_INFO_EX</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-set_partition_information">SET_PARTITION_INFORMATION</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_PARTITION_INFO](ni-winioctl-ioctl_disk_get_partition_info.md)
+* [IOCTL_DISK_SET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_set_partition_info_ex.md)
+* [SET_PARTITION_INFORMATION](ns-winioctl-set_partition_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_partition_info_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_set_partition_info_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_SET_PARTITION_INFO_EX
 title: IOCTL_DISK_SET_PARTITION_INFO_EX
-description: Sets partition information for the specified disk partition, including layout information for AT and EFI (Extensible Firmware Interface) partitions.helpviewer_keywords: ["IOCTL_DISK_SET_PARTITION_INFO_EX","IOCTL_DISK_SET_PARTITION_INFO_EX control","IOCTL_DISK_SET_PARTITION_INFO_EX control code [Files]","_win32_ioctl_disk_set_partition_info_ex","base.ioctl_disk_set_partition_info_ex","fs.ioctl_disk_set_partition_info_ex","winioctl/IOCTL_DISK_SET_PARTITION_INFO_EX"]
+description: Sets partition information for the specified disk partition, including layout information for AT and EFI (Extensible Firmware Interface) partitions.
+helpviewer_keywords: ["IOCTL_DISK_SET_PARTITION_INFO_EX","IOCTL_DISK_SET_PARTITION_INFO_EX control","IOCTL_DISK_SET_PARTITION_INFO_EX control code [Files]","_win32_ioctl_disk_set_partition_info_ex","base.ioctl_disk_set_partition_info_ex","fs.ioctl_disk_set_partition_info_ex","winioctl/IOCTL_DISK_SET_PARTITION_INFO_EX"]
 old-location: fs\ioctl_disk_set_partition_info_ex.htm
 tech.root: FileIO
 ms.assetid: 6feec7a9-5b57-406b-bbea-04cf9cdaf56b
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_SET_PARTITION_INFO_EX IOCTL
 
-
 ## -description
-
 
 Sets partition information for the specified disk partition, including layout information for AT and EFI (Extensible Firmware Interface) partitions.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_DISK_SET_PARTITION_INFO_EX, // dwIoControlCode(LPVOID) lpInBuffer,              // input buffer
+  IOCTL_DISK_SET_PARTITION_INFO_EX, // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
   (DWORD) nInBufferSize,            // size of input buffer
-  NULL,                             // lpOutBuffer0,                                // nOutBufferSize(LPDWORD) lpBytesReturned,        // number of bytes returned
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,36 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_set_drive_layout">IOCTL_DISK_SET_DRIVE_LAYOUT</a>.
-
-
+If the partition is on a disk formatted as type master boot record (MBR), partition size totals are limited. For more information, see the Remarks section of [IOCTL_DISK_SET_DRIVE_LAYOUT](ni-winioctl-ioctl_disk_set_drive_layout.md).
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_partition_info_ex">IOCTL_DISK_GET_PARTITION_INFO_EX</a>
-
-
-
-<a href="https://msdn.microsoft.com/library/ff566194.aspx">SET_PARTITION_INFORMATION_EX</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [IOCTL_DISK_GET_PARTITION_INFO_EX](ni-winioctl-ioctl_disk_get_partition_info_ex.md)
+* [SET_PARTITION_INFORMATION_EX](https://msdn.microsoft.com/library/ff566194.aspx)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_update_properties.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_update_properties.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_UPDATE_PROPERTIES
 title: IOCTL_DISK_UPDATE_PROPERTIES
-description: Invalidates the cached partition table and re-enumerates the device.helpviewer_keywords: ["IOCTL_DISK_UPDATE_PROPERTIES","IOCTL_DISK_UPDATE_PROPERTIES control","IOCTL_DISK_UPDATE_PROPERTIES control code [Files]","_win32_ioctl_disk_update_properties","base.ioctl_disk_update_properties","fs.ioctl_disk_update_properties","winioctl/IOCTL_DISK_UPDATE_PROPERTIES"]
+description: Invalidates the cached partition table and re-enumerates the device.
+helpviewer_keywords: ["IOCTL_DISK_UPDATE_PROPERTIES","IOCTL_DISK_UPDATE_PROPERTIES control","IOCTL_DISK_UPDATE_PROPERTIES control code [Files]","_win32_ioctl_disk_update_properties","base.ioctl_disk_update_properties","fs.ioctl_disk_update_properties","winioctl/IOCTL_DISK_UPDATE_PROPERTIES"]
 old-location: fs\ioctl_disk_update_properties.htm
 tech.root: FileIO
 ms.assetid: d97e0257-c3b0-48d5-b801-594763be8178
@@ -44,89 +45,46 @@ req.redist:
 
 # IOCTL_DISK_UPDATE_PROPERTIES IOCTL
 
-
 ## -description
-
 
 Invalidates the cached partition table and re-enumerates the device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_UPDATE_PROPERTIES,// dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD)lpBytesReturned,    // lpBytesReturned(LPDWORD) lpOverlapped       // lpOverlapped);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_UPDATE_PROPERTIES, // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD)lpBytesReturned,     // lpBytesReturned
+  (LPDWORD) lpOverlapped        // lpOverlapped
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -135,33 +93,16 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+This operation is used in synchronizing the system view of the specified disk device when the partition table of the disk is directly modified. Be sure to perform this operation when you update the usable space for a disk so that the system will update its partition table.
 
-
-This operation is used in synchronizing the system view of the specified disk device when the partition table of the disk is directly modified. 
-			Be sure to perform this operation when you update the usable space for a disk so that the system will update its partition table.
-
-You can update the properties of  a live volume, and the volume can be open for sharing during the update operation.
+You can update the properties of a live volume, and the volume can be open for sharing during the update operation.
 
 You do not need to lock a volume that you are updating, nor do you need to shut down other applications or services during the update operation.
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_verify.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_disk_verify.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_DISK_VERIFY
 title: IOCTL_DISK_VERIFY
-description: Verifies the specified extent on a fixed disk.helpviewer_keywords: ["IOCTL_DISK_VERIFY","IOCTL_DISK_VERIFY control","IOCTL_DISK_VERIFY control code [Files]","_win32_ioctl_disk_verify","base.ioctl_disk_verify","fs.ioctl_disk_verify","winioctl/IOCTL_DISK_VERIFY"]
+description: Verifies the specified extent on a fixed disk.
+helpviewer_keywords: ["IOCTL_DISK_VERIFY","IOCTL_DISK_VERIFY control","IOCTL_DISK_VERIFY control code [Files]","_win32_ioctl_disk_verify","base.ioctl_disk_verify","fs.ioctl_disk_verify","winioctl/IOCTL_DISK_VERIFY"]
 old-location: fs\ioctl_disk_verify.htm
 tech.root: FileIO
 ms.assetid: 156b217d-6cdc-4802-b711-8845934e277b
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_DISK_VERIFY IOCTL
 
-
 ## -description
-
 
 Verifies the specified extent on a fixed disk.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_DISK_VERIFY,           // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer 
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_DISK_VERIFY,            // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer 
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-verify_information">VERIFY_INFORMATION</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [VERIFY_INFORMATION](ns-winioctl-verify_information.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_serial_lsrmst_insert.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_serial_lsrmst_insert.md
@@ -45,97 +45,49 @@ req.redist:
 
 # IOCTL_SERIAL_LSRMST_INSERT IOCTL
 
-
 ## -description
 
+Enables or disables the placement of line status and modem status values into the regular data stream that an application acquires through the [ReadFile](/windows/win32/api/fileapi/nf-fileapi-readfile) function.
 
-Enables or disables the placement of line status and modem status values into the regular data stream that an application acquires through the 
-[ReadFile](/windows/win32/api/fileapi/nf-fileapi-readfile) function.
+When this line-status and modem-status data placement mode is enabled, status values are preceded in the data stream by an escape character. The user-definable escape character is set by the **IOCTL_SERIAL_LSRMST_INSERT** control code. See the Remarks section for status value details.
 
-When this line-status and modem-status data placement mode is enabled, status values are preceded in the data stream by an escape character. The user-definable escape character is set by the 
-<b>IOCTL_SERIAL_LSRMST_INSERT</b> control code. See the Remarks section for status value details.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_SERIAL_LSRMST_INSERT,  // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer 
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_SERIAL_LSRMST_INSERT,   // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer 
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -144,50 +96,21 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+> [!NOTE]
+> An application that uses this scheme must examine each character in the data stream to determine the presence of modem-status or line-status data.
 
+The following values follow the designated escape character in the data stream if the **LSRMST_INSERT** mode has been turned on.
 
-<div class="alert"><b>Note</b>  An application that uses this scheme must examine each character in the data stream to determine the presence of modem-status or line-status data.</div>
-<div> </div>
-The following values follow the designated escape character in the data stream if the <b>LSRMST_INSERT</b> mode has been turned on.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td><b>SERIAL_LSRMST_ESCAPE</b></td>
-<td>Indicates the reception of the escape character itself into the data stream.</td>
-</tr>
-<tr>
-<td><b>SERIAL_LSRMST_LSR_DATA</b></td>
-<td>Indicates that a line status change occurred, and data was available in the receive hardware buffer. Following this <b>BYTE</b> is a <b>BYTE</b> value of the line status register is the <b>BYTE</b> present in the receive hardware buffer when the line status change was processed.</td>
-</tr>
-<tr>
-<td><b>SERIAL_LSRMST_LSR_NODATA</b></td>
-<td>Indicates that a line status change occurred, but no data was available in the receive hardware buffer.</td>
-</tr>
-<tr>
-<td><b>SERIAL_LSRMST_MST</b></td>
-<td>Indicates that a modem status change occurred. Following this <b>BYTE</b> is a <b>BYTE</b> that is the value of the modem status register when the modem status change was processed.</td>
-</tr>
-</table>
- 
-
-
+Value | Meaning
+------|--------
+**SERIAL_LSRMST_ESCAPE** | Indicates the reception of the escape character itself into the data stream.
+**SERIAL_LSRMST_LSR_DATA** | Indicates that a line status change occurred, and data was available in the receive hardware buffer. Following this **BYTE** is a **BYTE** value of the line status register is the **BYTE** present in the receive hardware buffer when the line status change was processed.
+**SERIAL_LSRMST_LSR_NODATA** | Indicates that a line status change occurred, but no data was available in the receive hardware buffer.
+**SERIAL_LSRMST_MST**  | Indicates that a modem status change occurred. Following this **BYTE** is a **BYTE** that is the value of the modem status register when the modem status change was processed.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_serial_lsrmst_insert.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_serial_lsrmst_insert.md
@@ -47,7 +47,7 @@ req.redist:
 
 ## -description
 
-Enables or disables the placement of line status and modem status values into the regular data stream that an application acquires through the [ReadFile](/windows/win32/api/fileapi/nf-fileapi-readfile) function.
+Enables or disables the placement of line status and modem status values into the regular data stream that an application acquires through the [ReadFile](../fileapi/nf-fileapi-readfile.md) function.
 
 When this line-status and modem-status data placement mode is enabled, status values are preceded in the data stream by an escape character. The user-definable escape character is set by the **IOCTL_SERIAL_LSRMST_INSERT** control code. See the Remarks section for status value details.
 

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_check_verify.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_check_verify.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_CHECK_VERIFY
 title: IOCTL_STORAGE_CHECK_VERIFY
-description: Determines whether media are accessible for a device.helpviewer_keywords: ["IOCTL_STORAGE_CHECK_VERIFY","IOCTL_STORAGE_CHECK_VERIFY control","IOCTL_STORAGE_CHECK_VERIFY control code","_win32_ioctl_storage_check_verify","base.ioctl_storage_check_verify","winioctl/IOCTL_STORAGE_CHECK_VERIFY"]
+description: Determines whether media are accessible for a device.
+helpviewer_keywords: ["IOCTL_STORAGE_CHECK_VERIFY","IOCTL_STORAGE_CHECK_VERIFY control","IOCTL_STORAGE_CHECK_VERIFY control code","_win32_ioctl_storage_check_verify","base.ioctl_storage_check_verify","winioctl/IOCTL_STORAGE_CHECK_VERIFY"]
 old-location: base\ioctl_storage_check_verify.htm
 tech.root: devio
 ms.assetid: b4705882-30ce-4527-a1b5-c0b296b70274
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_CHECK_VERIFY IOCTL
 
-
 ## -description
-
 
 Determines whether media are accessible for a device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_STORAGE_CHECK_VERIFY,  // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_CHECK_VERIFY,   // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,19 +94,7 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_device_power_cap.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_device_power_cap.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_DEVICE_POWER_CAP
 title: IOCTL_STORAGE_DEVICE_POWER_CAP
-description: Windows applications can use this control code to specify a maximum operational power consumption level for a storage device.helpviewer_keywords: ["IOCTL_STORAGE_DEVICE_POWER_CAP","IOCTL_STORAGE_DEVICE_POWER_CAP control","IOCTL_STORAGE_DEVICE_POWER_CAP control code [Files]","fs.ioctl_storage_device_power_cap","winioctl/IOCTL_STORAGE_DEVICE_POWER_CAP"]
+description: Windows applications can use this control code to specify a maximum operational power consumption level for a storage device.
+helpviewer_keywords: ["IOCTL_STORAGE_DEVICE_POWER_CAP","IOCTL_STORAGE_DEVICE_POWER_CAP control","IOCTL_STORAGE_DEVICE_POWER_CAP control code [Files]","fs.ioctl_storage_device_power_cap","winioctl/IOCTL_STORAGE_DEVICE_POWER_CAP"]
 old-location: fs\ioctl_storage_device_power_cap.htm
 tech.root: FileIO
 ms.assetid: 4BF06CA7-5219-4EE0-9A74-F43035914332
@@ -44,96 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_DEVICE_POWER_CAP IOCTL
 
-
 ## -description
 
+Windows applications can use this control code to specify a maximum operational power  consumption level for a storage device. The OS will do it's best to transition the device to a power state that will not exceed the given maximum. However, this depends on what the device supports. The actual maximum may be less than or greater than the desired maximum.
 
-Windows applications can use this 
-   control code to specify a maximum operational power  consumption level for a storage device. The OS will do it's best to transition the device to a power state that will not exceed the given maximum. However, this depends on what the device supports. The actual maximum may be less than or greater than the desired maximum.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_DEVICE_POWER_CAP, // dwIoControlCode(LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_DEVICE_POWER_CAP,   // dwIoControlCode
+  (LPDWORD) lpInBuffer,             // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPDWORD) lpOutBuffer,            // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -142,26 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 This IOCTL is sent to the device driver with a maximum power value that the driver is expected to honor. This IOCTL then returns with a value that represents what the device driver is actually capable of achieving. This value could be equal to, less than, or greater than the desired value that was sent originally. 
 
 For example, consider a storage device driver that implements three operational power states that have a maximum power consumption level of 10 watts, 8 watts, and 6 watts. If the caller of this IOCTL specifies that the device should not consume more than 9 watts, it must choose it's 8 watt state because that is the highest state it has that is still less than 9 watts. If the caller of this IOCTL specifies that the device should not consume more than 5 watts, the device driver will pick the 6 watt state because 6 watts is the minimum value the device can function at.
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_eject_media.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_eject_media.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_EJECT_MEDIA
 title: IOCTL_STORAGE_EJECT_MEDIA
-description: Ejects media from a SCSI device.helpviewer_keywords: ["IOCTL_STORAGE_EJECT_MEDIA","IOCTL_STORAGE_EJECT_MEDIA control","IOCTL_STORAGE_EJECT_MEDIA control code","_win32_ioctl_storage_eject_media","base.ioctl_storage_eject_media","winioctl/IOCTL_STORAGE_EJECT_MEDIA"]
+description: Ejects media from a SCSI device.
+helpviewer_keywords: ["IOCTL_STORAGE_EJECT_MEDIA","IOCTL_STORAGE_EJECT_MEDIA control","IOCTL_STORAGE_EJECT_MEDIA control code","_win32_ioctl_storage_eject_media","base.ioctl_storage_eject_media","winioctl/IOCTL_STORAGE_EJECT_MEDIA"]
 old-location: base\ioctl_storage_eject_media.htm
 tech.root: devio
 ms.assetid: e1eeb3b8-b52b-4570-a3bc-e245ae58464f
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_EJECT_MEDIA IOCTL
 
-
 ## -description
 
+Ejects media from a SCSI device.
 
-Ejects media  from a SCSI device.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_STORAGE_EJECT_MEDIA,   // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_EJECT_MEDIA,    // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,36 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-<b>IOCTL_STORAGE_EJECT_MEDIA</b> may or may not be supported on SCSI devices that support removable media.
-
-
+**IOCTL_STORAGE_EJECT_MEDIA** may or may not be supported on SCSI devices that support removable media.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_load_media">IOCTL_STORAGE_LOAD_MEDIA</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_media_removal">IOCTL_STORAGE_MEDIA_REMOVAL</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_LOAD_MEDIA](ni-winioctl-ioctl_storage_load_media.md)
+* [IOCTL_STORAGE_MEDIA_REMOVAL](ni-winioctl-ioctl_storage_media_removal.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_ejection_control.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_ejection_control.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_EJECTION_CONTROL
 title: IOCTL_STORAGE_EJECTION_CONTROL
-description: Enables or disables the mechanism that ejects media. Disabling the mechanism locks the drive.helpviewer_keywords: ["IOCTL_STORAGE_EJECTION_CONTROL","IOCTL_STORAGE_EJECTION_CONTROL control","IOCTL_STORAGE_EJECTION_CONTROL control code","_win32_ioctl_storage_ejection_control","base.ioctl_storage_ejection_control","winioctl/IOCTL_STORAGE_EJECTION_CONTROL"]
+description: Enables or disables the mechanism that ejects media. Disabling the mechanism locks the drive.
+helpviewer_keywords: ["IOCTL_STORAGE_EJECTION_CONTROL","IOCTL_STORAGE_EJECTION_CONTROL control","IOCTL_STORAGE_EJECTION_CONTROL control code","_win32_ioctl_storage_ejection_control","base.ioctl_storage_ejection_control","winioctl/IOCTL_STORAGE_EJECTION_CONTROL"]
 old-location: base\ioctl_storage_ejection_control.htm
 tech.root: devio
 ms.assetid: d31aae7b-df93-419d-9a53-80a601a3c437
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_EJECTION_CONTROL IOCTL
 
-
 ## -description
-
 
 Enables or disables the mechanism that ejects media. Disabling the mechanism locks the drive.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_STORAGE_EJECTION_CONTROL,  // dwIoControlCode(LPVOID) lpInBuffer,             // input buffer
-  (DWORD) nInBufferSize,           // size of input buffer
-  NULL,                            // lpOutBuffer0,                               // nOutBufferSize(LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_EJECTION_CONTROL,   // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,33 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The driver tracks 
-<b>IOCTL_STORAGE_EJECTION_CONTROL</b> requests by caller. It ignores requests to enable the ejection mechanism unless it has received a request to disable the ejection mechanism from the same caller. This prevents other callers from unlocking the drive.
-
-
+The driver tracks **IOCTL_STORAGE_EJECTION_CONTROL** requests by caller. It ignores requests to enable the ejection mechanism unless it has received a request to disable the ejection mechanism from the same caller. This prevents other callers from unlocking the drive.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-prevent_media_removal">PREVENT_MEDIA_REMOVAL</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [PREVENT_MEDIA_REMOVAL](ns-winioctl-prevent_media_removal.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_activate.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_activate.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_FIRMWARE_ACTIVATE
 title: IOCTL_STORAGE_FIRMWARE_ACTIVATE
-description: Windows applications can use this control code to activate a firmware image on a specified device.helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_ACTIVATE","IOCTL_STORAGE_FIRMWARE_ACTIVATE control","IOCTL_STORAGE_FIRMWARE_ACTIVATE control code [Files]","fs.ioctl_storage_firmware_activate","winioctl/IOCTL_STORAGE_FIRMWARE_ACTIVATE"]
+description: Windows applications can use this control code to activate a firmware image on a specified device.
+helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_ACTIVATE","IOCTL_STORAGE_FIRMWARE_ACTIVATE control","IOCTL_STORAGE_FIRMWARE_ACTIVATE control code [Files]","fs.ioctl_storage_firmware_activate","winioctl/IOCTL_STORAGE_FIRMWARE_ACTIVATE"]
 old-location: fs\ioctl_storage_firmware_activate.htm
 tech.root: FileIO
 ms.assetid: 000BEB58-D91E-4859-AC31-A4C72B84A982
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_FIRMWARE_ACTIVATE IOCTL
 
-
 ## -description
-
 
 Windows applications can use this control code to activate a firmware image on a specified device.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_FIRMWARE_ACTIVATE, // dwIoControlCode(LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_FIRMWARE_ACTIVATE,  // dwIoControlCode
+  (LPDWORD) lpInBuffer,             // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPDWORD) lpOutBuffer,            // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,43 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_download">IOCTL_STORAGE_FIRMWARE_DOWNLOAD</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_get_info">IOCTL_STORAGE_FIRMWARE_GET_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_activate">STORAGE_HW_FIRMWARE_ACTIVATE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_download">STORAGE_HW_FIRMWARE_DOWNLOAD</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info">STORAGE_HW_FIRMWARE_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query">STORAGE_HW_FIRMWARE_INFO_QUERY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info">STORAGE_HW_FIRMWARE_SLOT_INFO</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_FIRMWARE_DOWNLOAD](ni-winioctl-ioctl_storage_firmware_download.md)
+* [IOCTL_STORAGE_FIRMWARE_GET_INFO](ni-winioctl-ioctl_storage_firmware_get_info.md)
+* [STORAGE_HW_FIRMWARE_ACTIVATE](ns-winioctl-storage_hw_firmware_activate.md)
+* [STORAGE_HW_FIRMWARE_DOWNLOAD](ns-winioctl-storage_hw_firmware_download.md)
+* [STORAGE_HW_FIRMWARE_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info)
+* [STORAGE_HW_FIRMWARE_INFO_QUERY](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query)
+* [STORAGE_HW_FIRMWARE_SLOT_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_download.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_download.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_FIRMWARE_DOWNLOAD
 title: IOCTL_STORAGE_FIRMWARE_DOWNLOAD
-description: Windows applications can use this control code to download a firmware image to the target device, but not activate it.helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_DOWNLOAD","IOCTL_STORAGE_FIRMWARE_DOWNLOAD control","IOCTL_STORAGE_FIRMWARE_DOWNLOAD control code [Files]","fs.ioctl_storage_firmware_download","winioctl/IOCTL_STORAGE_FIRMWARE_DOWNLOAD"]
+description: Windows applications can use this control code to download a firmware image to the target device, but not activate it.
+helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_DOWNLOAD","IOCTL_STORAGE_FIRMWARE_DOWNLOAD control","IOCTL_STORAGE_FIRMWARE_DOWNLOAD control code [Files]","fs.ioctl_storage_firmware_download","winioctl/IOCTL_STORAGE_FIRMWARE_DOWNLOAD"]
 old-location: fs\ioctl_storage_firmware_download.htm
 tech.root: FileIO
 ms.assetid: 77E50787-1E71-4D90-A1D3-E6665CE0EFDC
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_FIRMWARE_DOWNLOAD IOCTL
 
-
 ## -description
-
 
 Windows applications can use this control code to download a firmware image to the target device, but not activate it. If the image to be downloaded is larger than the controller’s maximum data transfer size, this IOCTL will have to be called multiple times until the entire image is downloaded.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_FIRMWARE_DOWNLOAD, // dwIoControlCode(LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_FIRMWARE_DOWNLOAD,  // dwIoControlCode
+  (LPDWORD) lpInBuffer,             // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPDWORD) lpOutBuffer,            // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,43 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_activate">IOCTL_STORAGE_FIRMWARE_ACTIVATE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_get_info">IOCTL_STORAGE_FIRMWARE_GET_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_activate">STORAGE_HW_FIRMWARE_ACTIVATE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_download">STORAGE_HW_FIRMWARE_DOWNLOAD</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info">STORAGE_HW_FIRMWARE_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query">STORAGE_HW_FIRMWARE_INFO_QUERY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info">STORAGE_HW_FIRMWARE_SLOT_INFO</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_FIRMWARE_ACTIVATE](ni-winioctl-ioctl_storage_firmware_activate.md)
+* [IOCTL_STORAGE_FIRMWARE_GET_INFO](ni-winioctl-ioctl_storage_firmware_get_info.md)
+* [STORAGE_HW_FIRMWARE_ACTIVATE](ns-winioctl-storage_hw_firmware_activate.md)
+* [STORAGE_HW_FIRMWARE_DOWNLOAD](ns-winioctl-storage_hw_firmware_download.md)
+* [STORAGE_HW_FIRMWARE_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info)
+* [STORAGE_HW_FIRMWARE_INFO_QUERY](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query)
+* [STORAGE_HW_FIRMWARE_SLOT_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_get_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_firmware_get_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_FIRMWARE_GET_INFO
 title: IOCTL_STORAGE_FIRMWARE_GET_INFO
-description: Windows applications can use this control code to query the storage device for detailed firmware information.helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_GET_INFO","IOCTL_STORAGE_FIRMWARE_GET_INFO control","IOCTL_STORAGE_FIRMWARE_GET_INFO control code [Files]","fs.ioctl_storage_firmware_get_info","winioctl/IOCTL_STORAGE_FIRMWARE_GET_INFO"]
+description: Windows applications can use this control code to query the storage device for detailed firmware information.
+helpviewer_keywords: ["IOCTL_STORAGE_FIRMWARE_GET_INFO","IOCTL_STORAGE_FIRMWARE_GET_INFO control","IOCTL_STORAGE_FIRMWARE_GET_INFO control code [Files]","fs.ioctl_storage_firmware_get_info","winioctl/IOCTL_STORAGE_FIRMWARE_GET_INFO"]
 old-location: fs\ioctl_storage_firmware_get_info.htm
 tech.root: FileIO
 ms.assetid: DBF40C42-2282-4F0E-B83A-D3154D7EF332
@@ -44,95 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_FIRMWARE_GET_INFO IOCTL
 
-
 ## -description
-
 
 Windows applications can use this control code to query the storage device for detailed firmware information. A successful call will return information about firmware revisions, activity status, as well as read/write attributes for each slot. The amount of data returned will vary based on storage protocol.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_FIRMWARE_GET_INFO, // dwIoControlCode(LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_FIRMWARE_GET_INFO,  // dwIoControlCode
+  (LPDWORD) lpInBuffer,             // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPDWORD) lpOutBuffer,            // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,43 +94,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_activate">IOCTL_STORAGE_FIRMWARE_ACTIVATE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_firmware_download">IOCTL_STORAGE_FIRMWARE_DOWNLOAD</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_activate">STORAGE_HW_FIRMWARE_ACTIVATE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hw_firmware_download">STORAGE_HW_FIRMWARE_DOWNLOAD</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info">STORAGE_HW_FIRMWARE_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query">STORAGE_HW_FIRMWARE_INFO_QUERY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info">STORAGE_HW_FIRMWARE_SLOT_INFO</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_FIRMWARE_ACTIVATE](ni-winioctl-ioctl_storage_firmware_activate.md)
+* [IOCTL_STORAGE_FIRMWARE_DOWNLOAD](ni-winioctl-ioctl_storage_firmware_download.md)
+* [STORAGE_HW_FIRMWARE_ACTIVATE](ns-winioctl-storage_hw_firmware_activate.md)
+* [STORAGE_HW_FIRMWARE_DOWNLOAD](ns-winioctl-storage_hw_firmware_download.md)
+* [STORAGE_HW_FIRMWARE_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info)
+* [STORAGE_HW_FIRMWARE_INFO_QUERY](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-info-query)
+* [STORAGE_HW_FIRMWARE_SLOT_INFO](https://docs.microsoft.com/windows/desktop/FileIO/storage-hw-firmware-slot-info)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_device_number.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_device_number.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_GET_DEVICE_NUMBER
 title: IOCTL_STORAGE_GET_DEVICE_NUMBER
-description: Retrieves the device type, device number, and, for a partitionable device, the partition number of a device.helpviewer_keywords: ["IOCTL_STORAGE_GET_DEVICE_NUMBER","IOCTL_STORAGE_GET_DEVICE_NUMBER control","IOCTL_STORAGE_GET_DEVICE_NUMBER control code","base.ioctl_storage_get_device_number","winioctl/IOCTL_STORAGE_GET_DEVICE_NUMBER"]
+description: Retrieves the device type, device number, and, for a partitionable device, the partition number of a device.
+helpviewer_keywords: ["IOCTL_STORAGE_GET_DEVICE_NUMBER","IOCTL_STORAGE_GET_DEVICE_NUMBER control","IOCTL_STORAGE_GET_DEVICE_NUMBER control code","base.ioctl_storage_get_device_number","winioctl/IOCTL_STORAGE_GET_DEVICE_NUMBER"]
 old-location: base\ioctl_storage_get_device_number.htm
 tech.root: devio
 ms.assetid: 2cd9610b-aa83-4d0a-a7a9-1d4dab8be331
@@ -44,94 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_GET_DEVICE_NUMBER IOCTL
 
-
 ## -description
-
 
 Retrieves the device type, device number, and, for a partitionable device, the partition number of a device. 
 
-To perform this operation, call the 
-   <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_STORAGE_GET_DEVICE_NUMBER, // dwIoControlCodeNULL,                            // lpInBuffer0,                               // nInBufferSize(LPVOID), lpOutBuffer,           // output buffer
-  (DWORD), nOutBufferSize,         // size of output buffer
-  (LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_GET_DEVICE_NUMBER,  // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID), lpOutBuffer,            // output buffer
+  (DWORD), nOutBufferSize,          // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,28 +94,12 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The values in the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_device_number">STORAGE_DEVICE_NUMBER</a> structure are guaranteed to remain unchanged until the device is removed or the system is restarted. It is not guaranteed to be persistent across device restarts or system restarts. 
-
-
+The values in the [STORAGE_DEVICE_NUMBER](ns-winioctl-storage_device_number.md) structure are guaranteed to remain unchanged until the device is removed or the system is restarted. It is not guaranteed to be persistent across device restarts or system restarts.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_device_number">STORAGE_DEVICE_NUMBER</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [STORAGE_DEVICE_NUMBER](ns-winioctl-storage_device_number.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_hotplug_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_hotplug_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_GET_HOTPLUG_INFO
 title: IOCTL_STORAGE_GET_HOTPLUG_INFO
-description: Retrieves the hotplug configuration of the specified device.helpviewer_keywords: ["IOCTL_STORAGE_GET_HOTPLUG_INFO","IOCTL_STORAGE_GET_HOTPLUG_INFO control","IOCTL_STORAGE_GET_HOTPLUG_INFO control code","_win32_ioctl_storage_get_hotplug_info","base.ioctl_storage_get_hotplug_info","winioctl/IOCTL_STORAGE_GET_HOTPLUG_INFO"]
+description: Retrieves the hotplug configuration of the specified device.
+helpviewer_keywords: ["IOCTL_STORAGE_GET_HOTPLUG_INFO","IOCTL_STORAGE_GET_HOTPLUG_INFO control","IOCTL_STORAGE_GET_HOTPLUG_INFO control code","_win32_ioctl_storage_get_hotplug_info","base.ioctl_storage_get_hotplug_info","winioctl/IOCTL_STORAGE_GET_HOTPLUG_INFO"]
 old-location: base\ioctl_storage_get_hotplug_info.htm
 tech.root: devio
 ms.assetid: 4ecf6f84-17fc-4c48-a859-c043e8f9cd14
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_GET_HOTPLUG_INFO IOCTL
 
-
 ## -description
-
 
 Retrieves the hotplug configuration of the specified device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_STORAGE_GET_HOTPLUG_INFO,  // dwIoControlCodeNULL,                            // lpInBuffer0,                               // nInBufferSize(LPVOID) lpOutBuffer,            // output buffer
-  (DWORD) nOutBufferSize,          // size of output buffer
-  (LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_GET_HOTPLUG_INFO,   // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,37 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-Refer to the Remarks section in the reference page for 
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hotplug_info">STORAGE_HOTPLUG_INFO</a> for more information about hotplug devices.
-
-
+Refer to the Remarks section in the reference page for [STORAGE_HOTPLUG_INFO](ns-winioctl-storage_hotplug_info.md) for more information about hotplug devices.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_set_hotplug_info">IOCTL_STORAGE_SET_HOTPLUG_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hotplug_info">STORAGE_HOTPLUG_INFO</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_SET_HOTPLUG_INFO](ni-winioctl-ioctl_storage_set_hotplug_info.md)
+* [STORAGE_HOTPLUG_INFO](ns-winioctl-storage_hotplug_info.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_serial_number.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_serial_number.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER
 title: IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER
-description: Retrieves the serial number of a USB device.helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER","IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER control","IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER control code","_win32_ioctl_storage_get_media_serial_number","base.ioctl_storage_get_media_serial_number","winioctl/IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER"]
+description: Retrieves the serial number of a USB device.
+helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER","IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER control","IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER control code","_win32_ioctl_storage_get_media_serial_number","base.ioctl_storage_get_media_serial_number","winioctl/IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER"]
 old-location: base\ioctl_storage_get_media_serial_number.htm
 tech.root: devio
 ms.assetid: 379c236d-c6f5-4a12-8adc-aa6377e81e6c
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER IOCTL
 
-
 ## -description
-
 
 Retrieves the serial number of a USB device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                      // handle to device
-  IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER, // dwIoControlCodeNULL,                                  // lpInBuffer0,                                     // nInBufferSize(LPVOID) lpOutBuffer,                  // output buffer
-  (DWORD) nOutBufferSize,                // size of output buffer
-  (LPDWORD) lpBytesReturned,             // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped            // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                         // handle to device
+  IOCTL_STORAGE_GET_MEDIA_SERIAL_NUMBER,    // dwIoControlCode
+  NULL,                                     // lpInBuffer
+  0,                                        // nInBufferSize
+  (LPVOID) lpOutBuffer,                     // output buffer
+  (DWORD) nOutBufferSize,                   // size of output buffer
+  (LPDWORD) lpBytesReturned,                // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped               // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/media-serial-number-data-str">MEDIA_SERIAL_NUMBER_DATA</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [MEDIA_SERIAL_NUMBER_DATA](https://docs.microsoft.com/windows/desktop/DevIO/media-serial-number-data-str)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_types.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_types.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_GET_MEDIA_TYPES
 title: IOCTL_STORAGE_GET_MEDIA_TYPES
-description: Retrieves the geometry information for the device.helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_TYPES","IOCTL_STORAGE_GET_MEDIA_TYPES control","IOCTL_STORAGE_GET_MEDIA_TYPES control code","_win32_ioctl_storage_get_media_types","base.ioctl_storage_get_media_types","winioctl/IOCTL_STORAGE_GET_MEDIA_TYPES"]
+description: Retrieves the geometry information for the device.
+helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_TYPES","IOCTL_STORAGE_GET_MEDIA_TYPES control","IOCTL_STORAGE_GET_MEDIA_TYPES control code","_win32_ioctl_storage_get_media_types","base.ioctl_storage_get_media_types","winioctl/IOCTL_STORAGE_GET_MEDIA_TYPES"]
 old-location: base\ioctl_storage_get_media_types.htm
 tech.root: devio
 ms.assetid: 67f65549-f24b-4ef2-a98f-1fc618a3bb77
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_GET_MEDIA_TYPES IOCTL
 
-
 ## -description
-
 
 Retrieves the geometry information for the device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_STORAGE_GET_MEDIA_TYPES,   // dwIoControlCodeNULL,                            // lpInBuffer0,                               // nInBufferSize(LPVOID) lpOutBuffer,            // output buffer
-  (DWORD) nOutBufferSize,          // size of output buffer
-  (LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_GET_MEDIA_TYPES,    // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,36 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 This device I/O control operation is for all class drivers, as well as non-SCSI hard drives and floppy disk devices.
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-disk_geometry">DISK_GEOMETRY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_disk_get_drive_geometry">IOCTL_DISK_GET_DRIVE_GEOMETRY</a>
- 
-
- 
-
+* [DISK_GEOMETRY](ns-winioctl-disk_geometry.md)
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_DISK_GET_DRIVE_GEOMETRY](ni-winioctl-ioctl_disk_get_drive_geometry.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_types_ex.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_get_media_types_ex.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_GET_MEDIA_TYPES_EX
 title: IOCTL_STORAGE_GET_MEDIA_TYPES_EX
-description: Retrieves information about the types of media supported by a device.helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_TYPES_EX","IOCTL_STORAGE_GET_MEDIA_TYPES_EX control","IOCTL_STORAGE_GET_MEDIA_TYPES_EX control code","_win32_ioctl_storage_get_media_types_ex","base.ioctl_storage_get_media_types_ex","winioctl/IOCTL_STORAGE_GET_MEDIA_TYPES_EX"]
+description: Retrieves information about the types of media supported by a device.
+helpviewer_keywords: ["IOCTL_STORAGE_GET_MEDIA_TYPES_EX","IOCTL_STORAGE_GET_MEDIA_TYPES_EX control","IOCTL_STORAGE_GET_MEDIA_TYPES_EX control code","_win32_ioctl_storage_get_media_types_ex","base.ioctl_storage_get_media_types_ex","winioctl/IOCTL_STORAGE_GET_MEDIA_TYPES_EX"]
 old-location: base\ioctl_storage_get_media_types_ex.htm
 tech.root: devio
 ms.assetid: eb3676cb-9f50-4105-89b6-ee2174e197ec
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_GET_MEDIA_TYPES_EX IOCTL
 
-
 ## -description
-
 
 Retrieves information about the types of media supported by a device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,                 // handle to device
-  IOCTL_STORAGE_GET_MEDIA_TYPES_EX, // dwIoControlCodeNULL,                             // lpInBuffer0,                                // nInBufferSize(LPVOID) lpOutBuffer,             // output buffer
+  IOCTL_STORAGE_GET_MEDIA_TYPES_EX, // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
   (DWORD) nOutBufferSize,           // size of output buffer
   (LPDWORD) lpBytesReturned,        // number of bytes returned
   (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-get_media_types">GET_MEDIA_TYPES</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [GET_MEDIA_TYPES](ns-winioctl-get_media_types.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_load_media.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_load_media.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_LOAD_MEDIA
 title: IOCTL_STORAGE_LOAD_MEDIA
-description: Loads media into a device.helpviewer_keywords: ["IOCTL_STORAGE_LOAD_MEDIA","IOCTL_STORAGE_LOAD_MEDIA control","IOCTL_STORAGE_LOAD_MEDIA control code","_win32_ioctl_storage_load_media","base.ioctl_storage_load_media","winioctl/IOCTL_STORAGE_LOAD_MEDIA"]
+description: Loads media into a device.
+helpviewer_keywords: ["IOCTL_STORAGE_LOAD_MEDIA","IOCTL_STORAGE_LOAD_MEDIA control","IOCTL_STORAGE_LOAD_MEDIA control code","_win32_ioctl_storage_load_media","base.ioctl_storage_load_media","winioctl/IOCTL_STORAGE_LOAD_MEDIA"]
 old-location: base\ioctl_storage_load_media.htm
 tech.root: devio
 ms.assetid: e5b370e9-03e8-4ab8-ba3c-4677cecb3bef
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_LOAD_MEDIA IOCTL
 
-
 ## -description
-
 
 Loads media into a device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_STORAGE_LOAD_MEDIA,    // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_LOAD_MEDIA,     // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,37 +94,14 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The 
-<b>IOCTL_STORAGE_LOAD_MEDIA</b> control code is valid only for devices that support loadable media.
-
-
+The **IOCTL_STORAGE_LOAD_MEDIA** control code is valid only for devices that support loadable media.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_eject_media">IOCTL_STORAGE_EJECT_MEDIA</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_media_removal">IOCTL_STORAGE_MEDIA_REMOVAL</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_EJECT_MEDIA](ni-winioctl-ioctl_storage_eject_media.md)
+* [IOCTL_STORAGE_MEDIA_REMOVAL](ni-winioctl-ioctl_storage_media_removal.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_manage_data_set_attributes.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_manage_data_set_attributes.md
@@ -45,98 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES IOCTL
 
-
 ## -description
 
+The **IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES** control code communicates attribute information to the volume manager and storage system device.
 
-The <b>IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES</b> 
-   control code communicates attribute information to the volume manager and storage system device.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-   <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                 IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES, // dwIoControlCode
-                 (LPVOID)       lpInBuffer,      // input buffer
-                 (DWORD)        nInBufferSize,   // size of the input buffer
-                 (LPVOID)       lpOutBuffer,     // output buffer
-                 (DWORD)        nOutBufferSize,  // size of the input buffer
-                 (LPDWORD)      lpBytesReturned, // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                         // handle to device
+  IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES, // dwIoControlCode
+  (LPVOID) lpInBuffer,                      // input buffer
+  (DWORD) nInBufferSize,                    // size of the input buffer
+  (LPVOID) lpOutBuffer,                     // output buffer
+  (DWORD) nOutBufferSize,                   // size of the input buffer
+  (LPDWORD) lpBytesReturned,                // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped               // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -145,109 +94,25 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+Use the **IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES** control code for sending storage system-specific information to the volume manager and storage system.
 
+The input buffers passed through the *lpInBuffer* parameter start with a [DEVICE_MANAGE_DATA_SET_ATTRIBUTES](ns-winioctl-device_manage_data_set_attributes.md) structure but may contain additional parameters before the list of data set ranges depending on the value of the **Action** member of the **DEVICE_MANAGE_DATA_SET_ATTRIBUTES** structure. The output buffers returned through the *lpOutBuffer* parameter start with a [DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT](ns-winioctl-device_manage_data_set_attributes.md) structure but then can contain additional data depending on the value of the **Action** member of the **DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT** structure pointed to by the *lpOutBuffer* parameter. These values are one of the values for the [DEVICE_DATA_MANAGEMENT_SET_ACTION](https://docs.microsoft.com/windows/desktop/DevIO/device-data-management-set-action) data type.
 
-Use the 
-    <b>IOCTL_STORAGE_MANAGE_DATA_SET_ATTRIBUTES</b> 
-    control code for sending storage system-specific information to the volume manager and storage system.
-
-The input buffers passed through the <i>lpInBuffer</i> parameter start with a 
-     <a href="/windows/win32/api/winioctl/ns-winioctl-device_manage_data_set_attributes">DEVICE_MANAGE_DATA_SET_ATTRIBUTES</a> 
-     structure but may contain additional parameters before the list of data set ranges depending on the value of the 
-     <b>Action</b> member of the 
-     <b>DEVICE_MANAGE_DATA_SET_ATTRIBUTES</b> 
-     structure. The output buffers returned 
-     through the <i>lpOutBuffer</i> parameter start with a 
-     <a href="/windows/win32/api/winioctl/ns-winioctl-device_manage_data_set_attributes">DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT</a> 
-     structure but then can contain additional data depending on the value of the <b>Action</b> 
-     member of the 
-     <b>DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT</b> 
-     structure pointed to by the <i>lpOutBuffer</i> parameter. These values are one of the values 
-     for the 
-     <a href="https://docs.microsoft.com/windows/desktop/DevIO/device-data-management-set-action">DEVICE_DATA_MANAGEMENT_SET_ACTION</a> data 
-     type.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Parameters structure</th>
-<th>Output block structure</th>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Trim</b></td>
-<td>None</td>
-<td>None</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Notification</b></td>
-<td>
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_dsm_notification_parameters">DEVICE_DSM_NOTIFICATION_PARAMETERS</a>
-</td>
-<td>None</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_OffloadRead</b></td>
-<td>
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_dsm_offload_read_parameters">DEVICE_DSM_OFFLOAD_READ_PARAMETERS</a>
-</td>
-<td>
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_offload_read_output">STORAGE_OFFLOAD_READ_OUTPUT</a>
-</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_OffloadWrite</b></td>
-<td>
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_dsm_offload_write_parameters">DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS</a>
-</td>
-<td>
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_offload_write_output">STORAGE_OFFLOAD_WRITE_OUTPUT</a>
-</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Allocation</b></td>
-<td>None</td>
-<td>
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_data_set_lb_provisioning_state">DEVICE_DATA_SET_LB_PROVISIONING_STATE</a>
-</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Repair</b></td>
-<td>
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_data_set_repair_parameters">DEVICE_DATA_SET_REPAIR_PARAMETERS</a>
-</td>
-<td>None</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Scrub</b></td>
-<td>None</td>
-<td>None</td>
-</tr>
-<tr>
-<td><b>DeviceDsmAction_Resiliency</b></td>
-<td>None</td>
-<td>None</td>
-</tr>
-</table>
- 
-
-
+Value | Parameters structure | Output block structure
+------|----------------------|-----------------------
+**DeviceDsmAction_Trim** | None | None
+**DeviceDsmAction_Notification** | [DEVICE_DSM_NOTIFICATION_PARAMETERS](ns-winioctl-device_dsm_notification_parameters.md) | None
+**DeviceDsmAction_OffloadRead** | [DEVICE_DSM_OFFLOAD_READ_PARAMETERS](ns-winioctl-device_dsm_offload_read_parameters.md) | [STORAGE_OFFLOAD_READ_OUTPUT](ns-winioctl-storage_offload_read_output.md)
+**DeviceDsmAction_OffloadWrite** | [DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS](ns-winioctl-device_dsm_offload_write_parameters.md) | [STORAGE_OFFLOAD_WRITE_OUTPUT](ns-winioctl-storage_offload_write_output.md)
+**DeviceDsmAction_Allocation** | None | [DEVICE_DATA_SET_LB_PROVISIONING_STATE](ns-winioctl-device_data_set_lb_provisioning_state.md)
+**DeviceDsmAction_Repair** | [DEVICE_DATA_SET_REPAIR_PARAMETERS](ns-winioctl-device_data_set_repair_parameters.md) | None
+**DeviceDsmAction_Scrub** | None | None
+**DeviceDsmAction_Resiliency** | None | None
 
 
 ## -see-also
 
-
-
-
-<a href="/windows/win32/api/winioctl/ns-winioctl-device_manage_data_set_attributes">DEVICE_MANAGE_DATA_SET_ATTRIBUTES</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [DEVICE_MANAGE_DATA_SET_ATTRIBUTES](ns-winioctl-device_manage_data_set_attributes.md)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_mcn_control.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_mcn_control.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_MCN_CONTROL
 title: IOCTL_STORAGE_MCN_CONTROL
-description: Enables or disables media change notification. Disabling media change notification prevents the GUID_IO_MEDIA_ARRIVAL and GUID_IO_MEDIA_REMOVAL events.helpviewer_keywords: ["IOCTL_STORAGE_MCN_CONTROL","IOCTL_STORAGE_MCN_CONTROL control","IOCTL_STORAGE_MCN_CONTROL control code","_win32_ioctl_storage_mcn_control","base.ioctl_storage_mcn_control","winioctl/IOCTL_STORAGE_MCN_CONTROL"]
+description: Enables or disables media change notification. Disabling media change notification prevents the GUID_IO_MEDIA_ARRIVAL and GUID_IO_MEDIA_REMOVAL events.
+helpviewer_keywords: ["IOCTL_STORAGE_MCN_CONTROL","IOCTL_STORAGE_MCN_CONTROL control","IOCTL_STORAGE_MCN_CONTROL control code","_win32_ioctl_storage_mcn_control","base.ioctl_storage_mcn_control","winioctl/IOCTL_STORAGE_MCN_CONTROL"]
 old-location: base\ioctl_storage_mcn_control.htm
 tech.root: devio
 ms.assetid: 1122f27f-c1a6-49a9-b09a-5b33c451e1cc
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_MCN_CONTROL IOCTL
 
-
 ## -description
 
+Enables or disables media change notification. Disabling media change notification prevents the **GUID_IO_MEDIA_ARRIVAL** and **GUID_IO_MEDIA_REMOVAL** events.
 
-Enables or disables media change notification. Disabling media change notification prevents the <b>GUID_IO_MEDIA_ARRIVAL</b> and <b>GUID_IO_MEDIA_REMOVAL</b> events.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_STORAGE_MCN_CONTROL,   // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer
-  (DWORD) nInBufferSize,       // size of input buffer
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_MCN_CONTROL,    // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer
+  (DWORD) nInBufferSize,        // size of input buffer
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,19 +94,7 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_media_removal.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_media_removal.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_MEDIA_REMOVAL
 title: IOCTL_STORAGE_MEDIA_REMOVAL
-description: Enables or disables the mechanism that ejects media, for those devices possessing that locking capability.helpviewer_keywords: ["IOCTL_STORAGE_MEDIA_REMOVAL","IOCTL_STORAGE_MEDIA_REMOVAL control","IOCTL_STORAGE_MEDIA_REMOVAL control code","_win32_ioctl_storage_media_removal","base.ioctl_storage_media_removal","winioctl/IOCTL_STORAGE_MEDIA_REMOVAL"]
+description: Enables or disables the mechanism that ejects media, for those devices possessing that locking capability.
+helpviewer_keywords: ["IOCTL_STORAGE_MEDIA_REMOVAL","IOCTL_STORAGE_MEDIA_REMOVAL control","IOCTL_STORAGE_MEDIA_REMOVAL control code","_win32_ioctl_storage_media_removal","base.ioctl_storage_media_removal","winioctl/IOCTL_STORAGE_MEDIA_REMOVAL"]
 old-location: base\ioctl_storage_media_removal.htm
 tech.root: devio
 ms.assetid: 5971daa1-3bb7-4050-b252-2f5cabb1bf67
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_MEDIA_REMOVAL IOCTL
 
-
 ## -description
-
 
 Enables or disables the mechanism that ejects media, for those devices possessing that locking capability.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_STORAGE_MEDIA_REMOVAL, // dwIoControlCode(LPVOID) lpInBuffer,         // input buffer 
-  (DWORD) nInBufferSize,       // size of input buffer 
-  NULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_MEDIA_REMOVAL,  // dwIoControlCode
+  (LPVOID) lpInBuffer,          // input buffer 
+  (DWORD) nInBufferSize,        // size of input buffer 
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,41 +94,15 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The 
-<b>IOCTL_STORAGE_MEDIA_REMOVAL</b> control code is valid only for devices that support removable media.
-
-
+The **IOCTL_STORAGE_MEDIA_REMOVAL** control code is valid only for devices that support removable media.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_eject_media">IOCTL_STORAGE_EJECT_MEDIA</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_load_media">IOCTL_STORAGE_LOAD_MEDIA</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-prevent_media_removal">PREVENT_MEDIA_REMOVAL</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_EJECT_MEDIA](ni-winioctl-ioctl_storage_eject_media.md)
+* [IOCTL_STORAGE_LOAD_MEDIA](ni-winioctl-ioctl_storage_load_media.md)
+* [PREVENT_MEDIA_REMOVAL](ns-winioctl-prevent_media_removal.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_protocol_command.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_protocol_command.md
@@ -45,97 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_PROTOCOL_COMMAND IOCTL
 
-
 ## -description
 
-Windows applications can use <b>IOCTL_STORAGE_PROTOCOL_COMMAND</b> to conduct pass-through of protocol specific commands to the storage device or adapter. The request indicates the bus specific command which is further sent to a specific type of device to process. For more information, see the page on <a href="/windows/win32/fileio/working-with-nvme-devices#using-ioctl_storage_protocol_command-to-send-commands">working with NVMe drives</a>.
+Windows applications can use **IOCTL_STORAGE_PROTOCOL_COMMAND** to conduct pass-through of protocol specific commands to the storage device or adapter. The request indicates the bus specific command which is further sent to a specific type of device to process. For more information, see the page on [working with NVMe drives](/windows/win32/fileio/working-with-nvme-devices#using-ioctl_storage_protocol_command-to-send-commands).
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>
-BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_PROTOCOL_COMMAND, // dwIoControlCode
-                    (LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure
-</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_PROTOCOL_COMMAND,   // dwIoControlCode
+  (LPDWORD) lpInBuffer,             // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  (LPDWORD) lpOutBuffer,            // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -144,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ne-winioctl-storage_property_id">STORAGE_PROPERTY_ID</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_property_query">STORAGE_PROPERTY_QUERY</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [STORAGE_PROPERTY_ID](ne-winioctl-storage_property_id.md)
+* [STORAGE_PROPERTY_QUERY](ns-winioctl-storage_property_query.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_query_property.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_query_property.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_QUERY_PROPERTY
 title: IOCTL_STORAGE_QUERY_PROPERTY
-description: Windows applications can use this control code to return the properties of a storage device or adapter.helpviewer_keywords: ["IOCTL_STORAGE_QUERY_PROPERTY","IOCTL_STORAGE_QUERY_PROPERTY control","IOCTL_STORAGE_QUERY_PROPERTY control code [Files]","fs.ioctl_storage_query_property","winioctl/IOCTL_STORAGE_QUERY_PROPERTY"]
+description: Windows applications can use this control code to return the properties of a storage device or adapter.
+helpviewer_keywords: ["IOCTL_STORAGE_QUERY_PROPERTY","IOCTL_STORAGE_QUERY_PROPERTY control","IOCTL_STORAGE_QUERY_PROPERTY control code [Files]","fs.ioctl_storage_query_property","winioctl/IOCTL_STORAGE_QUERY_PROPERTY"]
 old-location: fs\ioctl_storage_query_property.htm
 tech.root: FileIO
 ms.assetid: 6755dcd4-e4a0-423f-9dcc-b9719c8e5c88
@@ -44,98 +45,46 @@ req.redist:
 
 # IOCTL_STORAGE_QUERY_PROPERTY IOCTL
 
-
 ## -description
 
+Windows applications can use this control code to return the properties of a storage device or adapter. The request indicates the kind of information to retrieve, such as the inquiry data for a device or the capabilities and limitations of an adapter. **IOCTL_STORAGE_QUERY_PROPERTY** can also be used to determine whether the port driver supports a particular property or which fields in the property descriptor can be modified with a subsequent change-property request.
 
-Windows applications can use this control code to return the properties of a storage device or adapter. The request indicates the kind of information 
-    to retrieve, such as the inquiry data for a device or the capabilities and limitations of an adapter. 
-    <b>IOCTL_STORAGE_QUERY_PROPERTY</b> can also be used 
-    to determine whether the port driver supports a particular property or which fields in the property descriptor can 
-    be modified with a subsequent change-property request.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl(
-     _In_        (HANDLE)       hDevice,               // handle to a partition
-     _In_        (DWORD) IOCTL_STORAGE_QUERY_PROPERTY, // dwIoControlCode
-     _In_        (LPVOID)       lpInBuffer,            // input buffer - STORAGE_PROPERTY_QUERY structure
-     _In_        (DWORD)        nInBufferSize,         // size of input buffer
-     _Out_opt_   (LPVOID)       lpOutBuffer,           // output buffer - see Remarks
-     _In_        (DWORD)        nOutBufferSize,        // size of output buffer
-     _Out_opt_   (LPDWORD)      lpBytesReturned,       // number of bytes returned
-     _Inout_opt_ (LPOVERLAPPED) lpOverlapped );        // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+
+```cpp
+BOOL DeviceIoControl(
+     _In_        (HANDLE)       hDevice,                // handle to a partition
+     _In_        (DWORD) IOCTL_STORAGE_QUERY_PROPERTY,  // dwIoControlCode
+     _In_        (LPVOID)       lpInBuffer,             // input buffer - STORAGE_PROPERTY_QUERY structure
+     _In_        (DWORD)        nInBufferSize,          // size of input buffer
+     _Out_opt_   (LPVOID)       lpOutBuffer,            // output buffer - see Remarks
+     _In_        (DWORD)        nOutBufferSize,         // size of output buffer
+     _Out_opt_   (LPDWORD)      lpBytesReturned,        // number of bytes returned
+     _Inout_opt_ (LPOVERLAPPED) lpOverlapped            // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -144,39 +93,13 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-The optional output buffer returned through the <i>lpOutBuffer</i> parameter can be one of 
-     several structures depending on the value of the <b>PropertyId</b> member of the 
-     <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_property_query">STORAGE_PROPERTY_QUERY</a> structure pointed to by the 
-     <i>lpInBuffer</i> parameter. These values are enumerated by the 
-     <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ne-winioctl-storage_property_id">STORAGE_PROPERTY_ID</a> enumeration. If the 
-     <b>QueryType</b> member of the 
-     <b>STORAGE_PROPERTY_QUERY</b> is set to 
-     <b>PropertyExistsQuery</b> then no structure is returned.
-
-
+The optional output buffer returned through the *lpOutBuffer* parameter can be one of several structures depending on the value of the **PropertyId** member of the [STORAGE_PROPERTY_QUERY](ns-winioctl-storage_property_query.md) structure pointed to by the *lpInBuffer* parameter. These values are enumerated by the [STORAGE_PROPERTY_ID](ne-winioctl-storage_property_id.md) enumeration. If the **QueryType** member of the **STORAGE_PROPERTY_QUERY** is set to **PropertyExistsQuery** then no structure is returned.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes">Disk Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_descriptor_header">STORAGE_DESCRIPTOR_HEADER</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_property_query">STORAGE_PROPERTY_QUERY</a>
- 
-
- 
-
+* [Disk Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/disk-management-control-codes)
+* [STORAGE_DESCRIPTOR_HEADER](ns-winioctl-storage_descriptor_header.md)
+* [STORAGE_PROPERTY_QUERY](ns-winioctl-storage_property_query.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_read_capacity.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_read_capacity.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_READ_CAPACITY
 title: IOCTL_STORAGE_READ_CAPACITY
-description: Retrieves the geometry information for the device.helpviewer_keywords: ["IOCTL_STORAGE_READ_CAPACITY","IOCTL_STORAGE_READ_CAPACITY control","IOCTL_STORAGE_READ_CAPACITY control code","base.ioctl_storage_read_capacity","winioctl/IOCTL_STORAGE_READ_CAPACITY"]
+description: Retrieves the geometry information for the device.
+helpviewer_keywords: ["IOCTL_STORAGE_READ_CAPACITY","IOCTL_STORAGE_READ_CAPACITY control","IOCTL_STORAGE_READ_CAPACITY control code","base.ioctl_storage_read_capacity","winioctl/IOCTL_STORAGE_READ_CAPACITY"]
 old-location: base\ioctl_storage_read_capacity.htm
 tech.root: devio
 ms.assetid: c0a2c73c-fae9-40e9-8009-4dffbb03a01d
@@ -44,93 +45,47 @@ req.redist:
 
 # IOCTL_STORAGE_READ_CAPACITY IOCTL
 
-
 ## -description
-
 
 Retrieves the geometry information for the device.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-    function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
- (HANDLE) hDevice,            // handle to device 
- IOCTL_STORAGE_READ_CAPACITY, // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSize(LPVOID) lpOutBuffer,        // output buffer 
- (DWORD) nOutBufferSize,      // size of output buffer 
- (LPDWORD) lpBytesReturned,   // number of bytes returned 
- (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure 
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_STORAGE_READ_CAPACITY,  // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  (LPVOID) lpOutBuffer,         // output buffer
+  (DWORD) nOutBufferSize,       // size of output buffer
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure 
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,23 +94,8 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/storage-read-capacity">STORAGE_READ_CAPACITY</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [STORAGE_READ_CAPACITY](https://docs.microsoft.com/windows/desktop/DevIO/storage-read-capacity)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_set_hotplug_info.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_set_hotplug_info.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_SET_HOTPLUG_INFO
 title: IOCTL_STORAGE_SET_HOTPLUG_INFO
-description: Sets the hotplug configuration of the specified device.helpviewer_keywords: ["IOCTL_STORAGE_SET_HOTPLUG_INFO","IOCTL_STORAGE_SET_HOTPLUG_INFO control","IOCTL_STORAGE_SET_HOTPLUG_INFO control code","_win32_ioctl_storage_set_hotplug_info","base.ioctl_storage_set_hotplug_info","winioctl/IOCTL_STORAGE_SET_HOTPLUG_INFO"]
+description: Sets the hotplug configuration of the specified device.
+helpviewer_keywords: ["IOCTL_STORAGE_SET_HOTPLUG_INFO","IOCTL_STORAGE_SET_HOTPLUG_INFO control","IOCTL_STORAGE_SET_HOTPLUG_INFO control code","_win32_ioctl_storage_set_hotplug_info","base.ioctl_storage_set_hotplug_info","winioctl/IOCTL_STORAGE_SET_HOTPLUG_INFO"]
 old-location: base\ioctl_storage_set_hotplug_info.htm
 tech.root: devio
 ms.assetid: f15c183d-d883-470c-9b78-e63d2a9b76ca
@@ -44,93 +45,48 @@ req.redist:
 
 # IOCTL_STORAGE_SET_HOTPLUG_INFO IOCTL
 
-
 ## -description
-
 
 Sets the hotplug configuration of the specified device.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,                // handle to device
-  IOCTL_STORAGE_SET_HOTPLUG_INFO,  // dwIoControlCode(LPVOID) lpInBuffer,             // input buffer
-  (DWORD) nInBufferSize,           // size of input buffer
-  NULL,                            // lpOutBuffer0,                               // nOutBufferSize(LPDWORD) lpBytesReturned,       // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped      // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to device
+  IOCTL_STORAGE_SET_HOTPLUG_INFO,   // dwIoControlCode
+  (LPVOID) lpInBuffer,              // input buffer
+  (DWORD) nInBufferSize,            // size of input buffer
+  NULL,                             // lpOutBuffer
+  0,                                // nOutBufferSize
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -139,40 +95,16 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+Refer to the Remarks section in the reference page for [STORAGE_HOTPLUG_INFO](ns-winioctl-storage_hotplug_info.md) for more information about hotplug devices.
 
-
-Refer to the Remarks section in the reference page for 
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hotplug_info">STORAGE_HOTPLUG_INFO</a> for more information about hotplug devices.
-
-This operation sets only the <b>DeviceHotplug</b> member of the 
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hotplug_info">STORAGE_HOTPLUG_INFO</a> structure passed in.
-
-
+This operation sets only the **DeviceHotplug** member of the [STORAGE_HOTPLUG_INFO](ns-winioctl-storage_hotplug_info.md) structure passed in.
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes">Device Management Control Codes</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_get_hotplug_info">IOCTL_STORAGE_GET_HOTPLUG_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_hotplug_info">STORAGE_HOTPLUG_INFO</a>
- 
-
- 
-
+* [Device Management Control Codes](https://docs.microsoft.com/windows/desktop/DevIO/device-management-control-codes)
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_GET_HOTPLUG_INFO](ni-winioctl-ioctl_storage_get_hotplug_info.md)
+* [STORAGE_HOTPLUG_INFO](ns-winioctl-storage_hotplug_info.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_set_temperature_threshold.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_storage_set_temperature_threshold.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD
 title: IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD
-description: Windows applications can use this control code to set the temperature threshold of a device (when it's supported by the device).helpviewer_keywords: ["IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD","IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD control","IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD control code [Files]","fs.ioctl_storage_set_temperature_threshold","winioctl/IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD"]
+description: Windows applications can use this control code to set the temperature threshold of a device (when it's supported by the device).
+helpviewer_keywords: ["IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD","IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD control","IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD control code [Files]","fs.ioctl_storage_set_temperature_threshold","winioctl/IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD"]
 old-location: fs\ioctl_storage_set_temperature_threshold.htm
 tech.root: FileIO
 ms.assetid: 6B4BF202-6CC9-4571-9078-019984805F00
@@ -44,95 +45,46 @@ req.redist:
 
 # IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD IOCTL
 
-
 ## -description
 
+Windows applications can use this control code to set the temperature threshold of a device (when it's supported by the device).  Use [IOCTL_STORAGE_QUERY_PROPERTY](ni-winioctl-ioctl_storage_query_property.md) to determine if the device supports changing the over and under temperature thresholds.
 
-Windows applications can use this control code to set the temperature threshold of a device (when it's supported by the device).  Use <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_query_property">IOCTL_STORAGE_QUERY_PROPERTY</a> to determine if the device supports changing the over and under temperature thresholds.
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-   WINAPI 
-   DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                    (DWORD)        IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD, // dwIoControlCode(LPDWORD)      lpInBuffer,      // input buffer
-                    (DWORD)        nInBufferSize,   // size of input buffer
-                    (LPDWORD)      lpOutBuffer,     // output buffer
-                    (DWORD)        nOutBufferSize,  // size of output buffer
-                    (LPDWORD)      lpBytesReturned, // number of bytes returned
-                    (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>
-</td>
-</tr>
-</table></span></div>
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                         // handle to device
+  IOCTL_STORAGE_SET_TEMPERATURE_THRESHOLD,  // dwIoControlCode
+  (LPDWORD) lpInBuffer,                     // input buffer
+  (DWORD) nInBufferSize,                    // size of input buffer
+  (LPDWORD) lpOutBuffer,                    // output buffer
+  (DWORD) nOutBufferSize,                   // size of output buffer
+  (LPDWORD) lpBytesReturned,                // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped               // OVERLAPPED structure
+);
+```
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,35 +93,11 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_storage_query_property">IOCTL_STORAGE_QUERY_PROPERTY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ne-winioctl-storage_property_id">STORAGE_PROPERTY_ID</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_property_query">STORAGE_PROPERTY_QUERY</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_temperature_info">STORAGE_TEMPERATURE_INFO</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-storage_temperature_threshold">STORAGE_TEMPERATURE_THRESHOLD</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_STORAGE_QUERY_PROPERTY](ni-winioctl-ioctl_storage_query_property.md)
+* [STORAGE_PROPERTY_ID](ne-winioctl-storage_property_id.md)
+* [STORAGE_PROPERTY_QUERY](ns-winioctl-storage_property_query.md)
+* [STORAGE_TEMPERATURE_INFO](ns-winioctl-storage_temperature_info.md)
+* [STORAGE_TEMPERATURE_THRESHOLD](ns-winioctl-storage_temperature_threshold.md)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_get_gpt_attributes.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_get_gpt_attributes.md
@@ -45,94 +45,47 @@ req.redist:
 
 # IOCTL_VOLUME_GET_GPT_ATTRIBUTES IOCTL
 
-
 ## -description
-
 
 Retrieves the attributes for a volume.
 
-To perform this operation, call the 
-   <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,           // handle to the volume device
-  IOCTL_VOLUME_GET_GPT_ATTRIBUTES, // dwIoControlCodeNULL,                       // lpInBuffer0,                          // nInBufferSize(LPVOID) lpOutBuffer,       // output buffer
-  (DWORD) nOutBufferSize,     // size of output buffer
-  (LPDWORD) lpBytesReturned,  // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                 // handle to the volume device
+  IOCTL_VOLUME_GET_GPT_ATTRIBUTES,  // dwIoControlCode
+  NULL,                             // lpInBuffer
+  0,                                // nInBufferSize
+  (LPVOID) lpOutBuffer,             // output buffer
+  (DWORD) nOutBufferSize,           // size of output buffer
+  (LPDWORD) lpBytesReturned,        // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped       // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -141,80 +94,20 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-Yes
-
-</td>
-</tr>
-</table>
- 
-
-
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | No
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | Yes
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="/windows/win32/api/winioctl/ns-winioctl-volume_get_gpt_attributes_information">VOLUME_GET_GPT_ATTRIBUTES_INFORMATION</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes">Volume Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [VOLUME_GET_GPT_ATTRIBUTES_INFORMATION](ns-winioctl-volume_get_gpt_attributes_information.md)
+* [Volume Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_get_volume_disk_extents.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_get_volume_disk_extents.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS
 title: IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS
-description: Retrieves the physical location of a specified volume on one or more disks.helpviewer_keywords: ["IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS","IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS control","IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS control code [Files]","_win32_ioctl_volume_get_volume_disk_extents","base.ioctl_volume_get_volume_disk_extents","fs.ioctl_volume_get_volume_disk_extents","winioctl/IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS"]
+description: Retrieves the physical location of a specified volume on one or more disks.
+helpviewer_keywords: ["IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS","IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS control","IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS control code [Files]","_win32_ioctl_volume_get_volume_disk_extents","base.ioctl_volume_get_volume_disk_extents","fs.ioctl_volume_get_volume_disk_extents","winioctl/IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS"]
 old-location: fs\ioctl_volume_get_volume_disk_extents.htm
 tech.root: FileIO
 ms.assetid: 8faff037-d815-48f8-8b59-d63f4ff4a746
@@ -44,94 +45,47 @@ req.redist:
 
 # IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS IOCTL
 
-
 ## -description
-
 
 Retrieves the physical location of a specified volume on one or more disks.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL 
-WINAPI 
-DeviceIoControl( (HANDLE) hDevice,                     // handle to device
-                 IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS, // dwIoControlCodeNULL,                                 // lpInBuffer0,                                    // nInBufferSize(LPVOID) lpOutBuffer,                 // output buffer
-                 (DWORD) nOutBufferSize,               // size of output buffer
-                 (LPDWORD) lpBytesReturned,            // number of bytes returned
-                 (LPOVERLAPPED) lpOverlapped           // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,                     // handle to device
+  IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS, // dwIoControlCode
+  NULL,                                 // lpInBuffer
+  0,                                    // nInBufferSize
+  (LPVOID) lpOutBuffer,                 // output buffer
+  (DWORD) nOutBufferSize,               // size of output buffer
+  (LPDWORD) lpBytesReturned,            // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped           // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,80 +94,20 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
-
-
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-Yes
-
-</td>
-</tr>
-</table>
- 
-
-
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | No
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | Yes
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-volume_disk_extents">VOLUME_DISK_EXTENTS</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes">Volume Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [VOLUME_DISK_EXTENTS](ns-winioctl-volume_disk_extents.md)
+* [Volume Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_is_clustered.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_is_clustered.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_VOLUME_IS_CLUSTERED
 title: IOCTL_VOLUME_IS_CLUSTERED
-description: Determines whether the specified volume is clustered.helpviewer_keywords: ["IOCTL_VOLUME_IS_CLUSTERED","IOCTL_VOLUME_IS_CLUSTERED control","IOCTL_VOLUME_IS_CLUSTERED control code [Files]","_win32_ioctl_volume_is_clustered","base.ioctl_volume_is_clustered","fs.ioctl_volume_is_clustered","winioctl/IOCTL_VOLUME_IS_CLUSTERED"]
+description: Determines whether the specified volume is clustered.
+helpviewer_keywords: ["IOCTL_VOLUME_IS_CLUSTERED","IOCTL_VOLUME_IS_CLUSTERED control","IOCTL_VOLUME_IS_CLUSTERED control code [Files]","_win32_ioctl_volume_is_clustered","base.ioctl_volume_is_clustered","fs.ioctl_volume_is_clustered","winioctl/IOCTL_VOLUME_IS_CLUSTERED"]
 old-location: fs\ioctl_volume_is_clustered.htm
 tech.root: FileIO
 ms.assetid: 3722b08c-237d-4551-b75e-1d28fe8e94c3
@@ -44,91 +45,47 @@ req.redist:
 
 # IOCTL_VOLUME_IS_CLUSTERED IOCTL
 
-
 ## -description
-
 
 Determines whether the specified volume is clustered.
 
-To perform this operation, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
-  (HANDLE) hDevice,            // handle to device
-  IOCTL_VOLUME_IS_CLUSTERED,   // dwIoControlCodeNULL,                        // lpInBuffer0,                           // nInBufferSizeNULL,                        // lpOutBuffer0,                           // nOutBufferSize(LPDWORD) lpBytesReturned,   // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped  // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
+  (HANDLE) hDevice,             // handle to device
+  IOCTL_VOLUME_IS_CLUSTERED,    // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -137,91 +94,28 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
+The **IOCTL_VOLUME_IS_CLUSTERED** control code is valid only if the Cluster service is running.
 
+The **ERROR_GEN_FAILURE** error indicates that the computer that currently owns the disk on which the volume resides is a server cluster node, but either the disk is a Physical Disk resource currently in an offline state or the disk is not a Physical Disk resource. To determine which of these situations exists, use the following steps:
 
-The 
-<b>IOCTL_VOLUME_IS_CLUSTERED</b> control code is valid only if the Cluster service is running.
+1. Call the [ClusterEnum](../clusapi/nf-clusapi-clusterenum.md) function to enumerate all Physical Disk resources in the cluster.
+1. Search each enumerated Physical Disk resource for the volume by calling the [ClusterResourceControl](../clusapi/nf-clusapi-clusterresourcecontrol) function with [CLUSCTL_RESOURCE_STORAGE_GET_DISK_INFO](https://docs.microsoft.com/previous-versions/windows/desktop/mscs/clusctl-resource-storage-get-disk-info). If you cannot find the volume among the Physical Disk resources in the cluster, the volume does not reside on a Physical Disk resource.
 
-The <b>ERROR_GEN_FAILURE</b> error indicates that the computer that currently owns the disk on which the volume resides is a server cluster node, but either the disk is a Physical Disk resource currently in an offline state or the disk is not a Physical Disk resource. To determine which of these situations exists, use the following steps:
-
-<ol>
-<li>Call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/clusapi/nf-clusapi-clusterenum">ClusterEnum</a> function to enumerate all Physical Disk resources in the cluster.</li>
-<li>Search each enumerated Physical Disk resource for the volume by calling the 
-<a href="https://docs.microsoft.com/previous-versions/windows/desktop/api/clusapi/nf-clusapi-clusterresourcecontrol">ClusterResourceControl</a> function with <a href="https://docs.microsoft.com/previous-versions/windows/desktop/mscs/clusctl-resource-storage-get-disk-info">CLUSCTL_RESOURCE_STORAGE_GET_DISK_INFO</a>. If you cannot find the volume among the Physical Disk resources in the cluster, the volume does not reside on a Physical Disk resource.</li>
-</ol>
-The <b>ERROR_INVALID_FUNCTION</b> error indicates that the computer that currently owns the disk on which the volume resides is not a server cluster node or the disk is not a Physical Disk resource. To determine whether a computer is a server cluster node, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/clusapi/nf-clusapi-getnodeclusterstate">GetNodeClusterState</a> function.
+The **ERROR_INVALID_FUNCTION** error indicates that the computer that currently owns the disk on which the volume resides is not a server cluster node or the disk is not a Physical Disk resource. To determine whether a computer is a server cluster node, call the [GetNodeClusterState](../clusapi/nf-clusapi-getnodeclusterstate.md) function.
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-Yes
-
-</td>
-</tr>
-</table>
- 
-
-
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | No
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | Yes
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes">Volume
-		  Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [Volume Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_offline.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_offline.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_VOLUME_OFFLINE
 title: IOCTL_VOLUME_OFFLINE
-description: Takes a volume offline.helpviewer_keywords: ["IOCTL_VOLUME_OFFLINE","IOCTL_VOLUME_OFFLINE control","IOCTL_VOLUME_OFFLINE control code [Files]","fs.ioctl_volume_offline","winioctl/IOCTL_VOLUME_OFFLINE"]
+description: Takes a volume offline.
+helpviewer_keywords: ["IOCTL_VOLUME_OFFLINE","IOCTL_VOLUME_OFFLINE control","IOCTL_VOLUME_OFFLINE control code [Files]","fs.ioctl_volume_offline","winioctl/IOCTL_VOLUME_OFFLINE"]
 old-location: fs\ioctl_volume_offline.htm
 tech.root: FileIO
 ms.assetid: 7c9b97eb-c167-41cd-b235-7a9d7830915e
@@ -44,23 +45,16 @@ req.redist:
 
 # IOCTL_VOLUME_OFFLINE IOCTL
 
-
 ## -description
-
 
 Takes a volume offline.
 
-<b>Windows Server 2003 and Windows XP:  </b>This control code is not supported for dynamic disks.
+**Windows Server 2003 and Windows XP:**  This control code is not supported for dynamic disks.
 
-To perform this operation, call the <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-    function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
   IOCTL_VOLUME_OFFLINE,         // dwIoControlCode
   NULL,                         // lpInBuffer
@@ -68,74 +62,32 @@ To perform this operation, call the <a href="https://docs.microsoft.com/windows/
   NULL,                         // lpOutBuffer 
   0,                            // nOutBufferSize
   (LPDWORD) lpBytesReturned,    // number of bytes returned
-  (LPOVERLAPPED) lpOverlapped); // OVERLAPPED structure
-</pre>
-</td>
-</tr>
-</table></span></div>
+  (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -144,93 +96,30 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-Applications must first successfully dismount the file system - via <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-fsctl_dismount_volume">FSCTL_DISMOUNT_VOLUME</a> - before using <b>IOCTL_VOLUME_OFFLINE</b>.
+Applications must first successfully dismount the file system - via [FSCTL_DISMOUNT_VOLUME](ni-winioctl-fsctl_dismount_volume.md) - before using **IOCTL_VOLUME_OFFLINE**.
 
 When a volume that is online is dismounted, the next call to open the volume causes it to be mounted.  Taking the volume offline using the same volume handle as was used for the dismount prevents the dismounted volume from being mounted again.
 
 When a volume is online, all requests sent to the volume are honored.
 
-When a volume that is online 
-    is dismounted, the next call to open the volume causes it to be mounted. Taking the volume offline prevents the 
-    dismounted volume from being mounted again.
+When a volume that is online is dismounted, the next call to open the volume causes it to be mounted. Taking the volume offline prevents the dismounted volume from being mounted again.
 
-To bring a volume online, use the 
-    <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_volume_online">IOCTL_VOLUME_ONLINE</a> control code.
+To bring a volume online, use the [IOCTL_VOLUME_ONLINE](ni-winioctl-ioctl_volume_online.md) control code.
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-</table>
- 
-
-
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | No
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | No
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_volume_online">IOCTL_VOLUME_ONLINE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes">Volume Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_VOLUME_ONLINE](ni-winioctl-ioctl_volume_online.md)
+* [Volume Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes)

--- a/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_online.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-ioctl_volume_online.md
@@ -1,7 +1,8 @@
 ---
 UID: NI:winioctl.IOCTL_VOLUME_ONLINE
 title: IOCTL_VOLUME_ONLINE
-description: Brings a volume online.helpviewer_keywords: ["IOCTL_VOLUME_ONLINE","IOCTL_VOLUME_ONLINE control","IOCTL_VOLUME_ONLINE control code [Files]","fs.ioctl_volume_online","winioctl/IOCTL_VOLUME_ONLINE"]
+description: Brings a volume online.
+helpviewer_keywords: ["IOCTL_VOLUME_ONLINE","IOCTL_VOLUME_ONLINE control","IOCTL_VOLUME_ONLINE control code [Files]","fs.ioctl_volume_online","winioctl/IOCTL_VOLUME_ONLINE"]
 old-location: fs\ioctl_volume_online.htm
 tech.root: FileIO
 ms.assetid: fa857959-c10e-4c64-8249-4bbf44e15eb9
@@ -44,94 +45,49 @@ req.redist:
 
 # IOCTL_VOLUME_ONLINE IOCTL
 
-
 ## -description
-
 
 Brings a volume online.
 
-<b>Windows Server 2003 and Windows XP:  </b>This control code is not supported for dynamic disks.
+**Windows Server 2003 and Windows XP:**  This control code is not supported for dynamic disks.
 
-To perform this operation, call the 
-   <a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a> 
-   function with the following parameters.
-<div class="code"><span codelanguage="ManagedCPlusPlus"><table>
-<tr>
-<th>C++</th>
-</tr>
-<tr>
-<td>
-<pre>BOOL DeviceIoControl(
+To perform this operation, call the [**DeviceIoControl**](../ioapiset/nf-ioapiset-deviceiocontrol.md) function with the following parameters.
+
+```cpp
+BOOL DeviceIoControl(
   (HANDLE) hDevice,             // handle to device
-  IOCTL_VOLUME_ONLINE,          // dwIoControlCodeNULL,                         // lpInBuffer0,                            // nInBufferSizeNULL,                         // lpOutBuffer0,                            // nOutBufferSize(LPDWORD) lpBytesReturned,    // number of bytes returned
+  IOCTL_VOLUME_ONLINE,          // dwIoControlCode
+  NULL,                         // lpInBuffer
+  0,                            // nInBufferSize
+  NULL,                         // lpOutBuffer
+  0,                            // nOutBufferSize
+  (LPDWORD) lpBytesReturned,    // number of bytes returned
   (LPOVERLAPPED) lpOverlapped   // OVERLAPPED structure
-);</pre>
-</td>
-</tr>
-</table></span></div>
+);
+```
+
 
 ## -ioctlparameters
 
-
-
-
 ### -input-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -input-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -output-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -output-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -in-out-buffer
-
-
-
-<text></text>
-
-
 
 
 ### -inout-buffer-length
 
 
-
-<text></text>
-
-
-
-
 ### -status-block
-
-
 
 Irp->IoStatus.Status is set to STATUS_SUCCESS if the request is successful.
 
@@ -140,88 +96,28 @@ Otherwise, Status to the appropriate error condition as a NTSTATUS code.
 For more information, see [NTSTATUS Values](https://docs.microsoft.com/windows-hardware/drivers/kernel/ntstatus-values).
 
 
-
-
 ## -remarks
 
-
-
-When a volume is offline, all read, write, and IOCTL requests fail with <b>ERROR_NOT_READY</b>. You cannot take the system or boot volume offline.
+When a volume is offline, all read, write, and IOCTL requests fail with **ERROR_NOT_READY**. You cannot take the system or boot volume offline.
 
 When a volume is online, all requests sent to the volume are honored.
 
 When a volume that is online is dismounted, the next call to open the volume causes it to be mounted. Taking the volume offline prevents the dismounted volume from being mounted again.
 
-To take a volume offline, use the <a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_volume_offline">IOCTL_VOLUME_OFFLINE</a> control code.
+To take a volume offline, use the [IOCTL_VOLUME_OFFLINE](ni-winioctl-ioctl_volume_offline.md) control code.
 
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
-<table>
-<tr>
-<th>Technology</th>
-<th>Supported</th>
-</tr>
-<tr>
-<td>
-Server Message Block (SMB) 3.0 protocol
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 Transparent Failover (TFO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-SMB 3.0 with Scale-out File Shares (SO)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-<tr>
-<td>
-Cluster Shared Volume File System (CsvFS)
-
-</td>
-<td>
-No
-
-</td>
-</tr>
-</table>
- 
-
-
+Technology | Supported
+-----------|----------
+Server Message Block (SMB) 3.0 protocol | No
+SMB 3.0 Transparent Failover (TFO) | No
+SMB 3.0 with Scale-out File Shares (SO) | No
+Cluster Shared Volume File System (CsvFS) | No
 
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol">DeviceIoControl</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_volume_offline">IOCTL_VOLUME_OFFLINE</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes">Volume Management Control Codes</a>
- 
-
- 
-
+* [DeviceIoControl](../ioapiset/nf-ioapiset-deviceiocontrol.md)
+* [IOCTL_VOLUME_OFFLINE](ni-winioctl-ioctl_volume_offline.md)
+* [Volume Management Control Codes](https://docs.microsoft.com/windows/desktop/FileIO/volume-management-control-codes)

--- a/sdk-api-src/content/winioctl/ns-winioctl-disk_extent.md
+++ b/sdk-api-src/content/winioctl/ns-winioctl-disk_extent.md
@@ -45,25 +45,18 @@ req.redist:
 
 # DISK_EXTENT structure
 
-
 ## -description
-
 
 Represents a disk extent.
 
 
 ## -struct-fields
 
-
-
-
 ### -field DiskNumber
 
 The number of the disk that contains this extent.
 
-This is the same number that is used to construct the name of the disk, for example, the 
-       <i>X</i> in "\\?\PhysicalDrive<i>X</i>" 
-       or "\\?\Harddisk<i>X</i>".
+This is the same number that is used to construct the name of the disk, for example, the *X* in "\\\\?\\PhysicalDrive*X*" or "\\\\?\\\Harddisk*X*".
 
 
 ### -field StartingOffset
@@ -78,19 +71,6 @@ The number of bytes in this extent.
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ni-winioctl-ioctl_volume_get_volume_disk_extents">IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS</a>
-
-
-
-<a href="/windows/win32/api/winnt/ns-winnt-large_integer~r1">LARGE_INTEGER</a>
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/winioctl/ns-winioctl-volume_disk_extents">VOLUME_DISK_EXTENTS</a>
- 
-
- 
-
+* [IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS](ni-winioctl-ioctl_volume_get_volume_disk_extents.md)
+* [LARGE_INTEGER](/windows/win32/api/winnt/ns-winnt-large_integer~r1)
+* [VOLUME_DISK_EXTENTS](ns-winioctl-volume_disk_extents.md)


### PR DESCRIPTION
This is the second part of the edits I made in pull request #167 with merge conflicts resolved.  Part 1 has been merged in pull request #214.

I have made formatting edits, mostly changing from HTML to Markdown to make future edits easier. Also, I fixed sample code blocks, including ones that had issues with spacing, which made the code ambiguous and confusing.

@Karl-Bridge-Microsoft, thanks for all your help. This should be all of it.