### PR TITLE
MDNS_QUERY_CALLBACK: correct function in "pQueryContext" parameter description

### DIFF
--- a/sdk-api-src/content/windns/nc-windns-mdns_query_callback.md
+++ b/sdk-api-src/content/windns/nc-windns-mdns_query_callback.md
@@ -55,7 +55,7 @@ Used to asynchronously return the results of an mDNS query.
 
 ### -param pQueryContext
 
-A pointer to the user context that was passed to [DnsServiceBrowse](nf-windns-dnsservicebrowse.md).
+A pointer to the user context that was passed to [DnsStartMulticastQuery](nf-windns-dnsstartmulticastquery.md).
 
 ### -param pQueryHandle
 


### PR DESCRIPTION
`DnsServiceBrowse()` accepts `DNS_SERVICE_BROWSE_CALLBACK` and `DNS_QUERY_COMPLETION_ROUTINE` as callback function.

`MDNS_QUERY_CALLBACK` is only accepted by `DnsStartMulticastQuery()`.