### PR TITLE
Fixing bold markup

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
@@ -1,7 +1,8 @@
 ---
 UID: NF:synchapi.EnterCriticalSection
 title: EnterCriticalSection function (synchapi.h)
-description: Waits for ownership of the specified critical section object. The function returns when the calling thread is granted ownership.helpviewer_keywords: ["EnterCriticalSection","EnterCriticalSection function","_win32_entercriticalsection","base.entercriticalsection","synchapi/EnterCriticalSection","winbase/EnterCriticalSection"]
+description: Waits for ownership of the specified critical section object. The function returns when the calling thread is granted ownership.
+helpviewer_keywords: ["EnterCriticalSection","EnterCriticalSection function","_win32_entercriticalsection","base.entercriticalsection","synchapi/EnterCriticalSection","winbase/EnterCriticalSection"]
 old-location: base\entercriticalsection.htm
 tech.root: Sync
 ms.assetid: bb307b7a-66fc-4d19-b774-deca8bf90492
@@ -75,7 +76,7 @@ A pointer to the critical section object.
 
 This function does not return a value.
 
-This function can raise <b>EXCEPTION_POSSIBLE_DEADLOCK</b> if a wait operation on the critical section times out. The timeout interval is specified by the following registry value: <b>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager</b>\<b>CriticalSectionTimeout</b>. Do not handle a possible deadlock exception; instead, debug the application.
+This function can raise <b>EXCEPTION_POSSIBLE_DEADLOCK</b> if a wait operation on the critical section times out. The timeout interval is specified by the following registry value: <b>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\CriticalSectionTimeout</b>. Do not handle a possible deadlock exception; instead, debug the application.
 
 
 


### PR DESCRIPTION
Fixing the path of the registry key so the markup does not get displayed