### PR TITLE
Switch Arg1 and Arg2 descriptions

### DIFF
--- a/sdk-api-src/content/wlanapi/nc-wlanapi-wlan_notification_callback.md
+++ b/sdk-api-src/content/wlanapi/nc-wlanapi-wlan_notification_callback.md
@@ -52,13 +52,13 @@ The <b>WLAN_NOTIFICATION_CALLBACK</b> callback function prototype defines the ty
 
 ### -param Arg1
 
-A pointer to the context information provided by the client when it registered for the notification.
-
-### -param Arg2
-
 A pointer to a <a href="https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms706902(v=vs.85)">WLAN_NOTIFICATION_DATA</a> structure that contains the notification information.
 
 <b>Windows XP with SP3 and Wireless LAN API for Windows XP with SP2:  </b>Only the wlan_notification_acm_connection_complete and wlan_notification_acm_disconnected notifications are available.
+
+### -param Arg2
+
+A pointer to the context information provided by the client when it registered for the notification.
 
 ## -remarks
 


### PR DESCRIPTION
According to the function header, Arg1 and Arg2 descriptions were switched.