### PR TITLE
Update ns-rectypes-lattice_metrics.md

### DIFF
--- a/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
+++ b/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
@@ -63,12 +63,12 @@ Describes the baseline and the midline height.
 
 ### -field lsBaseline
 
-The <a href="https://docs.microsoft.com/windows/desktop/api/rectypes/ns-rectypes-line_segment">LINE_SEGMENT</a> structure containing the start and end point of the baseline in ink coordinates.
+The <a href="https://docs.microsoft.com/windows/desktop/api/rectypes/ns-rectypes-line_segment">LINE_SEGMENT</a> structure containing the start and end point of the baseline, in ink coordinates.
 
 
 ### -field iMidlineOffset
 
-Offset of the midline from the basline in HIMETRIC units.
+Offset of the midline relative to the baseline, in HIMETRIC units.
 
 
 ## -see-also

--- a/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
+++ b/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
@@ -68,7 +68,7 @@ The <a href="https://docs.microsoft.com/windows/desktop/api/rectypes/ns-rectypes
 
 ### -field iMidlineOffset
 
-Offset of the midline relative to the baseline, in HIMETRIC units.
+Offset of the midline, relative to the baseline, in HIMETRIC units.
 
 
 ## -see-also

--- a/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
+++ b/sdk-api-src/content/rectypes/ns-rectypes-lattice_metrics.md
@@ -1,7 +1,8 @@
 ---
 UID: NS:rectypes.tagLATTICE_METRICS
 title: LATTICE_METRICS (rectypes.h)
-description: Describes the baseline and the midline height.helpviewer_keywords: ["4fdeaaf9-9026-4bf1-8e78-d03a98d44b32","LATTICE_METRICS","LATTICE_METRICS structure [Tablet PC]","rectypes/LATTICE_METRICS","tablet.lattice_metrics"]
+description: Describes the baseline and the midline height.
+helpviewer_keywords: ["4fdeaaf9-9026-4bf1-8e78-d03a98d44b32","LATTICE_METRICS","LATTICE_METRICS structure [Tablet PC]","rectypes/LATTICE_METRICS","tablet.lattice_metrics"]
 old-location: tablet\lattice_metrics.htm
 tech.root: tablet
 ms.assetid: 4fdeaaf9-9026-4bf1-8e78-d03a98d44b32
@@ -67,7 +68,7 @@ The <a href="https://docs.microsoft.com/windows/desktop/api/rectypes/ns-rectypes
 
 ### -field iMidlineOffset
 
-Height of the midline in HIMETRIC units.
+Offset of the midline from the basline in HIMETRIC units.
 
 
 ## -see-also


### PR DESCRIPTION
Changed the word `Height` to `Offset` as `Height` implies a nonnegative value, but this value can be negative as it is an offset.