### PR TITLE
updating req.lib

### DIFF
--- a/sdk-api-src/content/mfidl/nf-mfidl-mfcreatesourceresolver.md
+++ b/sdk-api-src/content/mfidl/nf-mfidl-mfcreatesourceresolver.md
@@ -26,7 +26,7 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Mf.lib
+req.lib: Mfplat.lib
 req.dll: Mfplat.dll
 req.irql: 
 topic_type:


### PR DESCRIPTION
Applications using this function should be linked against mfplat.lib. Tested on Windows 8 with MSVC 19 for x64.