### PR TITLE
Update ne-shobjidl_core-default_folder_menu_restrictions.md

### DIFF
--- a/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions.md
+++ b/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions.md
@@ -76,7 +76,7 @@ Defines shortcut menu restrictions used by [IDefaultFolderMenuInitialize::GetMen
 
 ### -field DFMR_OPTIN_HANDLERS_ONLY
 
-0x0040. Opt-in to load handler for placeholder files. Only used for handlers that will not cause implicit hydration. Opt-in handlers must have the registry value "ContextMenuOptIn" under HKCR\CLSID\<handler clsid>
+0x0040. Opt-in to load handler for partial cloud files. Only used for handlers that will not cause implicit hydration. Opt-in handlers must have the registry value "ContextMenuOptIn" under HKCR\CLSID\<handler clsid>
 
 
 ### -field DFMR_RESOURCE_AND_FOLDER_VERBS_ONLY

--- a/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions.md
+++ b/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions.md
@@ -76,7 +76,7 @@ Defines shortcut menu restrictions used by [IDefaultFolderMenuInitialize::GetMen
 
 ### -field DFMR_OPTIN_HANDLERS_ONLY
 
-0x0040. Only load opt-in handlers that have the registry value "ContextMenuOptIn" under HKCR\CLSID\<handler clsid>
+0x0040. Opt-in to load handler for placeholder files. Only used for handlers that will not cause implicit hydration. Opt-in handlers must have the registry value "ContextMenuOptIn" under HKCR\CLSID\<handler clsid>
 
 
 ### -field DFMR_RESOURCE_AND_FOLDER_VERBS_ONLY


### PR DESCRIPTION
Updated to clarify purpose of DFMR_OPTIN_HANDLERS_ONLY is for use with handlers that do not implicitly hydrate placeholder files.