### PR TITLE
SetThreadDescription & Windows Server 2016

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
@@ -87,6 +87,8 @@ If the function fails, the return value is an <b>HRESULT</b> that denotes the er
 
 The description of a thread can be set more than once; the most recently set value is used. You can retrieve the description of a thread by calling <a href="https://docs.microsoft.com/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription">GetThreadDescription</a>.
 
+SetThreadDescription is only available by <a href="https://docs.microsoft.com/en-us/windows/win32/dlls/using-run-time-dynamic-linking"> Run Time Dynamic Linking</a> on Windows Server 2016, 1607.
+
 
 #### Examples
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreaddescription.md
@@ -48,22 +48,15 @@ ms.custom: 19H1
 
 # SetThreadDescription function
 
-
 ## -description
-
 
 Assigns a description to a thread.
 
-
 ## -parameters
-
-
-
 
 ### -param hThread [in]
 
 A handle for the thread for which you want to set the description. The handle must have THREAD_SET_LIMITED_INFORMATION access.
-
 
 ### -param lpThreadDescription [in]
 
@@ -72,28 +65,18 @@ A Unicode string that specifies the description of the thread.
 
 ## -returns
 
-
-
-If the function succeeds, the return value is the <b>HRESULT</b> that denotes a successful operation.
-If the function fails, the return value is an <b>HRESULT</b> that denotes the error.
- 
-
-
-
+If the function succeeds, the return value is the **HRESULT** that denotes a successful operation.
+If the function fails, the return value is an **HRESULT** that denotes the error.
 
 ## -remarks
 
+The description of a thread can be set more than once; the most recently set value is used. You can retrieve the description of a thread by calling [GetThreadDescription](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription).
 
-
-The description of a thread can be set more than once; the most recently set value is used. You can retrieve the description of a thread by calling <a href="https://docs.microsoft.com/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription">GetThreadDescription</a>.
-
-SetThreadDescription is only available by <a href="https://docs.microsoft.com/en-us/windows/win32/dlls/using-run-time-dynamic-linking"> Run Time Dynamic Linking</a> on Windows Server 2016, 1607.
-
+SetThreadDescription is only available by [Run Time Dynamic Linking](/windows/win32/dlls/using-run-time-dynamic-linking) on Windows Server 2016, 1607.
 
 #### Examples
 
-The following example sets the description for the current thread to "simulation_thread".
-
+The following example sets the description for the current thread to `simulation_thread`.
 
 ```cpp
 HRESULT hr = SetThreadDescription(GetCurrentThread(), L"simulation_thread");
@@ -101,20 +84,10 @@ if (FAILED(hr))
 {
     // Call failed.
 }
-
 ```
-
-
-
-
 
 ## -see-also
 
-
-<a href="https://docs.microsoft.com/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription">GetThreadDescription</a>
- 
- 
-<a href="https://docs.microsoft.com/visualstudio/debugger/how-to-set-a-thread-name-in-native-code">How to: Set a Thread Name in Native Code</a>
-
+[GetThreadDescription](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreaddescription), [How to: Set a Thread Name in Native Code](https://docs.microsoft.com/visualstudio/debugger/how-to-set-a-thread-name-in-native-code)
 
  


### PR DESCRIPTION
SetThreadDescription is only available by <a href="https://docs.microsoft.com/en-us/windows/win32/dlls/using-run-time-dynamic-linking"> Run Time Dynamic Linking</a> on Windows Server 2016, 1607.