### PR TITLE
Fix wrong description

### DIFF
--- a/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
@@ -246,7 +246,7 @@ A pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/winsvc/ns
       
 
 The service control manager fills in the structure only when 
-       <b>ControlService</b> returns zero and <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns one of the following error 
+       <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns one of the following error 
        codes: <b>NO_ERROR</b>, <b>ERROR_INVALID_SERVICE_CONTROL</b>, 
        <b>ERROR_SERVICE_CANNOT_ACCEPT_CTRL</b>, or 
        <b>ERROR_SERVICE_NOT_ACTIVE</b>. Otherwise, the structure is not filled in.

--- a/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
@@ -246,7 +246,7 @@ A pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/winsvc/ns
       
 
 The service control manager fills in the structure only when 
-       <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns one of the following error 
+       [GetLastError](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) returns one of the following error 
        codes: <b>NO_ERROR</b>, <b>ERROR_INVALID_SERVICE_CONTROL</b>, 
        <b>ERROR_SERVICE_CANNOT_ACCEPT_CTRL</b>, or 
        <b>ERROR_SERVICE_NOT_ACTIVE</b>. Otherwise, the structure is not filled in.

--- a/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-controlservice.md
@@ -246,7 +246,7 @@ A pointer to a <a href="https://docs.microsoft.com/windows/desktop/api/winsvc/ns
       
 
 The service control manager fills in the structure only when 
-       <b>ControlService</b> returns one of the following error 
+       <b>ControlService</b> returns zero and <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns one of the following error 
        codes: <b>NO_ERROR</b>, <b>ERROR_INVALID_SERVICE_CONTROL</b>, 
        <b>ERROR_SERVICE_CANNOT_ACCEPT_CTRL</b>, or 
        <b>ERROR_SERVICE_NOT_ACTIVE</b>. Otherwise, the structure is not filled in.


### PR DESCRIPTION
The description of `lpServiceStatus` in the original text is:

> lpServiceStatus
> 
> A pointer to a SERVICE_STATUS structure that receives the latest service status information. The information returned reflects the most recent status that the service reported to the service control manager.
> 
> The service control manager fills in the structure only when ControlService returns one of the following error codes: NO_ERROR, ERROR_INVALID_SERVICE_CONTROL, ERROR_SERVICE_CANNOT_ACCEPT_CTRL, or ERROR_SERVICE_NOT_ACTIVE. Otherwise, the structure is not filled in.

Referring to the definition in the _winerror.h_ file, these macros correspond to the following values:

```cpp
#define NO_ERROR 0L
#define ERROR_INVALID_SERVICE_CONTROL    1052L
#define ERROR_SERVICE_CANNOT_ACCEPT_CTRL 1061L
#define ERROR_SERVICE_NOT_ACTIVE         1062L
```

This seems to conflict with the description in the _Return value_:

> Return value
> 
> If the function succeeds, the return value is nonzero.
> If the function fails, the return value is zero. To get extended error information, call GetLastError.
> 
> The following error codes can be set by the service control manager. Other error codes can be set by the registry functions that are called by the service control manager.
> Return code | Description
> -- | --
> ERROR_ACCESS_DENIED | The handle does not have the required access right.
> ERROR_DEPENDENT_SERVICES_RUNNING | The service cannot be stopped because other running services are dependent on it.
> ERROR_INVALID_HANDLE | The specified handle was not obtained using CreateService or OpenService, or the handle is no longer valid.
> ERROR_INVALID_PARAMETER | The requested control code is undefined.
> ERROR_INVALID_SERVICE_CONTROL | The requested control code is not valid, or it is unacceptable to the service.
> ERROR_SERVICE_CANNOT_ACCEPT_CTRL | The requested control code cannot be sent to the service because the state of the service is SERVICE_STOPPED, SERVICE_START_PENDING, or SERVICE_STOP_PENDING.
> ERROR_SERVICE_NOT_ACTIVE | The service has not been started.
> ERROR_SERVICE_REQUEST_TIMEOUT | The process for the service was started, but it did not call StartServiceCtrlDispatcher, or the thread that called StartServiceCtrlDispatcher may be blocked in a control handler function.
> ERROR_SHUTDOWN_IN_PROGRESS | The system is shutting down.

I guess the correct description of `lpServiceStatus` is what I changed.
Correct me if I'm wrong.