### PR TITLE
Compress API missing minimum required client/server metadata

### DIFF
--- a/sdk-api-src/content/compressapi/ne-compressapi-compress_information_class.md
+++ b/sdk-api-src/content/compressapi/ne-compressapi-compress_information_class.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-closecompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-closecompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-closedecompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-closedecompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-compress.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-compress.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-createcompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-createcompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-createdecompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-createdecompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-decompress.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-decompress.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-querycompressorinformation.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-querycompressorinformation.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-querydecompressorinformation.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-querydecompressorinformation.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-resetcompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-resetcompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-resetdecompressor.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-resetdecompressor.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-setcompressorinformation.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-setcompressorinformation.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/nf-compressapi-setdecompressorinformation.md
+++ b/sdk-api-src/content/compressapi/nf-compressapi-setdecompressorinformation.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/compressapi/ns-compressapi-compress_allocation_routines.md
+++ b/sdk-api-src/content/compressapi/ns-compressapi-compress_allocation_routines.md
@@ -15,8 +15,8 @@ dev_langs:
 req.header: compressapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
All the Compress API pages are missing the 'required minimum client/server' information. The header and main page indicate it's Windows 8 or later.