### PR TITLE
Just a simple clarification of remarks

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
@@ -102,7 +102,7 @@ A draw API submits work to the rendering pipeline.
 
 Instancing may extend performance by reusing the same geometry to draw multiple objects in a scene. One example of instancing could be 
       to draw the same object with different positions and colors. Instancing requires multiple vertex buffers: at least one for per-vertex data 
-      and a second buffer for per-instance data. Second buffer is only needed if input layout used has alements using D3D11_INPUT_PER_INSTANCE_DATA as the input element classification.
+      and a second buffer for per-instance data. Second buffer is only needed if input layout used has elements using D3D11_INPUT_PER_INSTANCE_DATA as the input element classification.
 
 
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:d3d11.ID3D11DeviceContext.DrawIndexedInstanced
 title: ID3D11DeviceContext::DrawIndexedInstanced (d3d11.h)
-description: Draw indexed, instanced primitives.helpviewer_keywords: ["8742ce56-5b31-7869-ab62-cb36d33cc5ca","DrawIndexedInstanced","DrawIndexedInstanced method [Direct3D 11]","DrawIndexedInstanced method [Direct3D 11]","ID3D11DeviceContext interface","ID3D11DeviceContext interface [Direct3D 11]","DrawIndexedInstanced method","ID3D11DeviceContext.DrawIndexedInstanced","ID3D11DeviceContext::DrawIndexedInstanced","d3d11/ID3D11DeviceContext::DrawIndexedInstanced","direct3d11.id3d11devicecontext_drawindexedinstanced"]
+description: Draw indexed, instanced primitives.
+helpviewer_keywords: ["8742ce56-5b31-7869-ab62-cb36d33cc5ca","DrawIndexedInstanced","DrawIndexedInstanced method [Direct3D 11]","DrawIndexedInstanced method [Direct3D 11]","ID3D11DeviceContext interface","ID3D11DeviceContext interface [Direct3D 11]","DrawIndexedInstanced method","ID3D11DeviceContext.DrawIndexedInstanced","ID3D11DeviceContext::DrawIndexedInstanced","d3d11/ID3D11DeviceContext::DrawIndexedInstanced","direct3d11.id3d11devicecontext_drawindexedinstanced"]
 old-location: direct3d11\id3d11devicecontext_drawindexedinstanced.htm
 tech.root: direct3d11
 ms.assetid: c7a4821a-324c-47e4-b89f-603d2afcfb51
@@ -101,7 +102,7 @@ A draw API submits work to the rendering pipeline.
 
 Instancing may extend performance by reusing the same geometry to draw multiple objects in a scene. One example of instancing could be 
       to draw the same object with different positions and colors. Instancing requires multiple vertex buffers: at least one for per-vertex data 
-      and a second buffer for per-instance data.
+      and a second buffer for per-instance data. Second buffer is only needed if input layout used has alements using D3D11_INPUT_PER_INSTANCE_DATA as the input element classification.
 
 
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstanced.md
@@ -45,75 +45,50 @@ req.redist:
 ms.custom: 19H1
 ---
 
-# ID3D11DeviceContext::DrawIndexedInstanced
-
-
 ## -description
-
 
 Draw indexed, instanced primitives.
 
-
 ## -parameters
-
-
-
 
 ### -param IndexCountPerInstance [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: <b><a href="/windows/desktop/winprog/windows-data-types">UINT</a></b>
 
 Number of indices read from the index buffer for each instance.
 
-
 ### -param InstanceCount [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: <b><a href="/windows/desktop/winprog/windows-data-types">UINT</a></b>
 
 Number of instances to draw.
 
-
 ### -param StartIndexLocation [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: <b><a href="/windows/desktop/winprog/windows-data-types">UINT</a></b>
 
 The location of the first index read by the GPU from the index buffer.
 
-
 ### -param BaseVertexLocation [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">INT</a></b>
+Type: <b><a href="/windows/desktop/winprog/windows-data-types">INT</a></b>
 
 A value added to each index before reading a vertex from the vertex buffer.
 
-
 ### -param StartInstanceLocation [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: <b><a href="/windows/desktop/winprog/windows-data-types">UINT</a></b>
 
 A value added to each index before reading per-instance data from a vertex buffer.
 
-
 ## -remarks
-
-
 
 A draw API submits work to the rendering pipeline.
 
-Instancing may extend performance by reusing the same geometry to draw multiple objects in a scene. One example of instancing could be 
-      to draw the same object with different positions and colors. Instancing requires multiple vertex buffers: at least one for per-vertex data 
-      and a second buffer for per-instance data. Second buffer is only needed if input layout used has elements using D3D11_INPUT_PER_INSTANCE_DATA as the input element classification.
+Instancing may extend performance by reusing the same geometry to draw multiple objects in a scene. One example of instancing could be to draw the same object with different positions and colors. Instancing requires multiple vertex buffers: at least one for per-vertex data and a second buffer for per-instance data.
 
-
-
+The second buffer is needed only if the input layout that you use has elements that use [D3D11_INPUT_PER_INSTANCE_DATA](/windows/win32/api/d3d11/ne-d3d11-d3d11_input_classification) as the input element classification.
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/d3d11/nn-d3d11-id3d11devicecontext">ID3D11DeviceContext</a>
- 
-
- 
-
+<a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11devicecontext">ID3D11DeviceContext</a>


### PR DESCRIPTION
Added the last sentence in the remarks to make it clear that the second vertex buffer is only needed if per-instance elements are used in the input layout for an instanced mesh