### PR TITLE
SHFileOperation is not replaced by IFileOperation

### DIFF
--- a/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:shellapi.SHFileOperationW
 title: SHFileOperationW function (shellapi.h)
-description: Copies, moves, renames, or deletes a file system object. This function has a better alternative in Windows Vista by IFileOperation. New applications should use IFileOperation.
+description: Copies, moves, renames, or deletes a file system object. Starting in Windows Vista, this function has been superseded by IFileOperation.
 helpviewer_keywords: ["SHFileOperation","SHFileOperation function [Windows Shell]","SHFileOperationA","SHFileOperationW","_win32_SHFileOperation","shell.SHFileOperation","shellapi/SHFileOperation","shellapi/SHFileOperationA","shellapi/SHFileOperationW"]
 old-location: shell\SHFileOperation.htm
 tech.root: shell

--- a/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:shellapi.SHFileOperationW
 title: SHFileOperationW function (shellapi.h)
-description: Copies, moves, renames, or deletes a file system object. This function has been replaced in Windows Vista by IFileOperation.helpviewer_keywords: ["SHFileOperation","SHFileOperation function [Windows Shell]","SHFileOperationA","SHFileOperationW","_win32_SHFileOperation","shell.SHFileOperation","shellapi/SHFileOperation","shellapi/SHFileOperationA","shellapi/SHFileOperationW"]
+description: Copies, moves, renames, or deletes a file system object. This function has a better alternative in Windows Vista by IFileOperation. New applications should use IFileOperation.
+helpviewer_keywords: ["SHFileOperation","SHFileOperation function [Windows Shell]","SHFileOperationA","SHFileOperationW","_win32_SHFileOperation","shell.SHFileOperation","shellapi/SHFileOperation","shellapi/SHFileOperationA","shellapi/SHFileOperationW"]
 old-location: shell\SHFileOperation.htm
 tech.root: shell
 ms.assetid: 7807015f-52c5-46f5-9e90-4e3e60ddf705

--- a/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shfileoperationw.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:shellapi.SHFileOperationW
 title: SHFileOperationW function (shellapi.h)
-description: Copies, moves, renames, or deletes a file system object. Starting in Windows Vista, this function has been superseded by IFileOperation.
+description: Copies, moves, renames, or deletes a file system object. On Windows Vista and later releases, we recommend that you use IFileOperation instead of this function.
 helpviewer_keywords: ["SHFileOperation","SHFileOperation function [Windows Shell]","SHFileOperationA","SHFileOperationW","_win32_SHFileOperation","shell.SHFileOperation","shellapi/SHFileOperation","shellapi/SHFileOperationA","shellapi/SHFileOperationW"]
 old-location: shell\SHFileOperation.htm
 tech.root: shell


### PR DESCRIPTION
Documentation is slightly misleading. IFileOperation does NOT replace SHFileOperationA/W on Vista onwards. New applications that run on Vista and above are recommended to use the IFileOperation interface.