### PR TITLE
add missing returns rection

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessid.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:processthreadsapi.GetProcessId
 title: GetProcessId function (processthreadsapi.h)
-description: Retrieves the process identifier of the specified process.helpviewer_keywords: ["GetProcessId","GetProcessId function","base.getprocessid","processthreadsapi/GetProcessId","winbase/GetProcessId"]
+description: Retrieves the process identifier of the specified process.
+helpviewer_keywords: ["GetProcessId","GetProcessId function","base.getprocessid","processthreadsapi/GetProcessId","winbase/GetProcessId"]
 old-location: base\getprocessid.htm
 tech.root: ProcThread
 ms.assetid: 9a024147-8bfe-427a-af12-a63f23328e38
@@ -70,6 +71,18 @@ A handle to the process. The handle must have the PROCESS_QUERY_INFORMATION or P
 <a href="https://docs.microsoft.com/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
 
 <b>Windows Server 2003 and Windows XP:  </b>The handle must have the PROCESS_QUERY_INFORMATION access right.
+
+
+## -returns
+
+
+
+If the function succeeds, the return value is the process identifier.
+
+If the function fails, the return value is zero. To get extended error information, call 
+<a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+
+
 
 
 ## -remarks


### PR DESCRIPTION
the return section was missing on https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getprocessid