### PR TITLE
Update ne-shldisp-shellspecialfolderconstants.md

### DIFF
--- a/sdk-api-src/content/shldisp/ne-shldisp-shellspecialfolderconstants.md
+++ b/sdk-api-src/content/shldisp/ne-shldisp-shellspecialfolderconstants.md
@@ -245,7 +245,7 @@ Specifies unique, system-independent values that identify special folders. These
 
 ### -field ssfPROGRAMFILESx86
 
-0x30 (48). <a href="https://docs.microsoft.com/previous-versions/windows/desktop/legacy/bb776779(v=vs.85)">Version 6.0</a>. Program Files folder. A typical path is C:\Program Files, or C:\Program Files (X86) on a 64-bit computer.
+0x2a (42). <a href="https://docs.microsoft.com/previous-versions/windows/desktop/legacy/bb776779(v=vs.85)">Version 6.0</a>. Program Files folder. A typical path is C:\Program Files, or C:\Program Files (X86) on a 64-bit computer.
 
 
 ## -remarks


### PR DESCRIPTION
Initial request comment:

>Checked this against shlobj.h.
Suspect someone was counting decimal 28, 29, 30 instead of hex 0x28, 0x29, 0x2a

Reply:

>Thanks for submitting your feedback. I checked the declaration of the ssfPROGRAMFILESx86 value in shldisp.h (the header file referenced in this article), and it looks like this value is in fact assigned to the hex value 0x30 there. Based on this, I'm closing this pull request to change the article. However, if I'm misunderstanding something or you feel this is being closed in error, please do reopen with more info.

>Here's what I'm seeing in the header:

        . . .
        ssfMYPICTURES	= 0x27,
        ssfPROFILE	= 0x28,
        ssfSYSTEMx86	= 0x29,
        ssfPROGRAMFILESx86	= 0x30
    } 	ShellSpecialFolderConstants;

Response:

Did extensive research based on request closed reply. Tried to interpret remarks in index.md as **NOT** implying that constants in `enum ShellSpecialFolderConstants`  should equal CSIDL #defines in shlobj.h (where I looked instead of shldisp.h), specifically
```
#define CSIDL_PROGRAM_FILESX86          0x002a        // x86 C:\Program Files on RISC
#define CSIDL_ADMINTOOLS                0x0030        // <user name>\Start Menu\Programs\Administrative Tools
```
Tried searching for functions/methods referenced in shldisp.h taking a `ShellSpecialFolderConstants` as a parameter without any success. Finally tried directly searching for "shellspecialfolderconstants". Fourth item returned was `Shell.Explore` method (https://docs.microsoft.com/en-us/windows/win32/shell/shell-explore). But this is a method of the `Shell.Application` COM object (see examples in `Shell.Explore` documentation). This object takes CSIDL values, as shown by the following Powershell
```
PS> $shlapp=new-object -com shell.application
PS> $shlapp.namespace(42).self.path # 0x2a
C:\Program Files (x86)
PS> $shlapp.namespace(48).self.path # 0x30
(%USERPROFILE%)\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Administrative Tools
```
**BUT** the documentation for `Shell.Explore` explicitly states that the parameter (vDir) is either a `string` or a `ShellSpecialFolderConstants`. This would strongly suggest that the values for `ShellSpecialFolderConstants` should **exactly** equal the CSIDL values for the corresponding folders.

This results in 2 basic possibilities:
1) The documentation for methods of `Shell.Application` is incorrect and any non-string vDir parameters are actually CSIDL values (which do not necessarily equal `ShellSpecialFolderConstants` values), or
2) The documentation for (and actual header?) shldisp.h is (/ has become) incorrect. Though it might seem unlikely, it is possible that the deprecation of `ShellSpecialFolderConstants` in favour of CSIDL (and then KNOWNFOLDERID) values occurred sufficiently before the substantial penetration of 64-bit Windows so the error never significantly manifested.

Unfortunately, without any details of an API that uses it, I am unable at this time to perform any direct tests using `ShellSpecialFolderConstants` (even if I had an appropriate ADE).
