### PR TITLE
Update ns-tlhelp32-processentry32.md

### DIFF
--- a/sdk-api-src/content/tlhelp32/ns-tlhelp32-processentry32.md
+++ b/sdk-api-src/content/tlhelp32/ns-tlhelp32-processentry32.md
@@ -94,7 +94,7 @@ The base priority of any threads created by this process.
 
 ### -field dwFlags
 
-This member is no longer used, and is always set to zero.
+This member is no longer used and is always set to zero.
 
 ### -field szExeFile
 


### PR DESCRIPTION
Consistency with other "This member is no longer used and is always set to zero." sentences.