### PR TITLE
Fix incorrectly formatted asterisk in VSSetConstatnBuffers

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-vssetconstantbuffers.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-vssetconstantbuffers.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:d3d11.ID3D11DeviceContext.VSSetConstantBuffers
 title: ID3D11DeviceContext::VSSetConstantBuffers (d3d11.h)
-description: Sets the constant buffers used by the vertex shader pipeline stage.helpviewer_keywords: ["2cf038d8-59ab-1d57-c785-ed14b6a1c06e","ID3D11DeviceContext interface [Direct3D 11]","VSSetConstantBuffers method","ID3D11DeviceContext.VSSetConstantBuffers","ID3D11DeviceContext::VSSetConstantBuffers","VSSetConstantBuffers","VSSetConstantBuffers method [Direct3D 11]","VSSetConstantBuffers method [Direct3D 11]","ID3D11DeviceContext interface","d3d11/ID3D11DeviceContext::VSSetConstantBuffers","direct3d11.id3d11devicecontext_vssetconstantbuffers"]
+description: Sets the constant buffers used by the vertex shader pipeline stage.
+helpviewer_keywords: ["2cf038d8-59ab-1d57-c785-ed14b6a1c06e","ID3D11DeviceContext interface [Direct3D 11]","VSSetConstantBuffers method","ID3D11DeviceContext.VSSetConstantBuffers","ID3D11DeviceContext::VSSetConstantBuffers","VSSetConstantBuffers","VSSetConstantBuffers method [Direct3D 11]","VSSetConstantBuffers method [Direct3D 11]","ID3D11DeviceContext interface","d3d11/ID3D11DeviceContext::VSSetConstantBuffers","direct3d11.id3d11devicecontext_vssetconstantbuffers"]
 old-location: direct3d11\id3d11devicecontext_vssetconstantbuffers.htm
 tech.root: direct3d11
 ms.assetid: c6f9674b-89fe-4e1e-b814-6ddd98a9cb98
@@ -90,7 +91,7 @@ The method will hold a reference to the interfaces passed in.
           This differs from the device state behavior in Direct3D 10.
         
 
-The Direct3D 11.1 runtime, which is available starting with Windows 8, can bind a larger number of <a href="https://docs.microsoft.com/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a> resources to the shader than the maximum constant buffer size that is supported by shaders (4096 constants – 4*32-bit components each).  When you bind such a large buffer, the shader can access only the first 4096 4*32-bit component constants in the buffer, as if 4096 constants is the full size of the buffer.
+The Direct3D 11.1 runtime, which is available starting with Windows 8, can bind a larger number of <a href="https://docs.microsoft.com/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a> resources to the shader than the maximum constant buffer size that is supported by shaders (4096 constants – 4\*32-bit components each).  When you bind such a large buffer, the shader can access only the first 4096 4\*32-bit component constants in the buffer, as if 4096 constants is the full size of the buffer.
         
 
 If the application wants the shader to access other parts of the buffer, it must call the <a href="https://docs.microsoft.com/windows/desktop/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-vssetconstantbuffers1">VSSetConstantBuffers1</a> method instead.


### PR DESCRIPTION
Currently render as italics, but shouldn't