### PR TITLE
ICodecAPI is not available via strmif.h on UWPs

### DIFF
--- a/sdk-api-src/content/strmif/nf-strmif-icodecapi-getvalue.md
+++ b/sdk-api-src/content/strmif/nf-strmif-icodecapi-getvalue.md
@@ -12,7 +12,7 @@ f1_keywords:
 - strmif/ICodecAPI.GetValue
 dev_langs:
 - c++
-req.header: strmif.h
+req.header: strmif.h | icodecapi.h on UWP apps
 req.include-header: Dshow.h
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP with SP2 [desktop apps \| UWP apps]


### PR DESCRIPTION
icodecapi.h should be used on UWP apps