### PR TITLE
WLAN_SET_EAPHOST_DATA_ALL_USERS

### DIFF
--- a/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapuserdata.md
+++ b/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapuserdata.md
@@ -205,7 +205,7 @@ The request is not supported.
 
 This value is returned when profile settings do not permit storage of user data. This can occur when single signon (SSO) is enabled  or when the request was to delete the stored credentials for this profile (the <i>pbEapUserData</i> parameter was <b>NULL</b>, the  <i>dwFlags</i> parameter contains <b>WLAN_SET_EAPHOST_DATA_ALL_USERS</b>,   and the <i>dwEapUserDataSize</i> parameter is 0). 
 
-On Windows 7, Windows Server 2008 R2 ,  and later, this value is returned if the <a href="https://docs.microsoft.com/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofileeapuserdata">WlanSetProfileEapUserData</a> function was called on a profile that uses a method other than 802.1X for authentication. 
+On Windows 10, Windows Server 2016 ,  and later, this value is returned if the <a href="https://docs.microsoft.com/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofileeapuserdata">WlanSetProfileEapUserData</a> function was called on a profile that uses a method other than 802.1X for authentication. 
 
 This value is also returned if this function was called from a Windows XP with SP3 or Wireless LAN API for Windows XP with SP2 client.
 


### PR DESCRIPTION
WLAN_SET_EAPHOST_DATA_ALL_USERS doesn't work for Windows 7 but definitely works on Windows 10.