### PR TITLE
Update PathCanonicalize and related APIs to describe forward slash behavior 

### DIFF
--- a/sdk-api-src/content/pathcch/nf-pathcch-pathalloccanonicalize.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathalloccanonicalize.md
@@ -166,4 +166,4 @@ This function supports these alternate path forms:
 <li>\\?\Volume{guid}\</li>
 </ul>
 
-This function does not convert forward slashes (`/`) into back slashes (`\`), it leaves them unmodified in the output. In cases of attacker controlled input, this function by itself, can not be used to convert paths into a form that can be compared with other paths for sub-path or file identity tests. Callers that need that should convert forward to back slashes before calling this function.
+This function does not convert forward slashes (`/`) into back slashes (`\`). With untrusted input, this function by itself, cannot be used to convert paths into a form that can be compared with other paths for sub-path or identity. Callers that need that ability should convert forward to back slashes before using this function.

--- a/sdk-api-src/content/pathcch/nf-pathcch-pathalloccanonicalize.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathalloccanonicalize.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:pathcch.PathAllocCanonicalize
 title: PathAllocCanonicalize function (pathcch.h)
-description: Converts a path string into a canonical form.This function differs from PathCchCanonicalize and PathCchCanonicalizeEx in that it returns the result on the heap.helpviewer_keywords: ["PATHCCH_ALLOW_LONG_PATHS","PATHCCH_DO_NOT_NORMALIZE_SEGMENTS","PATHCCH_ENSURE_IS_EXTENDED_LENGTH_PATH","PATHCCH_ENSURE_TRAILING_SLASH","PATHCCH_FORCE_DISABLE_LONG_NAME_PROCESS","PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS","PATHCCH_NONE","PathAllocCanonicalize","PathAllocCanonicalize function [Windows Shell]","pathcch/PathAllocCanonicalize","shell.PathAllocCanonicalize"]
+description: Converts a path string into a canonical form.This function differs from PathCchCanonicalize and PathCchCanonicalizeEx in that it returns the result on the heap.
+helpviewer_keywords: ["PATHCCH_ALLOW_LONG_PATHS","PATHCCH_DO_NOT_NORMALIZE_SEGMENTS","PATHCCH_ENSURE_IS_EXTENDED_LENGTH_PATH","PATHCCH_ENSURE_TRAILING_SLASH","PATHCCH_FORCE_DISABLE_LONG_NAME_PROCESS","PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS","PATHCCH_NONE","PathAllocCanonicalize","PathAllocCanonicalize function [Windows Shell]","pathcch/PathAllocCanonicalize","shell.PathAllocCanonicalize"]
 old-location: shell\PathAllocCanonicalize.htm
 tech.root: shell
 ms.assetid: 3179fe78-a969-4ee2-a50b-5f4f7d4dad71
@@ -47,7 +48,6 @@ ms.custom: 19H1
 
 # PathAllocCanonicalize function
 
-
 ## -description
 
 Converts a path string into a canonical form.
@@ -58,14 +58,11 @@ This function differs from <a href="https://docs.microsoft.com/windows/desktop/a
 
 <div class="alert"><b>Note</b> This function, <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathcchcanonicalize">PathCchCanonicalize</a>, or <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathcchcanonicalizeex">PathCchCanonicalizeEx</a>, should be used in place of <a href="https://docs.microsoft.com/windows/desktop/api/shlwapi/nf-shlwapi-pathcanonicalizea">PathCanonicalize</a>.</div>
 
-
 ## -parameters
-
 
 ### -param pszPathIn [in]
 
 A pointer to a buffer that contains the original string. This value cannot be <b>NULL</b>.
-
 
 ### -param dwFlags [in]
 
@@ -151,16 +148,13 @@ One or more of the following flags:
 </tr>
 </table>
 
-
 ### -param ppszPathOut [out]
 
 The address of a pointer to a buffer that, when this function returns successfully, receives the canonicalized path string. It is the responsibility of the caller to free this resource, when it is no longer needed, by calling the <a href="https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-localfree">LocalFree</a> function. This value cannot be <b>NULL</b>.
 
-
 ## -returns
 
 If this function succeeds, it returns <b xmlns:loc="http://microsoft.com/wdcml/l10n">S_OK</b>. Otherwise, it returns an <b xmlns:loc="http://microsoft.com/wdcml/l10n">HRESULT</b> error code.
-
 
 ## -remarks
 
@@ -171,3 +165,5 @@ This function supports these alternate path forms:
 <li>\\?\\UNC\</li>
 <li>\\?\Volume{guid}\</li>
 </ul>
+
+This function does not convert forward slashes (`/`) into back slashes (`\`), it leaves them unmodified in the output. In cases of attacker controlled input, this function by itself, can not be used to convert paths into a form that can be compared with other paths for sub-path or file identity tests. Callers that need that should convert forward to back slashes before calling this function.

--- a/sdk-api-src/content/pathcch/nf-pathcch-pathcchcanonicalize.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathcchcanonicalize.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:pathcch.PathCchCanonicalize
 title: PathCchCanonicalize function (pathcch.h)
-description: Converts a path string into a canonical form.This function differs from PathCchCanonicalizeEx in that you are restricted to a final path of length MAX_PATH.This function differs from PathAllocCanonicalize in that the caller must declare the size of the returned string, which is stored on the stack.This function differs from PathCanonicalize in that it accepts paths with &#0034;\\&#0034;, &#0034;\\?\&#0034; and &#0034;\\?\UNC\&#0034; prefixes.helpviewer_keywords: ["PathCchCanonicalize","PathCchCanonicalize function [Windows Shell]","pathcch/PathCchCanonicalize","shell.PathCchCanonicalize"]
+description: Converts a path string into a canonical form.This function differs from PathCchCanonicalizeEx in that you are restricted to a final path of length MAX_PATH.This function differs from PathAllocCanonicalize in that the caller must declare the size of the returned string, which is stored on the stack.This function differs from PathCanonicalize in that it accepts paths with &#0034;\\&#0034;, &#0034;\\?\&#0034; and &#0034;\\?\UNC\&#0034; prefixes.
+helpviewer_keywords: ["PathCchCanonicalize","PathCchCanonicalize function [Windows Shell]","pathcch/PathCchCanonicalize","shell.PathCchCanonicalize"]
 old-location: shell\PathCchCanonicalize.htm
 tech.root: shell
 ms.assetid: 25ff08b2-5978-4d44-9877-ba4230ef7d12
@@ -47,7 +48,6 @@ ms.custom: 19H1
 
 # PathCchCanonicalize function
 
-
 ## -description
 
 Converts a path string into a canonical form.
@@ -60,24 +60,19 @@ This function differs from <a href="https://docs.microsoft.com/windows/desktop/a
 
 <div class="alert"><b>Note</b>  This function, <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathcchcanonicalizeex">PathCchCanonicalizeEx</a>, or <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathalloccanonicalize">PathAllocCanonicalize</a> should be used in place of <a href="https://docs.microsoft.com/windows/desktop/api/shlwapi/nf-shlwapi-pathcanonicalizea">PathCanonicalize</a> to prevent the possibility of a buffer overrun.</div>
 
-
 ## -parameters
-
 
 ### -param pszPathOut [out]
 
 A pointer to a buffer that, when this function returns successfully, receives the canonicalized path string.
 
-
 ### -param cchPathOut [in]
 
 The size of the buffer pointed to by <i>pszPathOut</i>, in characters.
 
-
 ### -param pszPathIn [in]
 
 A pointer to the original path string. If this value points to an empty string, or results in an empty string once the "." and ".." elements are removed, a single backslash is copied to the buffer pointed to by <i>pszPathOut</i>.
-
 
 ## -returns
 
@@ -120,7 +115,6 @@ The function could not allocate a buffer of the neccessary size.
 </tr>
 </table>
 
-
 ## -remarks
 
 This function responds to the strings "." and ".." embedded in a path. The ".." string indicates to remove the immediately preceding path segment. The "." string indicates to skip over the next path segment. Note that the root segment of the path cannot be removed. If there are more ".." strings than there are path segments, the function returns S_OK and the buffer pointed to by <i>pszPathOut</i> contains a single backslash, "\".
@@ -128,6 +122,8 @@ This function responds to the strings "." and ".." embedded in a path. The ".." 
 All trailing periods are removed from the path, except when preceded by the "*" wild card character. In that case, a single period is retained after the '*' character, but all other trailing periods are removed.
 
 If the resulting path is a root drive ("x:"), a backslash is appended ("x:\").
+
+This function does not convert forward slashes (`/`) into back slashes (`\`). With untrusted input, this function by itself, cannot be used to convert paths into a form that can be compared with other paths for sub-path or identity. Callers that need that ability should convert forward to back slashes before using this function.
 
 The following examples show the effect of these strings.
 

--- a/sdk-api-src/content/pathcch/nf-pathcch-pathcchcanonicalizeex.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathcchcanonicalizeex.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:pathcch.PathCchCanonicalizeEx
 title: PathCchCanonicalizeEx function (pathcch.h)
-description: Simplifies a path by removing navigation elements such as &#0034;.&#0034; and &#0034;..&#0034; to produce a direct, well-formed path.This function differs from PathCchCanonicalize in that it allows for a longer final path to be constructed.This function differs from PathAllocCanonicalize in that the caller must declare the size of the returned string, which is stored on the stack.This function differs from PathCanonicalize in that it accepts paths with &#0034;\\&#0034;, &#0034;\\?\&#0034; and &#0034;\\?\UNC\&#0034; prefixes.helpviewer_keywords: ["PATHCCH_ALLOW_LONG_PATHS","PATHCCH_DO_NOT_NORMALIZE_SEGMENTS","PATHCCH_ENSURE_IS_EXTENDED_LENGTH_PATH","PATHCCH_ENSURE_TRAILING_SLASH","PATHCCH_FORCE_DISABLE_LONG_NAME_PROCESS","PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS","PATHCCH_NONE","PathCchCanonicalizeEx","PathCchCanonicalizeEx function [Windows Shell]","pathcch/PathCchCanonicalizeEx","shell.PathCchCanonicalizeEx"]
+description: Simplifies a path by removing navigation elements such as &#0034;.&#0034; and &#0034;..&#0034; to produce a direct, well-formed path.This function differs from PathCchCanonicalize in that it allows for a longer final path to be constructed.This function differs from PathAllocCanonicalize in that the caller must declare the size of the returned string, which is stored on the stack.This function differs from PathCanonicalize in that it accepts paths with &#0034;\\&#0034;, &#0034;\\?\&#0034; and &#0034;\\?\UNC\&#0034; prefixes.
+helpviewer_keywords: ["PATHCCH_ALLOW_LONG_PATHS","PATHCCH_DO_NOT_NORMALIZE_SEGMENTS","PATHCCH_ENSURE_IS_EXTENDED_LENGTH_PATH","PATHCCH_ENSURE_TRAILING_SLASH","PATHCCH_FORCE_DISABLE_LONG_NAME_PROCESS","PATHCCH_FORCE_ENABLE_LONG_NAME_PROCESS","PATHCCH_NONE","PathCchCanonicalizeEx","PathCchCanonicalizeEx function [Windows Shell]","pathcch/PathCchCanonicalizeEx","shell.PathCchCanonicalizeEx"]
 old-location: shell\PathCchCanonicalizeEx.htm
 tech.root: shell
 ms.assetid: fd7b8ce0-3c67-48fb-8e7e-521a6b438676
@@ -47,7 +48,6 @@ ms.custom: 19H1
 
 # PathCchCanonicalizeEx function
 
-
 ## -description
 
 Simplifies a path by removing navigation elements such as "." and ".." to produce a direct, well-formed path.
@@ -60,24 +60,19 @@ This function differs from <a href="https://docs.microsoft.com/windows/desktop/a
 
 <div class="alert"><b>Note</b> This function, <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathcchcanonicalize">PathCchCanonicalize</a>, or <a href="https://docs.microsoft.com/windows/desktop/api/pathcch/nf-pathcch-pathalloccanonicalize">PathAllocCanonicalize</a> should be used in place of <a href="https://docs.microsoft.com/windows/desktop/api/shlwapi/nf-shlwapi-pathcanonicalizea">PathCanonicalize</a> to prevent the possibility of a buffer overrun.</div>
 
-
 ## -parameters
-
 
 ### -param pszPathOut [out]
 
 A pointer to a buffer that, when this function returns successfully, receives the edited path string.
 
-
 ### -param cchPathOut [in]
 
 The size of the buffer pointed to by <i>pszPathOut</i>, in characters.
 
-
 ### -param pszPathIn [in]
 
 A pointer to the original path string. If this value is <b>NULL</b>, points to an empty string, or results in an empty string once the "." and ".." elements are removed, a single backslash is copied to the buffer pointed to by <i>pszPathOut</i>.
-
 
 ### -param dwFlags [in]
 
@@ -168,7 +163,6 @@ Disables the normalization of path segments that includes removing trailing dots
 </tr>
 </table>
 
-
 ## -returns
 
 If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> code, including but not limited to the following.
@@ -210,7 +204,6 @@ The function could not allocate a buffer of the neccessary size.
 </tr>
 </table>
 
-
 ## -remarks
 
 This function responds to the strings "." and ".." embedded in a path. The ".." string indicates to remove the immediately preceding path segment. The "." string indicates to skip over the next path segment. Note that the root segment of the path cannot be removed. If there are more ".." strings than there are path segments, the function returns <b>S_OK</b> and the buffer pointed to by <i>pszPathOut</i> contains a single backslash, "\".
@@ -218,6 +211,8 @@ This function responds to the strings "." and ".." embedded in a path. The ".." 
 All trailing periods are removed from the path, except when preceded by the "*" wild card character. In that case, a single period is retained after the '*' character, but all other trailing periods are removed.
 
 If the resulting path is a root drive ("x:"), a backslash is appended ("x:\").
+
+This function does not convert forward slashes (`/`) into back slashes (`\`). With untrusted input, this function by itself, cannot be used to convert paths into a form that can be compared with other paths for sub-path or identity. Callers that need that ability should convert forward to back slashes before using this function.
 
 The following examples show the effect of these strings.
 


### PR DESCRIPTION
these APIs do not canonicalize forward slashes, make that clear so clients are aware of the implications relative to path comparisons. 