### PR TITLE
Escape backslash

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulehandlea.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulehandlea.md
@@ -69,7 +69,7 @@ To avoid the race conditions described in the Remarks section, use the
 
 ### -param lpModuleName [in, optional]
 
-The name of the loaded module (either a .dll or .exe file). If the file name extension is omitted, the default library extension .dll is appended. The file name string can include a trailing point character (.) to indicate that the module name has no extension. The string does not have to specify a path. When specifying a path, be sure to use backslashes (\), not forward slashes (/). The name is compared (case independently) to the names of modules currently mapped into the address space of the calling process. 
+The name of the loaded module (either a .dll or .exe file). If the file name extension is omitted, the default library extension .dll is appended. The file name string can include a trailing point character (.) to indicate that the module name has no extension. The string does not have to specify a path. When specifying a path, be sure to use backslashes (\\), not forward slashes (/). The name is compared (case independently) to the names of modules currently mapped into the address space of the calling process. 
 
 
 


### PR DESCRIPTION
The backslash is not shown on the homepage because it is not escaped.

This PR escapes the backslash so it's shown as intended.