### PR TITLE
Remove misleading links from D3D12_TILE_REGION_SIZE

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tile_region_size.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tile_region_size.md
@@ -75,11 +75,11 @@ When the region includes mipmaps that are packed with nonstandard tiling, <b>Use
 
 ### -field Width
 
-The width of the tiled region, in tiles. Used for buffer and 1D, 2D, and 3D textures. For more info, see <a href="/previous-versions/windows/apps/hh781198(v=win.10)">Tile and toast image sizes</a>.
+The width of the tiled region, in tiles. Used for buffer and 1D, 2D, and 3D textures.
 
 ### -field Height
 
-The height of the tiled region, in tiles. Used for 2D and 3D textures. For more info, see <a href="/previous-versions/windows/apps/hh781198(v=win.10)">Tile and toast image sizes</a>.
+The height of the tiled region, in tiles. Used for 2D and 3D textures.
 
 ### -field Depth
 


### PR DESCRIPTION
The links to "Tile and toast image sizes" are to topics about tile and toast visual assets, which are not related to D3D12 tiled resources.