### PR TITLE
Clarify documentation for PrjMarkDirectoryAsPlaceholder

### DIFF
--- a/sdk-api-src/content/projectedfslib/nf-projectedfslib-prjmarkdirectoryasplaceholder.md
+++ b/sdk-api-src/content/projectedfslib/nf-projectedfslib-prjmarkdirectoryasplaceholder.md
@@ -65,7 +65,7 @@ A null-terminated Unicode string specifying the full path to the virtualization 
 
 ### -param targetPathName [in, optional]
 
-A null-terminated Unicode string specifying the path, relative to the virtualization root, to the directory to convert to a placeholder. 
+A null-terminated Unicode string specifying the full path to the directory to convert to a placeholder.
 
 
 If this parameter is not specified or is an empty string, then this means the caller wants to designate rootPathName as the virtualization root. The provider only needs to do this one time, upon establishing a new virtualization instance.


### PR DESCRIPTION
The targetPathName description is a bit misleading, and actually expects a full path, and not a relative path. Attempting to give it a relative path will always result in HRESULT(ERROR_INVALID_PARAMETER).