### PR TITLE
EnterCriticalSection: Note about processes currently exiting

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
@@ -111,6 +111,7 @@ If a thread terminates while it has ownership of a critical section, the state o
 
 If a critical section is deleted while it is still owned, the state of the threads waiting for ownership of the deleted critical section is undefined.
 
+While a process is exiting, if a call to <b>EnterCriticalSection</b> would block, it will instead terminate the process immediately. This may cause global destructors to not be called.
 
 #### Examples
 


### PR DESCRIPTION
According to https://devblogs.microsoft.com/oldnewthing/20100122-00/?p=15193 (and observed behavior), a call to EnterCriticalSection that blocks will terminate if the process is in the middle of exiting.