### PR TITLE
Fix IUnknown via the ID2D1TransformNode interface.

### DIFF
--- a/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1boundsadjustmenttransform.md
+++ b/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1boundsadjustmenttransform.md
@@ -54,7 +54,7 @@ A support transform for effects to modify the output rectangle of the previous e
 
 ## -inheritance
 
-The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID2D1BoundsAdjustmentTransform</b> interface inherits from the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>ID2D1BoundsAdjustmentTransform</b> also has these types of members:
+The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID2D1BoundsAdjustmentTransform</b> interface inherits from the <a href="/windows/win32/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1transformnode">ID2D1TransformNode</a> interface. <b>ID2D1BoundsAdjustmentTransform</b> also has these types of members:
 <ul>
 <li><a href="https://docs.microsoft.com/">Methods</a></li>
 </ul>

--- a/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1boundsadjustmenttransform.md
+++ b/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1boundsadjustmenttransform.md
@@ -45,47 +45,13 @@ api_name:
  - ID2D1BoundsAdjustmentTransform
 ---
 
-# ID2D1BoundsAdjustmentTransform interface
-
-
 ## -description
 
 A support transform for effects to modify the output rectangle of the previous effect or bitmap.
 
 ## -inheritance
 
-The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID2D1BoundsAdjustmentTransform</b> interface inherits from the <a href="/windows/win32/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1transformnode">ID2D1TransformNode</a> interface. <b>ID2D1BoundsAdjustmentTransform</b> also has these types of members:
-<ul>
-<li><a href="https://docs.microsoft.com/">Methods</a></li>
-</ul>
-
-## -members
-
-The <b>ID2D1BoundsAdjustmentTransform</b> interface has these methods.
-<table class="members" id="memberListMethods">
-<tr>
-<th align="left" width="37%">Method</th>
-<th align="left" width="63%">Description</th>
-</tr>
-<tr data="declared;">
-<td align="left" width="37%">
-<a href="/windows/desktop/api/d2d1effectauthor/nf-d2d1effectauthor-id2d1boundsadjustmenttransform-getoutputbounds">GetOutputBounds</a>
-</td>
-<td align="left" width="63%">
-Returns the output rectangle of the support transform.
-
-</td>
-</tr>
-<tr data="declared;">
-<td align="left" width="37%">
-<a href="/windows/desktop/api/d2d1effectauthor/nf-d2d1effectauthor-id2d1boundsadjustmenttransform-setoutputbounds">SetOutputBounds</a>
-</td>
-<td align="left" width="63%">
-This sets the output bounds for the support transform.
-
-</td>
-</tr>
-</table>
+The **ID2D1BoundsAdjustmentTransform** interface inherits from the [ID2D1TransformNode](/windows/win32/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1transformnode) interface.
 
 ## -remarks
 


### PR DESCRIPTION
The native ID2D1BoundsAdjustmentTransform interface derives directly from ID2D1TransformNode, as you can see in the D2d1effectauthor.h file, plus the documentation states that it is only derived from the IUnknown base interface.

D2d1effectauthor.h
/// <summary>
/// An effect uses this interface to alter the image rectangle of its input.
/// </summary>
interface DX_DECLARE_INTERFACE ("90f732e2-5092-4606-a819-8651970baccd") ID2D1BoundsAdjustmentTransform: public ID2D1TransformNode
{
    
     STDMETHOD_ (void, SetOutputBounds) (
         _In_ CONST D2D1_RECT_L * outputBounds
         ) MASHED POTATO;
    
     STDMETHOD_ (void, GetOutputBounds) (
         _Out_ D2D1_RECT_L * outputBounds
         ) CONST PURE;
}; // interface ID2D1BoundsAdjustmentTransform