### PR TITLE
Update nf-wincrypt-certverifycertificatechainpolicy.md

### DIFF
--- a/sdk-api-src/content/wincrypt/nf-wincrypt-certverifycertificatechainpolicy.md
+++ b/sdk-api-src/content/wincrypt/nf-wincrypt-certverifycertificatechainpolicy.md
@@ -161,7 +161,7 @@ Implements the Windows NT Authentication chain policy, which consists of three 
 <td width="60%">
 Checks the last element of the first simple chain for a Microsoft root public key. If that element does not contain a Microsoft root public key, the <b>dwError</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/wincrypt/ns-wincrypt-cert_chain_policy_status">CERT_CHAIN_POLICY_STATUS</a> structure pointed to by the <i>pPolicyStatus</i> parameter is set to <b>CERT_E_UNTRUSTEDROOT</b>.
 
-The <b>dwFlags</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/wincrypt/ns-wincrypt-cert_chain_policy_para">CERT_CHAIN_POLICY_PARA</a> structure pointed to by the <i>pPolicyStatus</i> parameter can contain the <b>MICROSOFT_ROOT_CERT_CHAIN_POLICY_CHECK_APPLICATION_ROOT_FLAG</b> flag, which causes this function to also check for the Microsoft application root "Microsoft Root Certificate Authority 2011".
+The <b>dwFlags</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/wincrypt/ns-wincrypt-cert_chain_policy_para">CERT_CHAIN_POLICY_PARA</a> structure pointed to by the <i>pPolicyStatus</i> parameter can contain the <b>MICROSOFT_ROOT_CERT_CHAIN_POLICY_CHECK_APPLICATION_ROOT_FLAG</b> flag, which causes this function to instead check for the Microsoft application root "Microsoft Root Certificate Authority 2011".
 
 The <b>dwFlags</b> member of the <a href="https://docs.microsoft.com/windows/desktop/api/wincrypt/ns-wincrypt-cert_chain_policy_para">CERT_CHAIN_POLICY_PARA</a> structure pointed to by the <i>pPolicyPara</i> parameter can contain the <b>MICROSOFT_ROOT_CERT_CHAIN_POLICY_ENABLE_TEST_ROOT_FLAG</b> flag, which causes this function to also check for the Microsoft test roots.
 


### PR DESCRIPTION
Using this flag does not check an additional certificate root, but instead changes which certificate root is used for validation.