### PR TITLE
Fix header level

### DIFF
--- a/sdk-api-src/content/d2d1svg/nf-d2d1svg-id2d1svgelement-getattributevalue(pcwstr_d2d1_svg_attribute_string_type_pwstr_uint32).md
+++ b/sdk-api-src/content/d2d1svg/nf-d2d1svg-id2d1svgelement-getattributevalue(pcwstr_d2d1_svg_attribute_string_type_pwstr_uint32).md
@@ -65,7 +65,7 @@ Type: <b>PCWSTR</b>
 The name of the attribute.
 
 
-#### - type
+### - type
 
 Type: <b><a href="https://docs.microsoft.com/windows/desktop/api/d2d1svg/ne-d2d1svg-d2d1_svg_attribute_string_type">D2D1_SVG_ATTRIBUTE_STRING_TYPE</a></b>
 
@@ -79,7 +79,7 @@ Type: <b>PWSTR</b>
 The value of the attribute.
 
 
-#### - valueCount
+### - valueCount
 
 Type: <b>UINT32</b>
 


### PR DESCRIPTION
A header level of 4 was indicated where a level of 3 was expected. The content of header level 4 wasn't shown, so this is not just a formatting consistency change.