### PR TITLE
Removed the information about the maximum size limit for SetEnvironmentVariableW and GetEnvironmentVariableW methods

### DIFF
--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
@@ -74,6 +74,7 @@ The name of the environment variable.
 
 A pointer to a buffer that receives the contents of the specified environment variable as a null-terminated string.
 
+The maximum size of a user-defined environment variable is 32,767 characters. There is no technical limitation on the size of the environment block. However, there are practical limits depending on the mechanism used to access the block. For example, a batch file cannot set a variable that is longer than the maximum command line length. For more information, see [Environment Variables](/windows/desktop/ProcThread/environment-variables).
 
 ### -param nSize [in]
 

--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
@@ -72,7 +72,7 @@ The name of the environment variable.
 
 ### -param lpBuffer [out, optional]
 
-A pointer to a buffer that receives the contents of the specified environment variable as a null-terminated string. An environment variable has a maximum size limit of 32,767 characters, including the null-terminating character.
+A pointer to a buffer that receives the contents of the specified environment variable as a null-terminated string.
 
 
 ### -param nSize [in]

--- a/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
@@ -72,8 +72,9 @@ The name of the environment variable. The operating system creates the environme
 
 ### -param lpValue [in, optional]
 
-The contents of the environment variable. For more information, see 
-<a href="https://docs.microsoft.com/windows/desktop/ProcThread/environment-variables">Environment Variables</a>.
+The contents of the environment variable. 
+
+The maximum size of a user-defined environment variable is 32,767 characters. There is no technical limitation on the size of the environment block. However, there are practical limits depending on the mechanism used to access the block. For example, a batch file cannot set a variable that is longer than the maximum command line length. For more information, see [Environment Variables](/windows/desktop/ProcThread/environment-variables).
 
 <b>Windows Server 2003 and Windows XP:  </b>The total size of the environment block for a process may not exceed 32,767 characters.
 

--- a/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
@@ -72,7 +72,7 @@ The name of the environment variable. The operating system creates the environme
 
 ### -param lpValue [in, optional]
 
-The contents of the environment variable. The maximum size of a user-defined environment variable is 32,767 characters. For more information, see 
+The contents of the environment variable. For more information, see 
 <a href="https://docs.microsoft.com/windows/desktop/ProcThread/environment-variables">Environment Variables</a>.
 
 <b>Windows Server 2003 and Windows XP:  </b>The total size of the environment block for a process may not exceed 32,767 characters.


### PR DESCRIPTION
I was trying to simulate the problem reported at https://github.com/dotnet/msbuild/issues/1765 and during some tests with the `SetEnvironmentVariableW` and `GetEnvironmentVariableW` methods I did not find the maximum character limits as explained in the documentation. I only received the "ERROR_NO_SYSTEM_RESOURCES" error message when entering a huge value, so I removed the message limit in the documentation.

Here is an example of a test that I did (with 64bits process):

```
#define VARNAME_W L"MyVariable"
#define BUFSIZE 900000000

int TestW()
{
	int result = 0;
	wstring inputString(BUFSIZE, 'a');
	const wchar_t* input = inputString.c_str();

	if (!SetEnvironmentVariableW(VARNAME_W, input))
	{
		printf("SetEnvironmentVariableW failed (%d)\n", GetLastError());
		result = 1;
	}
	else
	{
		wchar_t* output = new wchar_t[BUFSIZE + 1];
		DWORD getResult = GetEnvironmentVariableW(VARNAME_W, output, BUFSIZE + 1);
		if (getResult != BUFSIZE)
		{
			printf("GetEnvironmentVariableW failed (%d)\n", GetLastError());
			result = 2;
		}
		else
		{
			printf("GetEnvironmentVariableW: %ls\n", output);
		}
		delete[] output;
	}
	return result;
}
```