### PR TITLE
Add Idle Time warning property

### DIFF
--- a/sdk-api-src/content/wtsprotocol/nf-wtsprotocol-iwrdsprotocolconnection-queryproperty.md
+++ b/sdk-api-src/content/wtsprotocol/nf-wtsprotocol-iwrdsprotocolconnection-queryproperty.md
@@ -176,6 +176,19 @@ On output, pass the following <a href="/windows/desktop/api/wtsdefs/ns-wtsdefs-w
 <li><code>pPropertyEntriesOut[0].u.bVal.size = </code>Size of <a href="/windows/desktop/api/wtsdefs/ns-wtsdefs-wrds_dynamic_time_zone_information">WRDS_DYNAMIC_TIME_ZONE_INFORMATION</a> structure</li>
 </ul>
 
+#### CONNECTION_PROPERTY_IDLE_TIME_WARNING (693f7ff5-0c4e-4d17-b8e0-1f70325e5d58)
+
+Used to determine whether a logoff warning prompt is displayed when the idle timer expires.
+
+The <i>pPropertyEntriesIn</i> parameter will be <b>NULL</b>.
+
+On output, pass the following <a href="/windows/desktop/api/wtsdefs/ns-wtsdefs-wts_property_value">WRDS_PROPERTY_VALUE</a> structure in the <i>pPropertyEntriesOut</i> parameter:
+
+<ul>
+<li><code>pPropertyEntriesOut[0].Type = </code><b>WRDS_VALUE_TYPE_ULONG</b></li>
+<li><code>pPropertyEntriesOut[0].u.ulVal = </code><i>0 to disable warning prompt, 1 to enable it</i></li>
+</ul>
+
 ### -param ulNumEntriesIn [in]
 
 The number of entries in the <i>pPropertyEntriesIn</i> array.


### PR DESCRIPTION
New property that allows the stack to enable displaying a warning prompt when the idle timer expires and the user is about to be logged off.