### PR TITLE
Adjusted WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE members layout

### DIFF
--- a/sdk-api-src/content/wlanapi/ns-wlanapi-wlan_hosted_network_data_peer_state_change.md
+++ b/sdk-api-src/content/wlanapi/ns-wlanapi-wlan_hosted_network_data_peer_state_change.md
@@ -66,9 +66,9 @@ The previous network state for a data peer on the wireless Hosted Network.
 
 The current network state for a data peer on the wireless Hosted Network.
 
-The reason for the network state change for the data peer.
-
 ### -field PeerStateChangeReason
+
+The reason for the network state change for the data peer.
 
 ## -remarks
 


### PR DESCRIPTION
Placed `PeerStateChangeReason` description where it belongs