### PR TITLE
Max accepted latency is 5000ms not 500ms

### DIFF
--- a/sdk-api-src/content/audioclient/nf-audioclient-iaudioclient-initialize.md
+++ b/sdk-api-src/content/audioclient/nf-audioclient-iaudioclient-initialize.md
@@ -150,7 +150,7 @@ The requested buffer size is not aligned. This code can be returned for a render
 <td width="60%">
 <div class="alert"><b>Note</b>  Applies to Windows 7 and later.</div>
 <div> </div>
-Indicates that the buffer duration value requested by an exclusive-mode client is out of range. The requested duration value for pull mode must not be greater than 500 milliseconds; for push mode the duration value must not be greater than 2 seconds.
+Indicates that the buffer duration value requested by an exclusive-mode client is out of range. The requested duration value for pull mode must not be greater than 5000 milliseconds; for push mode the duration value must not be greater than 2 seconds.
 
 </td>
 </tr>
@@ -210,7 +210,7 @@ The method failed to create the audio endpoint for the render or the capture dev
 <td width="60%">
 <div class="alert"><b>Note</b>  Applies to Windows 7 and later.</div>
 <div> </div>
-Indicates that the device period requested by an exclusive-mode client is greater than 500 milliseconds.
+Indicates that the device period requested by an exclusive-mode client is greater than 5000 milliseconds.
 
 </td>
 </tr>


### PR DESCRIPTION
From my "extended" tests, it seems like the max accepted latency is 5000ms not 500ms, at least in exclusive, event callback, mode.
SDK: C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um\Audioclient.h

Anything up to 5000 is accepted by IAudioClient::Initialize, 5001ms is not. Reference code below:
```REFERENCE_TIME device_period = 0;
    result = m_audio_client->GetDevicePeriod(nullptr, &device_period);
    device_period = std::clamp((REFERENCE_TIME)user_preferred_latency * 10000, device_period, (REFERENCE_TIME)5000 * 10000);
    result = m_audio_client->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, AUDCLNT_STREAMFLAGS_EVENTCALLBACK, device_period,device_period, &m_format.Format, nullptr);
```