### PR TITLE
Update nf-evntprov-eventwrite.md

### DIFF
--- a/sdk-api-src/content/evntprov/nf-evntprov-eventwrite.md
+++ b/sdk-api-src/content/evntprov/nf-evntprov-eventwrite.md
@@ -161,6 +161,17 @@ Occurs when filled buffers are trying to flush to disk, but disk IOs are not hap
 <tr>
 <td width="40%">
 <dl>
+<dt><b>ERROR_NOACCESS</b></dt>
+</dl>
+</td>
+<td width="60%">
+      <i>UserData</i> points to an invalid memory location or the memory is not correctly aligned.
+</td>
+</tr>
+
+<tr>
+<td width="40%">
+<dl>
 <dt><b>STATUS_LOG_FILE_FULL</b></dt>
 </dl>
 </td>


### PR DESCRIPTION
Added ERROR_NOACCESS to the error list.

It seems that `ZwTracEvent` (called by `EventWrite`) requires the `UserData` to be aligned somehow. 
My guess is dword-alignment but I did not test for it yet.

If `UserData` is not correctly aligned `ZwEventTrace` returns `STATUS_DATATYPE_MISALIGNMENT` (0x80000002) which is translated to `ERROR_NOACCESS` (998) and returned by `EventWrite`.

It took me quite a time to figure this out. I called the function from Delphi code passing a pointer to a static array on the stack which was apparently not correctly aligned. Thus some hint in the docs would be appreciated. My guess is that this relates to all EventWrite* functions.

Note that I just debugged the assembly code of `EventWrite` and don't know the exact circumstances when `ERROR_NOACCESS` is actually returned.