### PR TITLE
Fix InitializeSecurityContext link

### DIFF
--- a/sdk-api-src/content/schannel/ns-schannel-secpkgcontext_connectioninfo.md
+++ b/sdk-api-src/content/schannel/ns-schannel-secpkgcontext_connectioninfo.md
@@ -51,7 +51,7 @@ ms.custom: 19H1
 
 
 The <b>SecPkgContext_ConnectionInfo</b> structure contains protocol and cipher information. This structure is used by the 
-<a href="https://docs.microsoft.com/windows/desktop/api/rrascfg/nn-rrascfg-ieapproviderconfig">InitializeSecurityContext (Schannel)</a> function.
+<a href="https://docs.microsoft.com/en-us/windows/win32/secauthn/initializesecuritycontext--schannel">InitializeSecurityContext (Schannel)</a> function.
 
 This attribute is supported only by the Schannel <a href="https://docs.microsoft.com/windows/desktop/SecGloss/s-gly">security support provider</a> (SSP).
 


### PR DESCRIPTION
Currently referencing a different page