### PR TITLE
Fix the maximum buffer length of lpCommandLine of CreateProcess

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -96,7 +96,7 @@ To run a batch file, you must start the command interpreter; set <i>lpApplicatio
 The command line to be executed. 
 
 
-The maximum length of this string is 32,768 characters, including the Unicode terminating null character. If <i>lpApplicationName</i> is <b>NULL</b>, the module name portion of <i>lpCommandLine</i> is limited to <b>MAX_PATH</b> characters.
+The maximum length of this string is 32,767 characters, including the Unicode terminating null character. If <i>lpApplicationName</i> is <b>NULL</b>, the module name portion of <i>lpCommandLine</i> is limited to <b>MAX_PATH</b> characters.
 
 The Unicode version of this function, <b>CreateProcessW</b>, can modify the contents of this string. Therefore, this parameter cannot be a pointer to read-only memory (such as a <b>const</b> variable or a literal string). If this parameter is a constant string, the function may cause an access violation.
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
@@ -96,7 +96,7 @@ To run a batch file, you must start the command interpreter; set <i>lpApplicatio
 The command line to be executed. 
 
 
-The maximum length of this string is 32,768 characters, including the Unicode terminating null character. If <i>lpApplicationName</i> is <b>NULL</b>, the module name portion of <i>lpCommandLine</i> is limited to <b>MAX_PATH</b> characters.
+The maximum length of this string is 32,767 characters, including the Unicode terminating null character. If <i>lpApplicationName</i> is <b>NULL</b>, the module name portion of <i>lpCommandLine</i> is limited to <b>MAX_PATH</b> characters.
 
 The Unicode version of this function, <b>CreateProcessW</b>, can modify the contents of this string. Therefore, this parameter cannot be a pointer to read-only memory (such as a <b>const</b> variable or a literal string). If this parameter is a constant string, the function may cause an access violation.
 


### PR DESCRIPTION
Fix the maximum buffer length of `lpCommandLine` of `CreateProcess`. It's actually 32767 (including the terminating null character).

(Although I expect confirmation by Microsoft folks... https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553 says this limitation comes from the underlying [UNICODE_STRING](https://docs.microsoft.com/en-us/windows/win32/api/subauth/ns-subauth-unicode_string) structure. It manages the buffer length with `USHORT`, so the maximum buffer length should be 65535 / 2 = 32767 characters.)

Here is a simple console application to demonstrate the limitation: [ConsoleApplication1.zip](https://github.com/MicrosoftDocs/sdk-api/files/4845275/ConsoleApplication1.zip) (Tested on Windows 10 Pro 2004)

Output from the Unicode build:

```
_tcslen(commandLine.get())+1: 32768
CreateProcess: Error 206

_tcslen(commandLine.get())+1: 32767
CreateProcess: Successful
FIND: Parameter format not correct
```