### PR TITLE
Convert HTML to Markdown (PM_COLLECT_PROC)

### DIFF
--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -70,9 +70,7 @@ Type: **LPVOID \***
 
 Consumer-allocated buffer that contains the performance data.
 
-Here, *pData* refers to the pointer pointed by *lppData* (`*lppData = pData`).
-
-On output, set *pData* to one byte past the end of your data. The data must conform to the [PERF_OBJECT_TYPE](ns-winperf-perf_object_type.md) structure.
+On output (where *pData* refers to the pointer pointed to by *lppData*), set *pData* to one byte past the end of your data. Note that the data must conform to the [PERF_OBJECT_TYPE](ns-winperf-perf_object_type.md) structure.
 
 If this function fails, leave the *pData* pointer value unchanged.
 
@@ -80,7 +78,7 @@ If this function fails, leave the *pData* pointer value unchanged.
 
 Type: **LPDWORD**
 
-On input, specifies the size, in bytes, of the *pData* buffer.
+On input, specifies the size, in bytes, of the *pData* buffer (where *pData* refers to the pointer pointed to by *lppData*).
 
 On output, set *lpcbTotalBytes* to the size, in bytes, of the data written to the *pData* buffer. The size must be 8-byte aligned.
 
@@ -90,29 +88,29 @@ If this function fails, set *lpcbTotalBytes* to zero.
 
 Type: **LPDWORD**
 
-Set *lpNumObjectTypes* to the number of object [types](ns-winperf-perf_object_type.md) (not [instances](ns-winperf-perf_instance_definition.md)) written to the *pData* buffer.
+Set *lpNumObjectTypes* to the number of object [types](ns-winperf-perf_object_type.md) (not [instances](ns-winperf-perf_instance_definition.md)) written to the *pData* buffer (where *pData* refers to the pointer pointed to by *lppData*).
 
 If this function fails, set *lpNumObjectTypes* to zero.
 
 > [!NOTE]
-> This parameter is annotated as both *In* and *Out*. Actually the pointee (the value behind this pointer) is never used as an input, and there are no contracts about its content upon function callback invokation: it is best to assume that the pointee is uninitialized and contains garbage data.
+> This parameter is annotated as both *In* and *Out*, however this parameter should not be used as input. 
 
 ## -returns
 
-Return one of the following return values only.
+One of the following values:
 
 | Return code | Description |
 |-------------|-------------|
-| **ERROR_MORE_DATA** | The size of the *pData* buffer as specified by *lpcbTotalBytes* is not large enough to store the data. Leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this can change before the next call. |
+| **ERROR_MORE_DATA** | The size of the *pData* buffer (where *pData* refers to the pointer pointed to by *lppData*) as specified by *lpcbTotalBytes* is not large enough to store the data. Leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this can change before the next call. |
 | **ERROR_SUCCESS** | Return this value in all cases other than the **ERROR_MORE_DATA** case, even if no data is returned or an error occurs. To report errors other than insufficient buffer size, use the Application Event Log. |
 
 ## -remarks
 
-If the requested objects specified in the *lpValueName* parameter do not correspond to any of the object indexes that your performance DLL supports, leave the *pData* parameter unchanged, and set the *lpcbTotalBytes* and *lpNumObjectTypes* parameters to zero. This indicates that no data was returned.
+If the requested objects specified in the *lpValueName* parameter do not correspond to any of the object indexes that your performance DLL supports, leave the *pData* parameter (where *pData* refers to the pointer pointed to by *lppData*) unchanged, and set the *lpcbTotalBytes* and *lpNumObjectTypes* parameters to zero. This indicates that no data was returned.
 
 If you support one or more of the queried objects, determine whether the size of the *pData* buffer as specified by *lpcbTotalBytes* is large enough to store the data. If not, leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this may change before the next call. Return **ERROR_MORE_DATA**.
 
-If your data collection is time-consuming, you should respond only to queries for specific objects and `Costly` queries. You should also lower the priority of the thread collecting the data, so that it does not adversely affect system performance. For the query string format, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
+If your data collection is time-consuming, you should respond only to queries for specific objects, or costly queries. You should also lower the priority of the thread collecting the data, so that it does not adversely affect system performance. For the query string format, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
 
 If the consumer is running on another computer (remotely), then the <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>, [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc), and **CollectPerformanceData** functions are called in the context of the Winlogon process, which handles the server side of the remote connection. This distinction is important when troubleshooting problems that occur only remotely.
 

--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -106,7 +106,7 @@ One of the following values:
 
 ## -remarks
 
-If the requested objects specified in the *lpValueName* parameter do not correspond to any of the object indexes that your performance DLL supports, leave the *pData* parameter (where *pData* refers to the pointer pointed to by *lppData*) unchanged, and set the *lpcbTotalBytes* and *lpNumObjectTypes* parameters to zero. This indicates that no data was returned.
+If the requested objects specified in the *lpValueName* parameter do not correspond to any of the object indexes that your performance DLL supports, leave the *pData* parameter unchanged (where *pData* refers to the pointer pointed to by *lppData*), and set the *lpcbTotalBytes* and *lpNumObjectTypes* parameters to zero. This indicates that no data was returned.
 
 If you support one or more of the queried objects, determine whether the size of the *pData* buffer as specified by *lpcbTotalBytes* is large enough to store the data. If not, leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this may change before the next call. Return **ERROR_MORE_DATA**.
 

--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -144,5 +144,5 @@ See [Implementing CollectPerformanceData](/windows/desktop/PerfCtrs/implementing
 
 ## -see-also
 
-- [OpenPerformanceData](/previous-versions/windows/desktop/legacy/aa372200)
+- [OpenPerformanceData](/previous-versions/windows/desktop/legacy/aa372200(v=vs.85))
 - [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc)

--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -59,23 +59,20 @@ The **CollectPerformanceData** function is a placeholder for the application-def
 
 Type: **LPWSTR**
 
-Null-terminated string that contains the query string (for example, "Global" or "238") passed to the [RegQueryValueEx](/windows/desktop/api/winreg/nf-winreg-regqueryvalueexa) function. For the query string format, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
+Null-terminated string that contains the query string (for example, "Global" or "238") passed to the [RegQueryValueEx](/windows/desktop/api/winreg/nf-winreg-regqueryvalueexa) function. For a list of possible values for *lpValueName*, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
 
 > [!NOTE]
-> This parameter is annotated as optional (nullable). The semantics of a null query was never explained, however, in practice it never happens to be null. Furthermore, queries against performance counters **HKEY**s via **RegQueryValueEx** are meaningless without a valid *lpValueName* parameter, which is exactly this query string. Running such null query results in `Error Code 0x00000057: The parameter is incorrect.`
->
-> With that being said, you should always verify input data, and if this parameter turns out to be null, the callback function should fail early. Check descriptions of other parameters on how to fail properly.
+> This parameter is annotated as optional (nullable), however a null value is not valid and can result in an error.
 
 ### -param lppData [in, out]
 
 Type: **LPVOID \***
 
-Consumer-allocated buffer that will contain the performance data.
+Consumer-allocated buffer that contains the performance data.
 
-Here, *pData* refers to the pointer pointed by *lppData*, i.e. `*lppData = pData`.
+Here, *pData* refers to the pointer pointed by *lppData* (`*lppData = pData`).
 
-On output, set *pData* to one byte past the end of your data. The data must conform to the 
-[PERF_OBJECT_TYPE](ns-winperf-perf_object_type.md) structure.
+On output, set *pData* to one byte past the end of your data. The data must conform to the [PERF_OBJECT_TYPE](ns-winperf-perf_object_type.md) structure.
 
 If this function fails, leave the *pData* pointer value unchanged.
 
@@ -143,9 +140,9 @@ The following tests are performed only if test level 1 is used:
 
 #### Examples
 
-For an example, see [Implementing CollectPerformanceData](/windows/desktop/PerfCtrs/implementing-collectperformancedata).
+See [Implementing CollectPerformanceData](/windows/desktop/PerfCtrs/implementing-collectperformancedata).
 
 ## -see-also
 
-- <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>
+- [OpenPerformanceData](/previous-versions/windows/desktop/legacy/aa372200)
 - [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc)

--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -144,5 +144,5 @@ See [Implementing CollectPerformanceData](/windows/desktop/PerfCtrs/implementing
 
 ## -see-also
 
-- [OpenPerformanceData](/previous-versions/windows/desktop/legacy/aa372200(v=vs.85))
+- <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>
 - [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc)

--- a/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
+++ b/sdk-api-src/content/winperf/nc-winperf-pm_collect_proc.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["CollectPerformanceData","CollectPerformanceData callback 
 old-location: perf\collectperformancedata.htm
 tech.root: perf
 ms.assetid: 9903eb4b-017b-47df-81c5-98c4e1ac697d
-ms.date: 12/05/2018
+ms.date: 24/09/2020
 ms.keywords: CollectPerformanceData, CollectPerformanceData callback function [Perf], PM_COLLECT_PROC, PM_COLLECT_PROC callback, base.collectperformancedata, perf.collectperformancedata, winperf/CollectPerformanceData
 req.header: winperf.h
 req.include-header: 
@@ -47,154 +47,105 @@ api_name:
 
 # PM_COLLECT_PROC callback function
 
-
 ## -description
 
 Collects the performance data and returns it to the consumer. Implement and export this function if you are writing a performance DLL to provide performance data. The system calls this function whenever a consumer queries the registry for performance data. 
 
-The <b>CollectPerformanceData</b> function is a placeholder for the application-defined function name.
+The **CollectPerformanceData** function is a placeholder for the application-defined function name.
 
 ## -parameters
 
-### -param lpValueName
+### -param lpValueName [in, optional]
 
-Null-terminated string that contains the query string (for example, "Global" or "238") passed to the <a href="/windows/desktop/api/winreg/nf-winreg-regqueryvalueexa">RegQueryValueEx</a> function. For possible query string values, see <a href="/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data">Using the Registry Functions to Consume Counter Data</a>.
+Type: **LPWSTR**
 
-### -param *lppData
+Null-terminated string that contains the query string (for example, "Global" or "238") passed to the [RegQueryValueEx](/windows/desktop/api/winreg/nf-winreg-regqueryvalueexa) function. For the query string format, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
 
-### -param lpcbTotalBytes
+> [!NOTE]
+> This parameter is annotated as optional (nullable). The semantics of a null query was never explained, however, in practice it never happens to be null. Furthermore, queries against performance counters **HKEY**s via **RegQueryValueEx** are meaningless without a valid *lpValueName* parameter, which is exactly this query string. Running such null query results in `Error Code 0x00000057: The parameter is incorrect.`
+>
+> With that being said, you should always verify input data, and if this parameter turns out to be null, the callback function should fail early. Check descriptions of other parameters on how to fail properly.
 
-On input, specifies the size, in bytes, of the <i>pData</i> buffer. 
+### -param lppData [in, out]
 
-On output, set <i>pcbData</i> to the size, in bytes, of the data written to the <i>pData</i> buffer. The size must be 8-byte aligned. 
+Type: **LPVOID \***
 
-If this function fails, set <i>pcbData</i> to zero.
+Consumer-allocated buffer that will contain the performance data.
 
-### -param lpNumObjectTypes
+Here, *pData* refers to the pointer pointed by *lppData*, i.e. `*lppData = pData`.
 
-Number of objects returned in <i>pData</i>. 
+On output, set *pData* to one byte past the end of your data. The data must conform to the 
+[PERF_OBJECT_TYPE](ns-winperf-perf_object_type.md) structure.
 
-If this function fails, set <i>pObjectsReturned</i> to zero.
+If this function fails, leave the *pData* pointer value unchanged.
 
+### -param lpcbTotalBytes [in, out]
 
-#### - pData
+Type: **LPDWORD**
 
-Consumer-allocated buffer that will contain the performance data. 
+On input, specifies the size, in bytes, of the *pData* buffer.
 
-On output, set <i>pData</i> to one byte past the end of your data. The data must conform to the 
-<a href="/windows/desktop/api/winperf/ns-winperf-perf_object_type">PERF_OBJECT_TYPE</a> structure.
+On output, set *lpcbTotalBytes* to the size, in bytes, of the data written to the *pData* buffer. The size must be 8-byte aligned.
 
-If this function fails, leave the <i>pData</i> pointer value unchanged.
+If this function fails, set *lpcbTotalBytes* to zero.
+
+### -param lpNumObjectTypes [in, out]
+
+Type: **LPDWORD**
+
+Set *lpNumObjectTypes* to the number of object [types](ns-winperf-perf_object_type.md) (not [instances](ns-winperf-perf_instance_definition.md)) written to the *pData* buffer.
+
+If this function fails, set *lpNumObjectTypes* to zero.
+
+> [!NOTE]
+> This parameter is annotated as both *In* and *Out*. Actually the pointee (the value behind this pointer) is never used as an input, and there are no contracts about its content upon function callback invokation: it is best to assume that the pointee is uninitialized and contains garbage data.
 
 ## -returns
 
 Return one of the following return values only.
 
-<table>
-<tr>
-<th>Return code</th>
-<th>Description</th>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>ERROR_MORE_DATA</b></dt>
-</dl>
-</td>
-<td width="60%">
-The size of the <i>pData</i> buffer as specified by <i>pcbData</i> is not large enough to store the data. Leave <i>pData</i> unchanged, and set <i>pcbData</i> and <i>pObjectsReturned</i> to zero. No attempt is made to indicate the required buffer size, because this can change before the next call.
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>ERROR_SUCCESS</b></dt>
-</dl>
-</td>
-<td width="60%">
-Return this value in all cases other than the ERROR_MORE_DATA case, even if no data is returned or an error occurs. To report errors other than insufficient buffer size, use the Application Event Log.
-
-</td>
-</tr>
-</table>
+| Return code | Description |
+|-------------|-------------|
+| **ERROR_MORE_DATA** | The size of the *pData* buffer as specified by *lpcbTotalBytes* is not large enough to store the data. Leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this can change before the next call. |
+| **ERROR_SUCCESS** | Return this value in all cases other than the **ERROR_MORE_DATA** case, even if no data is returned or an error occurs. To report errors other than insufficient buffer size, use the Application Event Log. |
 
 ## -remarks
 
-If the requested objects specified in the <i>pQuery</i> parameter do not correspond to any of the object indexes that your performance DLL supports, leave the <i>pData</i> parameter unchanged, and set the <i>pcbData</i> and <i>pObjectsReturned</i> parameters to zero. This indicates that no data is returned. 
+If the requested objects specified in the *lpValueName* parameter do not correspond to any of the object indexes that your performance DLL supports, leave the *pData* parameter unchanged, and set the *lpcbTotalBytes* and *lpNumObjectTypes* parameters to zero. This indicates that no data was returned.
 
-If you support one or more of the queried objects, determine whether the size of the <i>pData</i> buffer as specified by <i>pcbData</i> is large enough to store the data. If not, leave <i>pData</i> unchanged, and set <i>pcbData</i> and <i>pObjectsReturned</i> to zero. No attempt is made to indicate the required buffer size, because this may change before the next call. Return ERROR_MORE_DATA.
+If you support one or more of the queried objects, determine whether the size of the *pData* buffer as specified by *lpcbTotalBytes* is large enough to store the data. If not, leave *pData* unchanged, and set *lpcbTotalBytes* and *lpNumObjectTypes* to zero. No attempt is made to indicate the required buffer size, because this may change before the next call. Return **ERROR_MORE_DATA**.
 
-If your data collection is time-consuming, you should respond only to queries for specific objects and Costly queries. You should also lower the priority of the thread collecting the data, so that it does not adversely affect system performance.
+If your data collection is time-consuming, you should respond only to queries for specific objects and `Costly` queries. You should also lower the priority of the thread collecting the data, so that it does not adversely affect system performance. For the query string format, see [Using the Registry Functions to Consume Counter Data](/windows/desktop/PerfCtrs/using-the-registry-functions-to-consume-counter-data).
 
-If the consumer is running on another computer (remotely), then the <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>, <a href="/windows/desktop/api/winperf/nc-winperf-pm_close_proc">ClosePerformanceData</a>, and <b>CollectPerformanceData</b> functions are called in the context of the Winlogon process, which handles the server side of the remote connection. This distinction is important when troubleshooting problems that occur only remotely.
+If the consumer is running on another computer (remotely), then the <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>, [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc), and **CollectPerformanceData** functions are called in the context of the Winlogon process, which handles the server side of the remote connection. This distinction is important when troubleshooting problems that occur only remotely.
 
-After your function returns successfully, the system can perform some basic tests to ensure the integrity of the data. By default, no tests are performed. If a test fails, the system generates an event log message and the data is discarded to prevent any further problems due to pointers that are not valid. The following registry value controls the test level.<pre xml:space="preserve"><b>HKEY_LOCAL_MACHINE</b>
-   <b>Software</b>
-      <b>Microsoft</b>
-         <b>Windows NT</b>
-            <b>CurrentVersion</b>
-               <b>Perflib</b>
-                  <b>ExtCounterTestLevel</b></pre>
+After your function returns successfully, the system can perform some basic tests to ensure the integrity of the data. By default, no tests are performed. If a test fails, the system generates an event log message and the data is discarded to prevent any further problems due to pointers that are not valid. The following registry value controls the test level: `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Perflib\ExtCounterTestLevel`.
 
+The following are the possible test levels for **ExtCounterTestLevel**. 
 
-
-				
-				The following are the possible test levels for <b>ExtCounterTestLevel</b>. 
-
-<table>
-<tr>
-<th>Level</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td>1</td>
-<td>Test the pointers and buffers of trusted counter DLLs. Sends a copy of the user's buffer.</td>
-</tr>
-<tr>
-<td>2</td>
-<td>Test pointers and buffer lengths but does not test pointer references or buffer contents. Sends a copy of the user's buffer.</td>
-</tr>
-<tr>
-<td>3</td>
-<td>Do not test pointers or buffers. Sends a copy of the user's buffer.</td>
-</tr>
-<tr>
-<td>4</td>
-<td>Do not test pointers or buffers. Sends the user's buffer, not a copy.This is the default value.
-
-</td>
-</tr>
-</table>
- 
+| Level | Meaning |
+|-------|---------|
+| 1 | Test the pointers and buffers of trusted counter DLLs. Sends a copy of the user's buffer. |
+| 2 | Test pointers and buffer lengths but does not test pointer references or buffer contents. Sends a copy of the user's buffer. |
+| 3 | Do not test pointers or buffers. Sends a copy of the user's buffer. |
+| 4 | Do not test pointers or buffers. Sends the user's buffer, not a copy. This is the default value. |
 
 The following tests are performed at levels 1 and 2:
-				
 
-<ul>
-<li>Verifies that the value of <i>pcbData</i> is consistent with the returned buffer pointer, <i>pData</i>. If you add the <i>pcbData</i> value to the original buffer pointer passed to this function, you should end up with the same buffer pointer returned by this function. If they are not the same, a error message is logged and the data is ignored.</li>
-<li>Verify that a buffer overrun did not occur. The system adds a 1-KB guard page before and after the consumer-allocated buffer. If the returned buffer pointer, <i>pData</i>, points past the first byte of the appended guard page, then it is assumed that the buffer is not valid and the data is ignored. If the buffer pointer exceeds the end of the buffer, but not the end of the guard page, then a buffer overrun error is logged. If the buffer pointer is past the end of the guard page, then a heap error is logged because the heap that the buffer was allocated from could have been corrupted, causing other memory errors.</li>
-<li>Verify that the guard pages have not been corrupted. The 1-KB guard pages that were added before and after the buffer are initialized with a data pattern before this function is called. This data pattern is checked after the collect procedure returns. If any discrepancy is detected, a buffer overrun or other memory error is assumed and the data is ignored.</li>
-</ul>
+- Verifies that the value of *lpcbTotalBytes* is consistent with the returned buffer pointer, *pData*. If you add the *lpcbTotalBytes* value to the original buffer pointer passed to this function, you should end up with the same buffer pointer returned by this function. If they are not the same, a error message is logged and the data is ignored.
+- Verify that a buffer overrun did not occur. The system adds a 1-KB guard page before and after the consumer-allocated buffer. If the returned buffer pointer, *pData*, points past the first byte of the appended guard page, then it is assumed that the buffer is not valid and the data is ignored. If the buffer pointer exceeds the end of the buffer, but not the end of the guard page, then a buffer overrun error is logged. If the buffer pointer is past the end of the guard page, then a heap error is logged because the heap that the buffer was allocated from could have been corrupted, causing other memory errors.
+- Verify that the guard pages have not been corrupted. The 1-KB guard pages that were added before and after the buffer are initialized with a data pattern before this function is called. This data pattern is checked after the collect procedure returns. If any discrepancy is detected, a buffer overrun or other memory error is assumed and the data is ignored.
 
-				The following tests are performed only if test level 1 is used:
-				
+The following tests are performed only if test level 1 is used:
 
-<ul>
-<li>Verify that the sum of each object's <b>TotalByteLength</b> member is the same as the value of <i>pcbData</i>. If not, the data is ignored.</li>
-<li>Verify that the <b>ByteLength</b> member of each instance is consistent. The lengths are consistent if the next object or end of buffer follows the last instance. If not, the data is ignored.</li>
-</ul>
+- Verify that the sum of each object's **TotalByteLength** member is the same as the value of *lpcbTotalBytes*. If not, the data is ignored.
+- Verify that the **ByteLength** member of each instance is consistent. The lengths are consistent if the next object or end of buffer follows the last instance. If not, the data is ignored.
 
 #### Examples
 
-For an example, see <a href="/windows/desktop/PerfCtrs/implementing-collectperformancedata">Implementing CollectPerformanceData</a>.
-
-<div class="code"></div>
+For an example, see [Implementing CollectPerformanceData](/windows/desktop/PerfCtrs/implementing-collectperformancedata).
 
 ## -see-also
 
-<a href="/windows/desktop/api/winperf/nc-winperf-pm_close_proc">ClosePerformanceData</a>
-
-
-
-<a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>
+- <a href="/previous-versions/windows/desktop/legacy/aa372200(v=vs.85)">OpenPerformanceData</a>
+- [ClosePerformanceData](/windows/desktop/api/winperf/nc-winperf-pm_close_proc)


### PR DESCRIPTION
Fixes a lot of formatting wrongdoings, as well as renames
and reorders parameters consistently with callback signature.

Regarding this parameters:

    _In_opt_ LPWSTR lpValueName,
    ...
    _Inout_ LPDWORD lpNumObjectTypes

The query string parameter *lpValueName* is annotated as optional
(nullable), however I have not found a signle proof of that in either
documentation or in code. Queries against performance counters HKEYs
via RegQueryValueExW are meaningless without *lpValueName*, which is
exactly our query string. Running such null query results in
`Error Code 0x00000057: The parameter is incorrect.`

Number of objects written, *lpNumObjectTypes*, is specified as in/out.
I believe, this was an oversight. Documentation does not explain how
to use it as an input anyway.