### PR TITLE
Separate WinHTTP and HTTP.SYS categories

### DIFF
--- a/sdk-api-src/content/_http/config.json
+++ b/sdk-api-src/content/_http/config.json
@@ -4,7 +4,6 @@
     "httpserv.h",
     "http.h",
     "httpp.h",
-    "winhttp.h"
   ],
-  "displayName": "Windows HTTP Services (WinHTTP)"
+  "displayName": "HTTP Server API"
 }

--- a/sdk-api-src/content/_http/index.md
+++ b/sdk-api-src/content/_http/index.md
@@ -1,24 +1,21 @@
 ---
 UID: TP:http
-title: Windows HTTP Services (WinHTTP)
+title: HTTP Server API
 ms.assetid: cfab313a-3f98-3ef1-aa82-fdcc1fc87df9
 ms.date: 01/11/2019
 ms.keywords: 
 ms.topic: conceptual
 ---
 
-# Windows HTTP Services (WinHTTP)
+# HTTP Server API
 
 ## -description
 
-Overview of the Windows HTTP Services (WinHTTP) technology.
+Overview of the HTTP Server API technology.
 
-To develop Windows HTTP Services (WinHTTP), you need these headers:
+To develop HTTP Server API, you need these headers:
 
  * [http.h](../http/index.md)
- * [winhttp.h](../winhttp/index.md)
 
 For programming guidance for this technology, see:
 * [HTTP Server API](/windows/desktop/http)
-* [Windows HTTP Services (WinHTTP)](/windows/desktop/winhttp)
-

--- a/sdk-api-src/content/_winhttp/config.json
+++ b/sdk-api-src/content/_winhttp/config.json
@@ -1,0 +1,7 @@
+{
+  "tech": "winhttp",
+  "headers": [
+    "winhttp.h"
+  ],
+  "displayName": "Windows HTTP Services (WinHTTP)"
+}

--- a/sdk-api-src/content/_winhttp/index.md
+++ b/sdk-api-src/content/_winhttp/index.md
@@ -1,0 +1,22 @@
+---
+UID: TP:winhttp
+title: Windows HTTP Services (WinHTTP)
+ms.assetid: 4f410546-bcdd-44f6-801e-6968154b9940
+ms.date: 01/11/2019
+ms.keywords: 
+ms.topic: conceptual
+---
+
+# Windows HTTP Services (WinHTTP)
+
+## -description
+
+Overview of the Windows HTTP Services (WinHTTP) technology.
+
+To develop Windows HTTP Services (WinHTTP), you need these headers:
+
+ * [winhttp.h](../winhttp/index.md)
+
+For programming guidance for this technology, see:
+* [Windows HTTP Services (WinHTTP)](/windows/desktop/winhttp)
+

--- a/sdk-api-src/content/_wininet/index.md
+++ b/sdk-api-src/content/_wininet/index.md
@@ -16,6 +16,7 @@ Overview of the Windows Internet technology.
 To develop Windows Internet, you need these headers:
 
  * [proofofpossessioncookieinfo.h](../proofofpossessioncookieinfo/index.md)
+ * [wininet.h](../wininet/index.md)
  * [winineti.h](../winineti/index.md)
 
 For programming guidance for this technology, see:

--- a/sdk-api-src/content/http/index.md
+++ b/sdk-api-src/content/http/index.md
@@ -14,7 +14,7 @@ tech.root: http
 ## -description
 
 
-This header is used by Windows HTTP Services (WinHTTP). For more information, see:
+This header is used by HTTP Server API. For more information, see:
 
-- [Windows HTTP Services (WinHTTP)](../_http/index.md)
+- [HTTP Server API](../_http/index.md)
 

--- a/sdk-api-src/content/index.yml
+++ b/sdk-api-src/content/index.yml
@@ -134,7 +134,7 @@ landingContent:
         links:
           - text: Bluetooth
             url: _bluetooth/index.md
-          - text: Windows HTTP Services (WinHTTP)
+          - text: HTTP Server API
             url: _http/index.md
           - text: IP Helper
             url: _iphlp/index.md
@@ -142,6 +142,8 @@ landingContent:
             url: _netmgmt/index.md
           - text: Remote Procedure Call (RPC)
             url: _rpc/index.md
+          - text: Windows HTTP Services (WinHTTP)
+            url: _winhttp/index.md
           - text: Windows Internet
             url: _wininet/index.md
           - text: Windows Sockets 2

--- a/sdk-api-src/content/winhttp/index.md
+++ b/sdk-api-src/content/winhttp/index.md
@@ -5,7 +5,7 @@ ms.assetid: b99c19ca-45eb-37ee-9de5-fbee9a7805d2
 ms.date: 01/11/2019
 ms.keywords: 
 ms.topic: conceptual
-tech.root: http
+tech.root: WinHttp
 ---
 
 # Winhttp.h header
@@ -16,5 +16,5 @@ tech.root: http
 
 This header is used by Windows HTTP Services (WinHTTP). For more information, see:
 
-- [Windows HTTP Services (WinHTTP)](../_http/index.md)
+- [Windows HTTP Services (WinHTTP)](../_winhttp/index.md)
 


### PR DESCRIPTION
The documentation for WinHTTP and HTTP.SYS is combined into a single "Windows HTTP Services (WinHTTP)" category on MSDN, which causes some confusion. This PR splits the client and server documentation into separate categories.