### PR TITLE
Change example locale from en-FJ to en-XA for ResolveLocaleName

### DIFF
--- a/sdk-api-src/content/winnls/nf-winnls-resolvelocalename.md
+++ b/sdk-api-src/content/winnls/nf-winnls-resolvelocalename.md
@@ -67,12 +67,12 @@ Finds a possible <a href="https://docs.microsoft.com/windows/desktop/Intl/locale
 
 ### -param lpNameToResolve [in, optional]
 
-Pointer to a name to resolve, for example, "en-FJ" for English (Fiji).
+Pointer to a name to resolve, for example, "en-XA" for English (Private Use).
 
 
 ### -param lpLocaleName [out, optional]
 
-Pointer to a buffer in which this function retrieves the locale name that is the match for the input name. For example, the match for the name "en-FJ" is "en-US" for English (United States).
+Pointer to a buffer in which this function retrieves the locale name that is the match for the input name. For example, the match for the name "en-XA" is "en-US" for English (United States).
 
 <div class="alert"><b>Note</b>  If the function fails, the state of the output buffer is not guaranteed to be accurate. In this case, the application should check the return value and error status set by the function to determine the correct course of action.</div>
 <div> </div>


### PR DESCRIPTION
This PR removes "en-FJ" being used as an example of a fake or non existing locale. 

It seems that when [this](https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-resolvelocalename) doc file was created, en-FJ did not exist, but now it does so it doesn't make sense having it being used as an example of a fake locale being resolved into an existent one. 

@jefgen suggested that using that using a "Private Use" ISO region code might be better, as it can't be used for a real locale, and makes the example more obvious that it is a constructed locale

I did a search on the repo using vs code and the GitHub search and it seems this is the only file that uses en-FJ as an example, but it wouldn't hurt to keep an eye on other files that might be having the same problem.