### PR TITLE
Update nf-shlwapi-pathfileexistsw.md

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
@@ -77,7 +77,7 @@ A pointer to a null-terminated string of maximum length MAX_PATH that contains t
 
 Type: <b>BOOL</b>
 
-<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. Note that if the file does not exist, <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>.
+<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. If the file does not exist, <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="https://docs.microsoft.com/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>.
 
 
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
@@ -77,7 +77,7 @@ A pointer to a null-terminated string of maximum length MAX_PATH that contains t
 
 Type: <b>BOOL</b>
 
-<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
+<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. Note that if the file does not exist, <a href="https://docs.microsoft.com/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>.
 
 
 


### PR DESCRIPTION
Should be more clear about GetLastError returning non-zero value when the file doesn't exist.