### PR TITLE
Fix name requirement for NamedPipe

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-createnamedpipea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createnamedpipea.md
@@ -76,7 +76,7 @@ Creates an instance of a named pipe and returns a handle for subsequent pipe ope
 
 The unique pipe name. This string must have the following form:
 
-\\.\pipe&#92;<i>pipename</i>
+\\\\.\\pipe&#92;<i>pipename</i>
 
 The pipename part of the name can include any character other than a backslash, including numbers and special characters. The entire pipe name string can be up to 256 characters long. Pipe names are not case sensitive.
 


### PR DESCRIPTION
The double backslash in the markdown was interpreted as a quoted single backslash which would
cause the documentation to state that the name must be `\.\pipe` instead of `\\.\pipe`