### PR TITLE
RegSetValue -> RegSetValueEx

### DIFF
--- a/sdk-api-src/content/winreg/nf-winreg-regdeletevaluea.md
+++ b/sdk-api-src/content/winreg/nf-winreg-regdeletevaluea.md
@@ -87,7 +87,7 @@ This handle is returned by the
 ### -param lpValueName [in, optional]
 
 The registry value to be removed. If this parameter is <b>NULL</b> or an empty string, the value set by the 
-<a href="/windows/win32/api/winreg/nf-winreg-regsetvalueexa">RegSetValueExA</a> function is removed. 
+<a href="/windows/win32/api/winreg/nf-winreg-regsetvalueexa">RegSetValueEx</a> function is removed. 
 
 
 

--- a/sdk-api-src/content/winreg/nf-winreg-regdeletevaluea.md
+++ b/sdk-api-src/content/winreg/nf-winreg-regdeletevaluea.md
@@ -87,7 +87,7 @@ This handle is returned by the
 ### -param lpValueName [in, optional]
 
 The registry value to be removed. If this parameter is <b>NULL</b> or an empty string, the value set by the 
-<a href="/windows/desktop/api/winreg/nf-winreg-regsetvaluea">RegSetValue</a> function is removed. 
+<a href="/windows/win32/api/winreg/nf-winreg-regsetvalueexa">RegSetValueExA</a> function is removed. 
 
 
 


### PR DESCRIPTION
`RegSetValue` is for 16-bit compatibility. Documentation should correctly point to Ex version

`/windows/desktop/api/winreg` path redirects to `/windows/win32/api/winreg`, hence `win32` path component is more appropriate.