### PR TITLE
Fix SECPKG_CRED_OUTBOUND

### DIFF
--- a/sdk-api-src/content/sspi/nf-sspi-acquirecredentialshandlew.md
+++ b/sdk-api-src/content/sspi/nf-sspi-acquirecredentialshandlew.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:sspi.AcquireCredentialsHandleW
 title: AcquireCredentialsHandleW function (sspi.h)
-description: The AcquireCredentialsHandle (CredSSP) function acquires a handle to preexisting credentials of a security principal.helpviewer_keywords: ["AcquireCredentialsHandle","AcquireCredentialsHandle (CredSSP)","AcquireCredentialsHandle function [Security]","AcquireCredentialsHandleA","AcquireCredentialsHandleW","SECPKG_CRED_INBOUND","SECPKG_CRED_OUTBOUND","security.acquirecredentialshandle__credssp_","sspi/AcquireCredentialsHandle","sspi/AcquireCredentialsHandleA","sspi/AcquireCredentialsHandleW"]
+description: The AcquireCredentialsHandle (CredSSP) function acquires a handle to preexisting credentials of a security principal.
+helpviewer_keywords: ["AcquireCredentialsHandle","AcquireCredentialsHandle (CredSSP)","AcquireCredentialsHandle function [Security]","AcquireCredentialsHandleA","AcquireCredentialsHandleW","SECPKG_CRED_INBOUND","SECPKG_CRED_OUTBOUND","security.acquirecredentialshandle__credssp_","sspi/AcquireCredentialsHandle","sspi/AcquireCredentialsHandleA","sspi/AcquireCredentialsHandleW"]
 old-location: security\acquirecredentialshandle__credssp_.htm
 tech.root: SecAuthN
 ms.assetid: 3b73decf-75d4-4bc4-b7ca-5f16aaadff29
@@ -95,7 +96,7 @@ Validate an incoming server credential. Inbound credentials might be validated b
 <tr>
 <td width="40%"><a id="SECPKG_CRED_OUTBOUND"></a><a id="secpkg_cred_outbound"></a><dl>
 <dt><b>SECPKG_CRED_OUTBOUND</b></dt>
-<dt>0x0</dt>
+<dt>0x2</dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
The values for `SECPKG_CRED_OUTBOUND` is incorrect, the value according to [sspi.h](https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.16299.0/shared/sspi.h#L457) is `0x00000002` not `0x00000000`

Related to https://github.com/MicrosoftDocs/sdk-api/pull/284