### PR TITLE
Add documentation for 'ID3DDestructionNotifier'

### DIFF
--- a/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-registerdestructioncallback.md
+++ b/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-registerdestructioncallback.md
@@ -83,6 +83,28 @@ Type: <b><a href="windows/win32/com/structure-of-com-error-codes">HRESULT</a></b
 
 If this function suceeds, it will return **S_OK**
 
+## -remarks
+
+An example of this interface being used to log the destruction of an **ID3D12Resource**
+
+```cpp
+#include <d3dcommon.h> // for ID3DDestructionNotifier
+
+ComPtr<ID3D12Resource> resource = ...;
+
+ComPtr<ID3DDestructionNotifier> notifier;
+if (SUCCEEDED(resource.As(&notifier)))
+{
+    UINT callbackId;
+    ThrowIfFailed(notifier->RegisterDestructionCallback(LogResourceReleased, nullptr, &callbackId));
+}
+
+void LogResourceReleased(void* context)
+{
+    OutputDebugString("Resource released!\n");
+}
+```
+
 ## -see-also
 
 

--- a/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-registerdestructioncallback.md
+++ b/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-registerdestructioncallback.md
@@ -1,0 +1,99 @@
+---
+UID: NF:d3dcommon.ID3DDestructionNotifier.RegisterDestructionCallback
+title: ID3DDestructionNotifier::RegisterDestructionCallback (d3dcommon.h)
+description:Registers a user-defined callback to be invoked when the object this **ID3DDestructionNotifier** was created from is destroyed.
+helpviewer_keywords: ["ID3DDestructionNotifier interface [Direct3D]","RegisterDestructionCallback method","ID3DDestructionNotifier.RegisterDestructionCallback","ID3DDestructionNotifier::RegisterDestructionCallback","RegisterDestructionCallback","RegisterDestructionCallback method [Direct3D]","RegisterDestructionCallback method [Direct3D]","ID3DDestructionNotifier interface","d3dcommon/ID3DDestructionNotifier::RegisterDestructionCallback","direct3d11.id3ddestructionnotifier_registerdestructioncallback"]
+old-location: direct3d11\id3ddestructionnotifier_registerdestructioncallback.htm
+tech.root: direct3d11
+ms.assetid: 4d10c986-1cba-427c-ae90-f81b83be1b8b
+ms.date: 12/05/2018
+ms.keywords: ID3DDestructionNotifier interface [Direct3D],RegisterDestructionCallback method, ID3DDestructionNotifier.RegisterDestructionCallback, ID3DDestructionNotifier::RegisterDestructionCallback, RegisterDestructionCallback, RegisterDestructionCallback method [Direct3D], RegisterDestructionCallback method [Direct3D],ID3DDestructionNotifier interface, d3dcommon/ID3DDestructionNotifier::RegisterDestructionCallback, direct3d11.id3ddestructionnotifier_registerdestructioncallback
+f1_keywords:
+- d3dcommon/ID3DDestructionNotifier.RegisterDestructionCallback
+dev_langs:
+- c++
+req.header: d3dcommon.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.irql: 
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- COM
+api_location:
+- D3DCommon.h
+api_name:
+- ID3DDestructionNotifier.RegisterDestructionCallback
+targetos: Windows
+req.typenames: 
+req.redist: 
+ms.custom: 19H1
+---
+
+# ID3DDestructionNotifier::RegisterDestructionCallback
+
+
+## -description
+
+
+Registers a user-defined callback to be invoked when the object this **ID3DDestructionNotifier** was created from is destroyed.
+
+
+## -parameters
+
+
+
+
+### -param callbackFn
+
+Type: <b>PFN_DESTRUCTION_CALLBACK</b>
+
+A user-defined callback to be invoked when the object is destroyed.
+          
+
+
+### -param pData
+
+Type: <b>void*</b>
+
+The data to pass to **callbackFn** when invoked
+
+### -param pCallbackID
+
+Type: <b><a href="windows/desktop/WinProg/windows-data-types">UINT*</a></b>
+
+Pointer to a **UINT** used to identify the callback, and can be passed to <a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-unregisterdestructioncallback"></a> to unregister the callback.
+
+
+## -returns
+
+Type: <b><a href="windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
+
+If this function suceeds, it will return **S_OK**
+
+## -see-also
+
+
+
+
+<a href="windows/desktop/api/d3dcommon/nn-d3dcommon-id3ddestructionnotifier">ID3DDestructionNotifier</a>
+
+
+
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-unregisterdestructioncallback">ID3DDestructionNotifier::UnregisterDestructionCallback</a>
+ 
+
+ 
+

--- a/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-unregisterdestructioncallback.md
+++ b/sdk-api-src/content/d3dcommon/nf-d3dcommon-id3ddestructionotifier-unregisterdestructioncallback.md
@@ -1,0 +1,85 @@
+---
+UID: NF:d3dcommon.ID3DDestructionNotifier.UnregisterDestructionCallback
+title: ID3DDestructionNotifier::UnregisterDestructionCallback (d3dcommon.h)
+description: Unregisters a callback registered with ID3DDestructionNotifier::RegisterDestructionCallback.
+helpviewer_keywords: ["ID3DDestructionNotifier interface [Direct3D]","UnregisterDestructionCallback method","ID3DDestructionNotifier.UnregisterDestructionCallback","ID3DDestructionNotifier::UnregisterDestructionCallback","UnregisterDestructionCallback","UnregisterDestructionCallback method [Direct3D]","UnregisterDestructionCallback method [Direct3D]","ID3DDestructionNotifier interface","d3dcommon/ID3DDestructionNotifier::UnregisterDestructionCallback","direct3d11.id3ddestructionnotifier_unregisterdestructioncallback"]
+old-location: direct3d11\id3ddestructionnotifier_unregisterdestructioncallback.htm
+tech.root: direct3d11
+ms.assetid: 4d10c986-1cba-427c-ae90-f81b83be1b8b
+ms.date: 12/05/2018
+ms.keywords: ID3DDestructionNotifier interface [Direct3D],UnregisterDestructionCallback method, ID3DDestructionNotifier.UnregisterDestructionCallback, ID3DDestructionNotifier::UnregisterDestructionCallback, UnregisterDestructionCallback, UnregisterDestructionCallback method [Direct3D], UnregisterDestructionCallback method [Direct3D],ID3DDestructionNotifier interface, d3dcommon/ID3DDestructionNotifier::UnregisterDestructionCallback, direct3d11.id3ddestructionnotifier_unregisterdestructioncallback
+f1_keywords:
+- d3dcommon/ID3DDestructionNotifier.UnregisterDestructionCallback
+dev_langs:
+- c++
+req.header: d3dcommon.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.irql: 
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- COM
+api_location:
+- D3DCommon.h
+api_name:
+- ID3DDestructionNotifier.UnregisterDestructionCallback
+targetos: Windows
+req.typenames: 
+req.redist: 
+ms.custom: 19H1
+---
+
+# ID3DDestructionNotifier::UnregisterDestructionCallback
+
+
+## -description
+
+
+Unregisters a callback registered with <b><a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-registerdestructioncallback"></b>.
+
+
+## -parameters
+
+
+
+### -param callbackID
+
+Type: <b><a href="windows/desktop/WinProg/windows-data-types">UINT</a></b>
+
+A **UINT** that was created by the **pCallbackID** parameter of <b><a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-registerdestructioncallback">ID3DDestructionNotifier::RegisterDestructionCallback</a></b>.
+ 
+
+
+## -returns
+
+Type: <b><a href="windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
+
+If this function suceeds, it will return **S_OK**
+
+## -see-also
+
+
+
+
+<a href="windows/desktop/api/d3dcommon/nn-d3dcommon-id3ddestructionnotifier">ID3DDestructionNotifier</a>
+
+
+
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-registerdestructioncallback">ID3DDestructionNotifier::RegisterDestructionCallback</a>
+ 
+
+ 
+

--- a/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
+++ b/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
@@ -1,0 +1,108 @@
+---
+UID: NN:d3dcommon.ID3DDestructionNotifier
+title: ID3DDestructionNotifier (d3dcommon.h)
+description: ID3DDestructionNotifier is an include interface that the user implements to allow an application to call user-overridable methods for opening and closing shader
+helpviewer_keywords: ["ID3DDestructionNotifier","ID3DDestructionNotifier interface [Direct3D]","ID3DDestructionNotifier interface [Direct3D]","described","d3dcommon/ID3DDestructionNotifier","direct3d.id3ddestructionnotifier"]
+old-location: direct3d11\id3dinclude.htm
+tech.root: direct3d11
+ms.assetid: 2020ce65-3a6e-4a9f-9e97-b94e3c75f4f5
+ms.date: 12/05/2018
+ms.keywords: ID3DDestructionNotifier, ID3DDestructionNotifier interface [Direct3D], ID3DDestructionNotifier interface [Direct3D],described, d3dcommon/ID3DDestructionNotifier, direct3d.id3ddestructionnotifier
+f1_keywords:
+- d3dcommon/ID3DDestructionNotifier
+dev_langs:
+- c++
+req.header: d3dcommon.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 7 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2008 R2 [desktop apps \| UWP apps]
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.irql: 
+topic_type:
+- APIRef
+- kbSyntax
+api_type:
+- COM
+api_location:
+- D3DCommon.h
+api_name:
+- ID3DDestructionNotifier
+targetos: Windows
+req.typenames: 
+req.redist: 
+ms.custom: 19H1
+---
+
+# ID3DInclude interface
+
+
+## -description
+
+
+<b>ID3DDestructionNotifier</b> is an interface that can be used to register for callbacks when a D3D Nano-COM object is destroyed.
+To acquire an instance of this interface, call <a href="windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)"></a> on a D3D object with the **IID** of **ID3DDestructionNotifier**.
+
+
+## -inheritance
+
+The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3DDestructionNotifier</b> interface inherits from the <a href="https://docs.microsoft.com/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>ID3DInclude</b> also has these types of members:
+<ul>
+<li><a href="https://docs.microsoft.com/">Methods</a></li>
+</ul>
+
+## -members
+
+The <b>ID3DDestructionNotifier</b> interface has these methods.
+<table class="members" id="memberListMethods">
+<tr>
+<th align="left" width="37%">Method</th>
+<th align="left" width="63%">Description</th>
+</tr>
+<tr data="declared;">
+<td align="left" width="37%">
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-registerdestructioncallback">RegisterDestructionCallback</a>
+</td>
+<td align="left" width="63%">
+Registers a user-defined callback to be invoked when the current object is destroyed.
+
+</td>
+</tr>
+<tr data="declared;">
+<td align="left" width="37%">
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-unregisterdestructioncallback">UnregisterDestructionCallback</a>
+</td>
+<td align="left" width="63%">
+Unregisters a user-defined callback that was previously registered.
+
+</td>
+</tr>
+</table> 
+
+
+## -remarks
+
+The <b>ID3DDestructionNotifier</b> can be used to track resources which are being unexpectedly released early, or providing a log of object disposal.
+
+
+## -see-also
+
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-registerdestructioncallback">ID3DDestructionNotifier::RegisterDestructionCallback</a>
+
+
+
+<a href="windows/desktop/api/d3dcommon/nf-d3dcommon-id3ddestructionnotifier-unregisterdestructioncallback">ID3DDestructionNotifier::UnregisterDestructionCallback</a>
+
+
+<a href="https://docs.microsoft.com/windows/desktop/direct3d11/d3d11-graphics-reference-d3d11-common-interfaces">Common Version Interfaces</a>
+ 
+
+ 

--- a/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
+++ b/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
@@ -42,7 +42,7 @@ req.redist:
 ms.custom: 19H1
 ---
 
-# ID3DInclude interface
+# ID3DDestructionNotifier interface
 
 
 ## -description
@@ -51,10 +51,14 @@ ms.custom: 19H1
 <b>ID3DDestructionNotifier</b> is an interface that can be used to register for callbacks when a D3D Nano-COM object is destroyed.
 To acquire an instance of this interface, call <a href="windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)"></a> on a D3D object with the **IID** of **ID3DDestructionNotifier**.
 
+Using <b>ID3DDestructionNotifier</b> instead of <b><a href="windows/win32/api/d3d12/nf-d3d12-id3d12object-setprivatedatainterface">ID3D12Object::SetPrivateDataInterface</a></b> or D3D11 equivalents provides
+stronger guarantees about the order of destruction. With <b>ID3DDestructionNotifier</b>, implicit relationships, such as an <b><a href="windows/win32/api/d3d11/nn-d3d11-id3d11view">ID3D11View</a></b> holding a reference to its underlying <b><a href="windows/win32/api/d3d11/nn-d3d11-id3d11resource">ID3D11Resource</a></b>, are guaranteed to be valid and for the referenced object (here, the **ID3D11Object**) to still be alive when the destruction callback is invoked. With <b><a href="windows/win32/api/d3d12/nf-d3d12-id3d12object-setprivatedatainterface">ID3D12Object::SetPrivateDataInterface</a></b>, the implicit references can be released before the destruction callback is invoked.
+
+It isn't safe to access the object being destructed during the callback.
 
 ## -inheritance
 
-The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3DDestructionNotifier</b> interface inherits from the <a href="https://docs.microsoft.com/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>ID3DInclude</b> also has these types of members:
+The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3DDestructionNotifier</b> interface inherits from the <a href="https://docs.microsoft.com/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>ID3DDestructionNotifier</b> also has these types of members:
 <ul>
 <li><a href="https://docs.microsoft.com/">Methods</a></li>
 </ul>


### PR DESCRIPTION
Type has been present in `D3DCommon.h` for a while but isn't publicly documented