### PR TITLE
WLAN_SET_EAPHOST_DATA_ALL_USERS.

### DIFF
--- a/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
+++ b/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
@@ -244,7 +244,7 @@ The <i>eapType</i> parameter is an  <a href="https://docs.microsoft.com/windows/
 
 For more information on the allocation of EAP method types, see section 6.2 of <a href="http://tools.ietf.org/html/rfc3748">RFC 3748</a> published by the IETF.
 
-On Windows 7, Windows Server 2008 R2,  and later, the  <b>WlanSetProfileEapXmlUserData</b> function is enhanced. EAP user credentials can be set for all users of  a profile if the <i>dwFlags</i> parameter contains <b>WLAN_SET_EAPHOST_DATA_ALL_USERS</b>. 
+On Windows 10, Windows Server 2016,  and later, the  <b>WlanSetProfileEapXmlUserData</b> function is enhanced. EAP user credentials can be set for all users of  a profile if the <i>dwFlags</i> parameter contains <b>WLAN_SET_EAPHOST_DATA_ALL_USERS</b>. 
 
 All wireless LAN functions require an interface GUID for the wireless interface when performing profile operations. When a wireless interface is removed, its state is cleared from Wireless LAN Service (WLANSVC)  and no profile operations are possible.
 


### PR DESCRIPTION
WLAN_SET_EAPHOST_DATA_ALL_USERS doesn't work on Windows 7 but definitely works on Windows 10.