### PR TITLE
Clarify lifetime of handle returned by IDXGISwapChain2::GetFrameLaten…

### DIFF
--- a/sdk-api-src/content/dxgi1_3/nf-dxgi1_3-idxgiswapchain2-getframelatencywaitableobject.md
+++ b/sdk-api-src/content/dxgi1_3/nf-dxgi1_3-idxgiswapchain2-getframelatencywaitableobject.md
@@ -53,7 +53,7 @@ ms.custom: 19H1
 
 Returns a waitable handle that signals when the DXGI adapter has finished presenting a new frame.
 
-Windows 8.1 introduces new APIs that allow lower-latency rendering by waiting  until the previous frame is presented to the display before drawing the next frame. To use this method, first create the DXGI swap chain with the <a href="https://docs.microsoft.com/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_chain_flag">DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT</a> flag set, then call <b>GetFrameLatencyWaitableObject</b> to retrieve the waitable handle. Use the waitable handle with <a href="https://docs.microsoft.com/windows/desktop/api/synchapi/nf-synchapi-waitforsingleobjectex">WaitForSingleObjectEx</a> to synchronize rendering of each new frame with the end of the previous frame. For every frame it renders, the app should wait on this handle before starting any rendering operations. Note that this requirement includes the first frame the app renders with the swap chain. See the <a href="https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Platform%20Sample/DirectX%20latency%20sample">DirectXLatency sample</a>.
+Windows 8.1 introduces new APIs that allow lower-latency rendering by waiting  until the previous frame is presented to the display before drawing the next frame. To use this method, first create the DXGI swap chain with the <a href="https://docs.microsoft.com/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_chain_flag">DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT</a> flag set, then call <b>GetFrameLatencyWaitableObject</b> to retrieve the waitable handle. Use the waitable handle with <a href="https://docs.microsoft.com/windows/desktop/api/synchapi/nf-synchapi-waitforsingleobjectex">WaitForSingleObjectEx</a> to synchronize rendering of each new frame with the end of the previous frame. For every frame it renders, the app should wait on this handle before starting any rendering operations. Note that this requirement includes the first frame the app renders with the swap chain. See the <a href="https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Platform%20Sample/DirectX%20latency%20sample">DirectXLatency sample</a>. When you are done with the handle, use <a href="https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle">CloseHandle</a> to close it.
 
 
 ## -parameters
@@ -69,8 +69,10 @@ Windows 8.1 introduces new APIs that allow lower-latency rendering by waiting  
 
 A handle to the waitable object, or NULL if the swap chain was not created with <a href="https://docs.microsoft.com/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_chain_flag">DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT</a>.
 
+## -remarks
 
-
+When an application is finished using the object handle returned by
+**IDXGISwapChain2::GetFrameLatencyWaitableObject**, use the <a href="https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle">CloseHandle</a> function to close the handle.
 
 ## -see-also
 


### PR DESCRIPTION
…cyWaitableObject

From the documentation, it is not very clear whether the handle that is returned is owned by the swap chain and should not be closed or if it should be closed by the application.

When I looked at this page, I clicked on the "DirectXLatency sample" link, read the sample and because the sample does not close the handle, I assumed that I shouldn't close the handle:
https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Platform%20Sample/DirectX%20latency%20sample/%5BC%2B%2B%5D-DirectX%20latency%20sample/C%2B%2B

However, you should close the handle:
https://github.com/microsoft/terminal/pull/6435#discussion_r438303247