### PR TITLE
Fix incorrect URL links

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shgetvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shgetvaluea.md
@@ -107,7 +107,7 @@ The address of the value.
 
 Type: <b>LPDWORD</b>
 
-The type of value. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+The type of value. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shgetvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shgetvaluew.md
@@ -107,7 +107,7 @@ The address of the value.
 
 Type: <b>LPDWORD</b>
 
-The type of value. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+The type of value. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shqueryvalueexa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shqueryvalueexa.md
@@ -107,7 +107,7 @@ Reserved. Must be <b>NULL</b>.
 
 Type: <b>LPDWORD</b>
 
-The address of the variable that receives the key's value type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+The address of the variable that receives the key's value type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shqueryvalueexw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shqueryvalueexw.md
@@ -107,7 +107,7 @@ Reserved. Must be <b>NULL</b>.
 
 Type: <b>LPDWORD</b>
 
-The address of the variable that receives the key's value type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+The address of the variable that receives the key's value type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetusvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetusvaluea.md
@@ -76,7 +76,7 @@ A pointer to a null-terminated string with the name of the value. This value can
 
 Type: <b>DWORD*</b>
 
-A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. If type information is not required, this parameter can be <b>NULL</b>.
+A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. If type information is not required, this parameter can be <b>NULL</b>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetusvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetusvaluew.md
@@ -76,7 +76,7 @@ A pointer to a null-terminated string with the name of the value. This value can
 
 Type: <b>DWORD*</b>
 
-A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. If type information is not required, this parameter can be <b>NULL</b>.
+A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. If type information is not required, this parameter can be <b>NULL</b>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetvaluea.md
@@ -128,7 +128,7 @@ One or more of the <a href="/windows/desktop/shell/srrf">SRRF</a> flags that res
 
 Type: <b>LPDWORD</b>
 
-A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
+A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
 
 ### -param pvData [out]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shreggetvaluew.md
@@ -128,7 +128,7 @@ One or more of the <a href="/windows/desktop/shell/srrf">SRRF</a> flags that res
 
 Type: <b>LPDWORD</b>
 
-A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
+A pointer to a <b>DWORD</b> that receives the type of data stored in the retrieved value. When using default values, the input <i>pdwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
 
 ### -param pvData [out]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shregqueryusvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shregqueryusvaluea.md
@@ -104,7 +104,7 @@ A pointer to the <b>null</b>-terminated string that contains the name of the val
 
 Type: <b>LPDWORD*</b>
 
-A pointer to the variable that sets or receives the key's value type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. This parameter can be <b>NULL</b>.
+A pointer to the variable that sets or receives the key's value type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. This parameter can be <b>NULL</b>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shregqueryusvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shregqueryusvaluew.md
@@ -104,7 +104,7 @@ A pointer to the <b>null</b>-terminated string that contains the name of the val
 
 Type: <b>LPDWORD*</b>
 
-A pointer to the variable that sets or receives the key's value type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. This parameter can be <b>NULL</b>.
+A pointer to the variable that sets or receives the key's value type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. This parameter can be <b>NULL</b>.
 
 ### -param pvData [out, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetusvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetusvaluea.md
@@ -76,7 +76,7 @@ A pointer to a null-terminated string that specifies the name of the value.
 
 Type: <b>DWORD</b>
 
-Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [in, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetusvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetusvaluew.md
@@ -72,7 +72,7 @@ TBD
 
 Type: <b>DWORD</b>
 
-Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [in, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetvalue.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shregsetvalue.md
@@ -122,7 +122,7 @@ One or more of the <a href="/windows/desktop/shell/srrf">SRRF</a> flags that res
 
 Type: <b>DWORD</b>
 
-The <b>DWORD</b> that indicates the type of data stored in the value to be set. When using default values, the input <i>dwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
+The <b>DWORD</b> that indicates the type of data stored in the value to be set. When using default values, the input <i>dwType</i> is the type of the default value. For possible values, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>. If the SRRF_NOEXPAND flag is not set, REG_EXPAND_SZ types are automatically expanded and returned as REG_SZ. If type information is not required, this parameter can be <b>NULL</b>.
 
 ### -param pvData [in]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shsetvaluea.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shsetvaluea.md
@@ -107,7 +107,7 @@ The address of a null-terminated string that specifies the value. This value can
 
 Type: <b>DWORD</b>
 
-Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [in, optional]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shsetvaluew.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shsetvaluew.md
@@ -107,7 +107,7 @@ The address of a null-terminated string that specifies the value. This value can
 
 Type: <b>DWORD</b>
 
-Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/schemas">Registry Data Types</a>.
+Type of data to be stored. This parameter must be the <b>REG_SZ</b> type. For more information, see <a href="/windows/desktop/shell/hkey-type">Registry Data Types</a>.
 
 ### -param pvData [in, optional]
 


### PR DESCRIPTION
## Summary

This PR fixes the incorrect URL linking for all instances of Registry Data Types. At the moment, they all direct to the [Shell Schemas](https://docs.microsoft.com/en-us/windows/desktop/shell/schemas) page instead of the proposed [Registry Data Types](https://docs.microsoft.com/en-us/windows/win32/shell/hkey-type) docs page.