### PR TITLE
Fixed NL_NETWORK_CONNECTIVITY_LEVEL_HINT values description

### DIFF
--- a/sdk-api-src/content/nldef/ne-nldef-nl_network_connectivity_level_hint.md
+++ b/sdk-api-src/content/nldef/ne-nldef-nl_network_connectivity_level_hint.md
@@ -63,11 +63,11 @@ Specifies a hint for no connectivity.
 
 ### -field NetworkConnectivityLevelHintLocalAccess
 
-Specifies a hint for local and internet access.
+Specifies a hint for local network access only.
 
 ### -field NetworkConnectivityLevelHintInternetAccess
 
-Specifies a hint for local network access only.
+Specifies a hint for local and internet access.
 
 ### -field NetworkConnectivityLevelHintConstrainedInternetAccess
 


### PR DESCRIPTION
Swapped description for `NetworkConnectivityLevelHintLocalAccess` and `NetworkConnectivityLevelHintInternetAccess` as they were misplaced.