### PR TITLE
Update nf-winuser-wsprintfw.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
@@ -57,13 +57,13 @@ Writes formatted data to the specified buffer. Any arguments are converted and c
 
 ## -parameters
 
-### -param arg1 [out]
+### -param str [out]
 
 Type: <b>LPTSTR</b>
 
-The buffer that is to receive the formatted output. The maximum size of the buffer is 1,024 bytes.
+The buffer that is to receive the formatted output. The maximum size of the buffer is 2050 bytes.
 
-### -param arg2 [in]
+### -param format [in]
 
 Type: <b>LPCTSTR</b>
 


### PR DESCRIPTION
Fixed argument names and max buffer size.