### PR TITLE
Expand IWebAuthenticationCoreManagerInterop pages

### DIFF
--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/index.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/index.md
@@ -40,8 +40,6 @@ tech.root: winrt
 
 ## -description
 
-Contains core methods for obtaining tokens from web account providers.<br/><br/>
-
 ## -remarks
 
 This header is used by Windows Runtime C++ reference. For more information, see:

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/index.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/index.md
@@ -40,6 +40,9 @@ tech.root: winrt
 
 ## -description
 
+Provides Win32 apps with access to certain functions of [WebAuthenticationCoreManager](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager)
+that are otherwise available only to UWP apps.
+
 ## -remarks
 
 This header is used by Windows Runtime C++ reference. For more information, see:

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -48,7 +48,7 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-The window to be used as the parent for the window prompting the user for credentials,
+The window to be used as the owner for the window prompting the user for credentials,
 in case such a window becomes necessary.
 
 ### -param request

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -63,7 +63,7 @@ interface.
 Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
 for the interface
 [IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
-This IID is automatically generated but you can obtain it programatically:
+This IID is automatically generated but you can obtain it using code like this:
 
 ```cppwinrt
 using winrt::Windows::Foundation::IAsyncOperation;

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -58,7 +58,7 @@ Type: **[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectabl
 
 The web token request, given as an instance of the
 [WebTokenRequest](/uwp/api/windows.security.authentication.web.core.webtokenrequest)
-class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+class type-casted to the [IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)
 interface.
 
 ### -param riid
@@ -94,4 +94,4 @@ This method is the equivalent for desktop apps of
 [WebAuthenticationCoreManager.RequestTokenAsync(WebTokenRequest)](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager.requesttokenasync#Windows_Security_Authentication_Web_Core_WebAuthenticationCoreManager_RequestTokenAsync_Windows_Security_Authentication_Web_Core_WebTokenRequest_).
 
 ## -see-also
-[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenWithWebAccountForWindowAsync](nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync)
+[Web account management sample app](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenWithWebAccountForWindowAsync](/windows/win32/api/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync)

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -48,10 +48,13 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-The window to be used as the owner for the window prompting the user for credentials,
-in case such a window becomes necessary.
+Type: **[HWND](/windows/win32/winprog/windows-data-types)**
+
+The window to be used as the owner for the window prompting the user for credentials, in case such a window becomes necessary.
 
 ### -param request
+
+Type: **[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)\***
 
 The web token request, given as an instance of the
 [WebTokenRequest](/uwp/api/windows.security.authentication.web.core.webtokenrequest)
@@ -60,10 +63,11 @@ interface.
 
 ### -param riid
 
-Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
-for the interface
-[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
-This IID is automatically generated but you can obtain it using code like this:
+Type: **REFIID**
+
+Must be a reference to the [interface identifier (IID)](/openspecs/windows_protocols/ms-oaut/5583e1b8-454c-4147-9f56-f72416a15bee#gt_76ad3105-3f05-479d-a40c-c9c8fa2ebd83) for the interface
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)\<[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)\>.
+This IID is automatically generated, and you can obtain it using code like this:
 
 ```cppwinrt
 using winrt::Windows::Foundation::IAsyncOperation;
@@ -74,12 +78,13 @@ constexpr winrt::guid iidAsyncRequestResult{ winrt::guid_of<IAsyncOperation<WebT
 
 ### -param asyncInfo
 
-The address of a pointer to
-[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
-On successful return from this method, the pointer will be set to the
-asynchronous request operation object for the request operation just started.
+Type: **void\*\***
+
+The address of a pointer to [IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)\<[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)\>. On successful return from this method, the pointer will be set to the asynchronous request operation object for the request operation just started.
 
 ## -returns
+
+Type: **[HRESULT](/windows/win32/com/structure-of-com-error-codes)**
 
 A status code for the attempt to start the asynchronous request operation.
 

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -47,34 +47,45 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-Type: [HWND](https://docs.microsoft.com/windows/desktop/winprog/windows-data-types)
-
-The app window.
+The window to be used as the parent for the window prompting the user for credentials,
+if such a window is necessary.
 
 ### -param request
 
-Type: [IInspectable](../inspectable/nn-inspectable-iinspectable.md)\*
-
-The web token request.
+The web token request, given as an instance of the
+[WebTokenRequest](/uwp/api/windows.security.authentication.web.core.webtokenrequest)
+class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+interface.
 
 ### -param riid
 
-Type: [REFIID](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
+Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
+for the interface
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
+This IID is automatically generated but you can obtain it programatically:
 
-The interface identifier.
+```cppwinrt
+using winrt::Windows::Foundation::IAsyncOperation;
+using winrt::Windows::Security::Authentication::Web::Core::WebTokenRequestResult;
+
+constexpr winrt::guid iidAsyncRequestResult{ winrt::guid_of<IAsyncOperation<WebTokenRequestResult>>() };
+```
 
 ### -param asyncInfo
 
-Type: **void**\*\*
-
-The asynchronous operation.
+The address of a pointer to
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
+On successful return from this method, the pointer will be set to the
+asynchronous request operation object for the request operation just started.
 
 ## -returns
 
-Type: [HRESULT](https://docs.microsoft.com/windows/desktop/winprog/windows-data-types)
-
-The result of the operation.
+A status code for the attempt to start the asynchronous request operation.
 
 ## -remarks
 
+This method is the equivalent for desktop apps of
+[WebAuthenticationCoreManager.RequestTokenAsync(WebTokenRequest)](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager.requesttokenasync#Windows_Security_Authentication_Web_Core_WebAuthenticationCoreManager_RequestTokenAsync_Windows_Security_Authentication_Web_Core_WebTokenRequest_).
+
 ## -see-also
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenWithWebAccountForWindowAsync](nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync)

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:webauthenticationcoremanagerinterop.IWebAuthenticationCoreManagerInterop.RequestTokenForWindowAsync
 title: IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync
-description: Asynchronously requests a token from a web account provider. If necessary, the user is prompted to enter their credentials.helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync"]
+description: Asynchronously requests a token from a web account provider. If necessary, the user is prompted to enter their credentials.
+helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync"]
 ms.date: 5/28/2019
 ms.keywords: IWebAuthenticationCoreManagerInterop::RequestTokenForWindowAsync
 f1_keywords:
@@ -48,7 +49,7 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 ### -param appWindow
 
 The window to be used as the parent for the window prompting the user for credentials,
-if such a window is necessary.
+in case such a window becomes necessary.
 
 ### -param request
 

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
@@ -48,7 +48,7 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-The window to be used as the parent for the window prompting the user for credentials,
+The window to be used as the owner for the window prompting the user for credentials,
 in case such a window becomes necessary.
 
 ### -param request

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:webauthenticationcoremanagerinterop.IWebAuthenticationCoreManagerInterop.RequestTokenWithWebAccountForWindowAsync
 title: IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync
-description: Asynchronously requests a token from a web account provider. If necessary, the user is prompted to enter their credentials.helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync"]
+description: Asynchronously requests a token from a web account provider. If necessary, the user is prompted to enter their credentials.
+helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync"]
 ms.date: 5/28/2019
 ms.keywords: IWebAuthenticationCoreManagerInterop::RequestTokenWithWebAccountForWindowAsync
 f1_keywords:
@@ -48,7 +49,7 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 ### -param appWindow
 
 The window to be used as the parent for the window prompting the user for credentials,
-if such a window is necessary.
+in case such a window becomes necessary.
 
 ### -param request
 

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
@@ -48,31 +48,37 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-The window to be used as the owner for the window prompting the user for credentials,
-in case such a window becomes necessary.
+Type: **[HWND](/windows/win32/winprog/windows-data-types)**
+
+The window to be used as the owner for the window prompting the user for credentials, in case such a window becomes necessary.
 
 ### -param request
 
+Type: **[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)\***
+
 The web token request, given as an instance of the
 [WebTokenRequest](/uwp/api/windows.security.authentication.web.core.webtokenrequest)
-class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+class type-casted to the [IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)
 interface.
 
 ### -param webAccount
 
-Type: [IInspectable](../inspectable/nn-inspectable-iinspectable.md)\*
+Type: **[IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)\***
 
 The web account for the request, given as an instance of the
 [WebAccount](/uwp/api/windows.security.credentials.webaccount)
-class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+class type-casted to the [IInspectable](/windows/win32/api/inspectable/nn-inspectable-iinspectable)
 interface.
 
 ### -param riid
 
+Type: **REFIID**
+
 Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
 for the interface
-[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
-This IID is automatically generated but you can obtain it using code like this:
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)\<[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)\>.
+
+This IID is automatically generated, and you can obtain it using code like this:
 
 ```cppwinrt
 using winrt::Windows::Foundation::IAsyncOperation;
@@ -83,12 +89,16 @@ constexpr winrt::guid iidAsyncRequestResult{ winrt::guid_of<IAsyncOperation<WebT
 
 ### -param asyncInfo
 
+Type: **void\*\***
+
 The address of a pointer to
-[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)\<[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)\>.
 On successful return from this method, the pointer will be set to the
 asynchronous request operation object for the request operation just started.
 
 ## -returns
+
+Type: **[HRESULT](/windows/win32/com/structure-of-com-error-codes)**
 
 A status code for the attempt to start the asynchronous request operation.
 

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
@@ -47,40 +47,54 @@ Asynchronously requests a token from a web account provider. If necessary, the u
 
 ### -param appWindow
 
-Type: [HWND](https://docs.microsoft.com/windows/desktop/winprog/windows-data-types)
-
-The app window.
+The window to be used as the parent for the window prompting the user for credentials,
+if such a window is necessary.
 
 ### -param request
 
-Type: [IInspectable](../inspectable/nn-inspectable-iinspectable.md)\*
-
-The web token request.
+The web token request, given as an instance of the
+[WebTokenRequest](/uwp/api/windows.security.authentication.web.core.webtokenrequest)
+class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+interface.
 
 ### -param webAccount
 
 Type: [IInspectable](../inspectable/nn-inspectable-iinspectable.md)\*
 
-The web account for the request.
+The web account for the request, given as an instance of the
+[WebAccount](/uwp/api/windows.security.credentials.webaccount)
+class type-casted to the [IInspectable](../inspectable/nn-inspectable-iinspectable.md)
+interface.
 
 ### -param riid
 
-Type: [REFIID](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
+Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
+for the interface
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
+This IID is automatically generated but you can obtain it programatically:
 
-The interface identifier.
+```cppwinrt
+using winrt::Windows::Foundation::IAsyncOperation;
+using winrt::Windows::Security::Authentication::Web::Core::WebTokenRequestResult;
+
+constexpr winrt::guid iidAsyncRequestResult{ winrt::guid_of<IAsyncOperation<WebTokenRequestResult>>() };
+```
 
 ### -param asyncInfo
 
-Type: **void**\*\*
-
-The asynchronous operation.
+The address of a pointer to
+[IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
+On successful return from this method, the pointer will be set to the
+asynchronous request operation object for the request operation just started.
 
 ## -returns
 
-Type: [HRESULT](https://docs.microsoft.com/windows/desktop/winprog/windows-data-types)
-
-The result of the operation.
+A status code for the attempt to start the asynchronous request operation.
 
 ## -remarks
 
+This method is the equivalent for desktop apps of
+[WebAuthenticationCoreManager.RequestTokenAsync(WebTokenRequest, WebAccount)](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager.requesttokenasync#Windows_Security_Authentication_Web_Core_WebAuthenticationCoreManager_RequestTokenAsync_Windows_Security_Authentication_Web_Core_WebTokenRequest_Windows_Security_Credentials_WebAccount_).
+
 ## -see-also
+[Web account management code sample](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/WebAccountManagement), [RequestTokenForWindowAsync](nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenforwindowasync)

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nf-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop-requesttokenwithwebaccountforwindowasync.md
@@ -72,7 +72,7 @@ interface.
 Must refer to the [interface identifier (IID)](https://docs.microsoft.com/openspecs/windows_protocols/ms-oaut/bbde795f-5398-42d8-9f59-3613da03c318)
 for the interface
 [IAsyncOperation](/uwp/api/windows.foundation.iasyncoperation-1)&lt;[WebTokenRequestResult](/uwp/api/windows.security.authentication.web.core.webtokenrequestresult)&gt;.
-This IID is automatically generated but you can obtain it programatically:
+This IID is automatically generated but you can obtain it using code like this:
 
 ```cppwinrt
 using winrt::Windows::Foundation::IAsyncOperation;

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop.md
@@ -37,8 +37,24 @@ tech.root: winrt
 
 ## -description
 
-Contains core methods for obtaining tokens from web account providers.
+Provides desktop apps with access to certain functions of [WebAuthenticationCoreManager](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager)
+that are otherwise available only to UWP apps.
 
 ## -remarks
+
+This interface is implemented by WebAuthenticationCoreManager's [activation factory](../activation/nn-activation-iactivationfactory).
+To get an object of this interface, get a reference to the activation factory
+and then call [IUnknown::QueryInterface](../unknwn/nf-unknwn-iunknown-queryinterface%28refiid_void%29)
+on it:
+
+```cppwinrt
+using winrt::Windows::Security::Authentication::Web::Core::WebAuthenticationCoreManager;
+
+auto managerFactory = winrt::get_activation_factory<WebAuthenticationCoreManager>();
+winrt::com_ptr<IWebAuthenticationCoreManagerInterop> managerInterop{ managerFactory.as<IWebAuthenticationCoreManagerInterop>() };
+
+managerInterop->RequestTokenForWindowAsync(/* ... */)
+```
+
 
 ## -see-also

--- a/sdk-api-src/content/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop.md
+++ b/sdk-api-src/content/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop.md
@@ -1,7 +1,8 @@
 ---
 UID: NN:webauthenticationcoremanagerinterop.IWebAuthenticationCoreManagerInterop
 title: IWebAuthenticationCoreManagerInterop
-description: Contains core methods for obtaining tokens from web account providers.helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop"]
+description: Contains core methods for obtaining tokens from web account providers.
+helpviewer_keywords: ["IWebAuthenticationCoreManagerInterop"]
 ms.date: 5/28/2019
 ms.keywords: IWebAuthenticationCoreManagerInterop
 f1_keywords:
@@ -37,7 +38,7 @@ tech.root: winrt
 
 ## -description
 
-Provides desktop apps with access to certain functions of [WebAuthenticationCoreManager](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager)
+Provides Win32 apps with access to certain functions of [WebAuthenticationCoreManager](/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager)
 that are otherwise available only to UWP apps.
 
 ## -remarks


### PR DESCRIPTION
- Make clear the relationship between the [IWebAuthenticationCoreManagerInterop](https://docs.microsoft.com/en-us/windows/win32/api/webauthenticationcoremanagerinterop/nn-webauthenticationcoremanagerinterop-iwebauthenticationcoremanagerinterop) interface and UWP [WebAuthenticationCoreManager](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.core.webauthenticationcoremanager?view=winrt-19041).

- Show how to get a IWebAuthenticationCoreManagerInterop reference from a WebAuthenticationCoreManager.

- Show the correlations between ...Interop methods and the corresponding ...CoreManager methods.