### PR TITLE
Markup fixes for nf-winsock2-wsapoll.md

### DIFF
--- a/sdk-api-src/content/winsock2/nf-winsock2-wsapoll.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsapoll.md
@@ -69,7 +69,7 @@ A value that specifies the wait behavior, based on the following values.
 
 <table>
 <tr>
-<th>Return value</th>
+<th>Value</th>
 <th>Meaning</th>
 </tr>
 <tr>
@@ -91,7 +91,7 @@ A value that specifies the wait behavior, based on the following values.
 Returns one of the following values.
 			<table>
 <tr>
-<th>Value</th>
+<th>Return value</th>
 <th>Description</th>
 </tr>
 <tr>
@@ -145,7 +145,7 @@ An exception occurred while reading user input parameters.
 </dl>
 </td>
 <td width="60%">
-An invalid parameter was passed. This error is returned if the [WSAPOLLFD](./ns-winsock2-wsapollfd.md) structures  pointed to by the <i>fdarray</i> parameter when requesting socket
+An invalid parameter was passed. This error is returned if the <a href="/windows/win32/api/winsock2/ns-winsock2-wsapollfd">WSAPOLLFD</a> structures  pointed to by the <i>fdarray</i> parameter when requesting socket
                        status. This error is also returned if none of the sockets specified in the <b>fd</b> member of any of the <b>WSAPOLLFD</b> structures  pointed to by the <i>fdarray</i> parameter were valid. 
 
 </td>


### PR DESCRIPTION
There were `Return value` and `Value` table columns switched places and seems that markdown links don't render correctly inside HTML tables:

![image](https://user-images.githubusercontent.com/775038/94453747-b8722d00-01b9-11eb-866e-5f155fc33e43.png)
