### PR TITLE
Update ClearUnorderedAccessViewFloat and ClearUnorderedAccessViewUint

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -114,7 +114,7 @@ An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view
 <h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>
 For floating-point inputs, the runtime will set denormalized values to 0 (while preserving NANs).
 
-If you want to clear the UAV to a specific bit pattern, consider using <b><a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint>ID3D12GraphicsCommandList::ClearUnorderedAccessView</a></b>.
+If you want to clear the UAV to a specific bit pattern, consider using <b><a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint>ID3D12GraphicsCommandList::ClearUnorderedAccessViewUint</a></b>.
           
 
 Validation failure will result in the call to <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close">Close</a> returning <b>E_INVALIDARG</b>.

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -60,18 +60,19 @@ Sets all the elements in a unordered access view to the specified float values.
 
 ### -param ViewGPUHandleInCurrentHeap [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a></b>
+Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a></b>
 
-Describes the GPU descriptor handle that represents the start of the heap for the unordered-access view to clear.
-          
-
+A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a> that references an initialized descriptor for the unordered-access view that is to be cleared. This descriptor must be in a shader-visible descriptor heap, which must be set on the command list via [SetDescriptorHeaps](nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps.md).
 
 ### -param ViewCPUHandle [in]
 
-Type: <b><a href="https://docs.microsoft.com/windows/desktop/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a></b>
+Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a></b>
 
-Describes the CPU descriptor handle that represents the start of the heap for the render target to clear.
+A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a> in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
+
           
+> [!IMPORTANT]
+> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers which implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in `WRITE_BACK` memory (similar to `D3D12_HEAP_TYPE_UPLOAD` heap types), and CPU reads from this type of memory are prohibitively slow
 
 
 ### -param pResource [in]
@@ -112,6 +113,8 @@ An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view
 
 <h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>
 For floating-point inputs, the runtime will set denormalized values to 0 (while preserving NANs).
+
+If you want to clear the UAV to a specific bit pattern, consider using <b><a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint>ID3D12GraphicsCommandList::ClearUnorderedAccessView</a></b>.
           
 
 Validation failure will result in the call to <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close">Close</a> returning <b>E_INVALIDARG</b>.

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -71,15 +71,15 @@ Type: [in] **[ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource)\
 
 A pointer to the [ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource) interface that represents the unordered-access-view (UAV) resource to clear.
 
-### -param Values [in]
+### -param Values
 
-Type: **const FLOAT[4]**
+Type: [in] **const FLOAT[4]**
 
 A 4-component array that containing the values to fill the unordered-access-view resource with.
 
-### -param NumRects [in]
+### -param NumRects
 
-Type: **UINT**
+Type: [in] **UINT**
 
 The number of rectangles in the array that the *pRects* parameter specifies.
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -44,99 +44,67 @@ req.redist:
 ms.custom: 19H1
 ---
 
-# ID3D12GraphicsCommandList::ClearUnorderedAccessViewFloat
-
-
 ## -description
 
-
-Sets all the elements in a unordered access view to the specified float values.
-
+Sets all of the elements in an unordered-access view (UAV) to the specified float values.
 
 ## -parameters
 
+### -param ViewGPUHandleInCurrentHeap
 
+Type: [in] **[D3D12_GPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle)**
 
+A [D3D12_GPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle) that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared. This descriptor must be in a shader-visible descriptor heap, which must be set on the command list via [SetDescriptorHeaps](nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps.md).
 
-### -param ViewGPUHandleInCurrentHeap [in]
+### -param ViewCPUHandle
 
-Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a></b>
+Type: [in] **[D3D12_CPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle)**
 
-A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a> that references an initialized descriptor for the unordered-access view that is to be cleared. This descriptor must be in a shader-visible descriptor heap, which must be set on the command list via [SetDescriptorHeaps](nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps.md).
-
-### -param ViewCPUHandle [in]
-
-Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a></b>
-
-A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a> in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
-
+A [D3D12_CPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle) in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
           
 > [!IMPORTANT]
-> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers which implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in `WRITE_BACK` memory (similar to `D3D12_HEAP_TYPE_UPLOAD` heap types), and CPU reads from this type of memory are prohibitively slow
+> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers thath implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in **WRITE_BACK** memory (similar to **D3D12_HEAP_TYPE_UPLOAD** heap types), and CPU reads from this type of memory are prohibitively slow.
 
+### -param pResource
 
-### -param pResource [in]
+Type: [in] **[ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource)\***
 
-Type: <b>ID3D12Resource*</b>
-
-A pointer to the <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the unordered-access-view resource to clear.
-          
-
+A pointer to the [ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource) interface that represents the unordered-access-view (UAV) resource to clear.
 
 ### -param Values [in]
 
-Type: <b>const FLOAT[4]</b>
+Type: **const FLOAT[4]**
 
 A 4-component array that containing the values to fill the unordered-access-view resource with.
-          
-
 
 ### -param NumRects [in]
 
-Type: <b>UINT</b>
+Type: **UINT**
 
-The number of rectangles in the array that the <i>pRects</i> parameter specifies.
-          
+The number of rectangles in the array that the *pRects* parameter specifies.
 
+### -param pRects
 
-### -param pRects [in]
+Type: [in] **const [D3D12_RECT](/windows/win32/direct3d12/d3d12-rect)\***
 
-Type: <b>const D3D12_RECT*</b>
-
-An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view to clear. If <b>NULL</b>, <b>ClearUnorderedAccessViewFloat</b> clears the entire resource view.
-          
-
+An array of **D3D12_RECT** structures for the rectangles in the resource view to clear. If **NULL**, **ClearUnorderedAccessViewFloat** clears the entire resource view.
 
 ## -remarks
 
+### Runtime validation
 
+For floating-point inputs, the runtime sets denormalized values to 0 (while preserving NANs).
 
-<h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>
-For floating-point inputs, the runtime will set denormalized values to 0 (while preserving NANs).
+If you want to clear the UAV to a specific bit pattern, consider using [ID3D12GraphicsCommandList::ClearUnorderedAccessViewUint](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint).
 
-If you want to clear the UAV to a specific bit pattern, consider using <b><a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint>ID3D12GraphicsCommandList::ClearUnorderedAccessViewUint</a></b>.
-          
+Validation failure results in the call to [ID3D12GraphicsCommandList::Close](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close) returning **E_INVALIDARG**.
 
-Validation failure will result in the call to <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close">Close</a> returning <b>E_INVALIDARG</b>.
-          
+### Debug layer
 
-<h3><a id="Debug_layer"></a><a id="debug_layer"></a><a id="DEBUG_LAYER"></a>Debug layer</h3>
-The debug layer will issue errors if the input values are outside of a normalized range.
-          
+The debug layer issues errors if the input values are outside of a normalized range.
 
-The debug layer will issue an error if the subresources referenced by the view are not in the appropriate state. For <b>ClearUnorderedAccessViewFloat</b>, the state must be <a href="https://docs.microsoft.com/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_UNORDERED_ACCESS</a>.
-          
-
-
-
+The debug layer issues an error if the subresources referenced by the view aren't in the appropriate state. For **ClearUnorderedAccessViewFloat**, the state must be [D3D12_RESOURCE_STATE_UNORDERED_ACCESS](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states).
 
 ## -see-also
 
-
-
-
-<a href="https://docs.microsoft.com/windows/desktop/api/d3d12/nn-d3d12-id3d12graphicscommandlist">ID3D12GraphicsCommandList</a>
- 
-
- 
-
+[ID3D12GraphicsCommandList interface](/windows/win32/api/d3d12/nn-d3d12-id3d12graphicscommandlist)

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
@@ -60,10 +60,10 @@ A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_
 
 Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a></b>
 
-A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a> that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
+A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a> in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
 
 > [!IMPORTANT]
-> This descriptor must not be in a shader-visible descriptor heap.
+> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers which implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in `WRITE_BACK` memory (similar to `D3D12_HEAP_TYPE_UPLOAD` heap types), and CPU reads from this type of memory are prohibitively slow
 
 ### -param pResource [in]
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
@@ -50,55 +50,57 @@ Sets all the elements in a unordered-access view (UAV) to the specified integer 
 
 ## -parameters
 
-### -param ViewGPUHandleInCurrentHeap [in]
+### -param ViewGPUHandleInCurrentHeap
 
-Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a></b>
+Type: [in] **[D3D12_GPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle)**
 
-A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a> that references an initialized descriptor for the unordered-access view that is to be cleared. This descriptor must be in a shader-visible descriptor heap, which must be set on the command list via [SetDescriptorHeaps](nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps.md).
+A [D3D12_GPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle) that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared. This descriptor must be in a shader-visible descriptor heap, which must be set on the command list via [SetDescriptorHeaps](nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps.md).
 
-### -param ViewCPUHandle [in]
+### -param ViewCPUHandle
 
-Type: <b><a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a></b>
+Type: [in] **[D3D12_CPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle)**
 
-A <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle">D3D12_CPU_DESCRIPTOR_HANDLE</a> in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
-
-> [!IMPORTANT]
-> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers which implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in `WRITE_BACK` memory (similar to `D3D12_HEAP_TYPE_UPLOAD` heap types), and CPU reads from this type of memory are prohibitively slow
-
-### -param pResource [in]
-
-Type: <b>ID3D12Resource\*</b>
-
-A pointer to the <a href="/windows/win32/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the unordered-access view resource to clear.
+A [D3D12_CPU_DESCRIPTOR_HANDLE](/windows/win32/api/d3d12/ns-d3d12-d3d12_cpu_descriptor_handle) in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
           
-### -param Values [in]
+> [!IMPORTANT]
+> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers thath implement the clear as fixed-function hardware (rather than via a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in **WRITE_BACK** memory (similar to **D3D12_HEAP_TYPE_UPLOAD** heap types), and CPU reads from this type of memory are prohibitively slow.
 
-Type: <b>const UINT[4]</b>
+### -param pResource
 
-A four-component array containing the values to fill the unordered-access view resource with.
+Type: [in] **[ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource)\***
 
-### -param NumRects [in]
+A pointer to the [ID3D12Resource](/windows/win32/api/d3d12/nn-d3d12-id3d12resource) interface that represents the unordered-access-view (UAV) resource to clear.
+          
+### -param Values
 
-Type: <b>UINT</b>
+Type: [in] **const UINT[4]**
 
-The number of rectangles in the array that the <i>pRects</i> parameter specifies.
+A 4-component array that containing the values to fill the unordered-access-view resource with.
 
-### -param pRects [in]
+### -param NumRects
 
-Type: <b>const D3D12_RECT*</b>
+Type: [in] **UINT**
 
-An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view to clear. If <b>NULL</b>, then <b>ClearUnorderedAccessViewUint</b> clears the entire resource view.
+The number of rectangles in the array that the *pRects* parameter specifies.
+
+### -param pRects
+
+Type: [in] **const [D3D12_RECT](/windows/win32/direct3d12/d3d12-rect)\***
+
+An array of **D3D12_RECT** structures for the rectangles in the resource view to clear. If **NULL**, **ClearUnorderedAccessViewUint** clears the entire resource view.
           
 ## -remarks
 
-<h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>
-Validation failure will result in the call to <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close">ID3D12GraphicsCommandList::Close</a> returning <b>E_INVALIDARG</b>.
+### Runtime validation
 
-<h3><a id="Debug_layer"></a><a id="debug_layer"></a><a id="DEBUG_LAYER"></a>Debug layer</h3>
-The debug layer will issue errors if the input values are outside of a normalized range.
+Validation failure results in the call to [ID3D12GraphicsCommandList::Close](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close) returning **E_INVALIDARG**.
 
-The debug layer will issue an error if the subresources referenced by the view are not in the appropriate state. For <b>ClearUnorderedAccessViewUint</b>, the state must be <a href="/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_UNORDERED_ACCESS</a>.
+### Debug layer
+
+The debug layer issues errors if the input values are outside of a normalized range.
+
+The debug layer issues an error if the subresources referenced by the view aren't in the appropriate state. For **ClearUnorderedAccessViewUint**, the state must be [D3D12_RESOURCE_STATE_UNORDERED_ACCESS](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states).
 
 ## -see-also
 
-[ID3D12GraphicsCommandList](/windows/win32/api/d3d12/nn-d3d12-id3d12graphicscommandlist)
+[ID3D12GraphicsCommandList interface](/windows/win32/api/d3d12/nn-d3d12-id3d12graphicscommandlist)


### PR DESCRIPTION
The page for float was different to that for UInt and didn't mention the restriction that the handle must be non shader-visible. Fixed that and also fixed any diffs between the 2, + added a note on why it must be shader opaque