### PR TITLE
Fixed bad links

### DIFF
--- a/sdk-api-src/content/ioapiset/nf-ioapiset-deviceiocontrol.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-deviceiocontrol.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:ioapiset.DeviceIoControl
 title: DeviceIoControl function (ioapiset.h)
-description: Sends a control code directly to a specified device driver, causing the corresponding device to perform the corresponding operation.helpviewer_keywords: ["DeviceIoControl","DeviceIoControl function","_win32_deviceiocontrol","base.deviceiocontrol","ioapiset/DeviceIoControl"]
+description: Sends a control code directly to a specified device driver, causing the corresponding device to perform the corresponding operation.
+helpviewer_keywords: ["DeviceIoControl","DeviceIoControl function","_win32_deviceiocontrol","base.deviceiocontrol","ioapiset/DeviceIoControl"]
 old-location: base\deviceiocontrol.htm
 tech.root: devio
 ms.assetid: 1d35c087-6672-4fc6-baa1-a886dd9d3878
@@ -138,11 +139,11 @@ For lists of supported control codes, see the following topics:
 
 - [Disk Management Control Codes](/windows/win32/FileIO/disk-management-control-codes)
 
-- [File Management Control Codes](windows/win32/FileIO/file-management-control-codes)
+- [File Management Control Codes](/windows/win32/FileIO/file-management-control-codes)
 
-- [Power Management Control Codes](windows/win32/Power/power-management-control-codes)
+- [Power Management Control Codes](/windows/win32/Power/power-management-control-codes)
 
-- [Volume Management Control Codes](windows/win32/FileIO/volume-management-control-codes)
+- [Volume Management Control Codes](/windows/win32/FileIO/volume-management-control-codes)
 
 ### Examples
 


### PR DESCRIPTION
File, power, and volume control codes were missing initial forward slash. This resulted on those 3 links hitting a 404.