### PR TITLE
Make sure __cdecl is not missed.

### DIFF
--- a/sdk-api-src/content/winnt/nf-winnt-rtlrestorecontext.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlrestorecontext.md
@@ -56,6 +56,14 @@ ms.custom: 19H1
 
 Restores the context of the caller to the specified context record.
 
+## -syntax
+
+```cpp
+NTSYSAPI VOID __cdecl RtlRestoreContext(
+  PCONTEXT          ContextRecord,
+  _EXCEPTION_RECORD *ExceptionRecord
+);
+```
 
 ## -parameters
 


### PR DESCRIPTION
Add an explicit "syntax" section. so make sure the calling-convention keyword (__cdecl) is not missed.