### PR TITLE
Fix error regarding SetClipboardData in response to WM_RENDERALLFORMATS

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-setclipboarddata.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclipboarddata.md
@@ -60,7 +60,7 @@ ms.custom: 19H1
 ## -description
 
 
-Places data on the clipboard in a specified clipboard format. The window must be the current clipboard owner, and the application must have called the [**OpenClipboard**](nf-winuser-openclipboard) function. (When responding to the [WM_RENDERFORMAT](/windows/win32/dataxchg/wm-renderformat) message, the clipboard owner must not call **OpenClipboard** before calling **SetClipboardData**.)
+Places data on the clipboard in a specified clipboard format. The window must be the current clipboard owner, and the application must have called the [**OpenClipboard**](nf-winuser-openclipboard.md) function. (When responding to the [WM_RENDERFORMAT](/windows/win32/dataxchg/wm-renderformat) message, the clipboard owner must not call **OpenClipboard** before calling **SetClipboardData**.)
 
 
 ## -parameters

--- a/sdk-api-src/content/winuser/nf-winuser-setclipboarddata.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclipboarddata.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:winuser.SetClipboardData
 title: SetClipboardData function (winuser.h)
-description: Places data on the clipboard in a specified clipboard format.helpviewer_keywords: ["SetClipboardData","SetClipboardData function [Data Exchange]","_win32_SetClipboardData","_win32_setclipboarddata_cpp","dataxchg.setclipboarddata","winui._win32_setclipboarddata","winuser/SetClipboardData"]
+description: Places data on the clipboard in a specified clipboard format.
+helpviewer_keywords: ["SetClipboardData","SetClipboardData function [Data Exchange]","_win32_SetClipboardData","_win32_setclipboarddata_cpp","dataxchg.setclipboarddata","winui._win32_setclipboarddata","winuser/SetClipboardData"]
 old-location: dataxchg\setclipboarddata.htm
 tech.root: dataxchg
 ms.assetid: VS|winui|~\winui\windowsuserinterface\dataexchange\clipboard\clipboardreference\clipboardfunctions\setclipboarddata.htm
@@ -59,7 +60,7 @@ ms.custom: 19H1
 ## -description
 
 
-Places data on the clipboard in a specified clipboard format. The window must be the current clipboard owner, and the application must have called the <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-openclipboard">OpenClipboard</a> function. (When responding to the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-renderformat">WM_RENDERFORMAT</a> and <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-renderallformats">WM_RENDERALLFORMATS</a> messages, the clipboard owner must not call <b>OpenClipboard</b> before calling <b>SetClipboardData</b>.)
+Places data on the clipboard in a specified clipboard format. The window must be the current clipboard owner, and the application must have called the [**OpenClipboard**](nf-winuser-openclipboard) function. (When responding to the [WM_RENDERFORMAT](/windows/win32/dataxchg/wm-renderformat) message, the clipboard owner must not call **OpenClipboard** before calling **SetClipboardData**.)
 
 
 ## -parameters
@@ -78,7 +79,7 @@ The clipboard format. This parameter can be a registered format or any of the st
 
 Type: <b>HANDLE</b>
 
-A handle to the data in the specified format. This parameter can be <b>NULL</b>, indicating that the window provides data in the specified clipboard format (renders the format) upon request. If a window delays rendering, it must process the <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-renderformat">WM_RENDERFORMAT</a> and <a href="https://docs.microsoft.com/windows/desktop/dataxchg/wm-renderallformats">WM_RENDERALLFORMATS</a> messages.
+A handle to the data in the specified format. This parameter can be <b>NULL</b>, indicating that the window provides data in the specified clipboard format (renders the format) upon request; this is known as [delayed rendering](/windows/win32/dataxchg/clipboard-operations#delayed-rendering). If a window delays rendering, it must process the [WM_RENDERFORMAT](/windows/win32/dataxchg/wm-renderformat) and [WM_RENDERALLFORMATS](/windows/win32/dataxchg/wm-renderallformats) messages.
 
 If <b>SetClipboardData</b> succeeds, the system owns the object identified by the <i>hMem</i> parameter. The application may not write to or free the data once ownership has been transferred to the system, but it can lock and read from the data until the <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-closeclipboard">CloseClipboard</a> function is called. (The memory must be unlocked before the Clipboard is closed.) If the <i>hMem</i> parameter identifies a memory object, the object must have been allocated using the function with the <b>GMEM_MOVEABLE</b> flag.
 


### PR DESCRIPTION
When a window responds to the  [`WM_RENDERALLFORMATS` window message](https://docs.microsoft.com/en-us/windows/win32/dataxchg/wm-renderallformats), it needs to call OpenClipboard before calling SetClipboardData; otherwise its SetClipboardData calls will fail and the data won't be set.

This change removes an incorrect contrary claim in [the documentation for SetClipboardData](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata), and updates a bit of markup on the same page from HTML to Markdown.

Pairs with https://github.com/MicrosoftDocs/win32/pull/397