### PR TITLE
_InlineInterlockedAdd64 is really InterlockedAdd64

### DIFF
--- a/sdk-api-src/content/winnt/nf-winnt-_inlineinterlockedadd64.md
+++ b/sdk-api-src/content/winnt/nf-winnt-_inlineinterlockedadd64.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:winnt._InlineInterlockedAdd64
-title: _InlineInterlockedAdd64 function (winnt.h)
-description: Performs an atomic addition operation on the specified LONGLONG values.
+title: InterlockedAdd64 function (winnt.h)
+description: Performs an atomic addition operation on the specified LONG64 values.
 helpviewer_keywords: ["InterlockedAdd64","InterlockedAdd64 function","_InlineInterlockedAdd64","base.interlockedadd64","winnt/InterlockedAdd64"]
 old-location: base\interlockedadd64.htm
 tech.root: Sync
@@ -44,13 +44,13 @@ req.redist:
 ms.custom: 19H1
 ---
 
-# _InlineInterlockedAdd64 function
+# InterlockedAdd64 function
 
 
 ## -description
 
 
-Performs an atomic addition operation on the specified <b>LONGLONG</b> values.
+Performs an atomic addition operation on the specified <b>LONG64</b> values.
 
 
 ## -parameters


### PR DESCRIPTION
InterlockedAdd64 is the name of the function that should be called/publicly documented. _InlineInterlockedAdd64 is hidden behind the define in winnt.h. Also, the type is LONG64, not LONGLONG.