### PR TITLE
Fix a casing typo in LsaFreeReturnBuffer

### DIFF
--- a/sdk-api-src/content/ntsecapi/nf-ntsecapi-lsagetlogonsessiondata.md
+++ b/sdk-api-src/content/ntsecapi/nf-ntsecapi-lsagetlogonsessiondata.md
@@ -69,7 +69,7 @@ Specifies a pointer to a <b>LUID</b> that identifies the logon session whose inf
 
 Address of a pointer to a 
 <a href="https://docs.microsoft.com/windows/desktop/api/ntsecapi/ns-ntsecapi-security_logon_session_data">SECURITY_LOGON_SESSION_DATA</a> structure containing information on the logon session specified by <i>LogonId</i>. This structure is allocated by the LSA. When the information is no longer needed, call the 
-<a href="https://docs.microsoft.com/windows/desktop/api/ntsecapi/nf-ntsecapi-lsafreereturnbuffer">LSAFreeReturnBuffer</a> function to free the memory used by this structure.
+<a href="https://docs.microsoft.com/windows/desktop/api/ntsecapi/nf-ntsecapi-lsafreereturnbuffer">LsaFreeReturnBuffer</a> function to free the memory used by this structure.
 
 
 ## -returns


### PR DESCRIPTION
`LsaFreeReturnBuffer` is the correct casing for the "LSA" prefix of this function.