### PR TITLE
Proposed additions to WTS_CONNECTSTATE_CLASS

### DIFF
--- a/sdk-api-src/content/wtsapi32/ne-wtsapi32-wts_connectstate_class.md
+++ b/sdk-api-src/content/wtsapi32/ne-wtsapi32-wts_connectstate_class.md
@@ -60,6 +60,8 @@ Specifies the connection state of a Remote Desktop Services session.
 
 A user is logged on to the WinStation.
 
+This state occurs when a user is signed in and actively connected to the device.
+
 ### -field WTSConnected
 
 The WinStation is connected to the client.
@@ -75,6 +77,8 @@ The WinStation is shadowing another WinStation.
 ### -field WTSDisconnected
 
 The WinStation is active but the client is disconnected.
+
+This state occurs when a user is signed in but not actively connected to the device, such as when the user has chosen to exit to the lock screen.
 
 ### -field WTSIdle
 

--- a/sdk-api-src/content/wtsapi32/ne-wtsapi32-wts_connectstate_class.md
+++ b/sdk-api-src/content/wtsapi32/ne-wtsapi32-wts_connectstate_class.md
@@ -58,9 +58,7 @@ Specifies the connection state of a Remote Desktop Services session.
 
 ### -field WTSActive
 
-A user is logged on to the WinStation.
-
-This state occurs when a user is signed in and actively connected to the device.
+A user is logged on to the WinStation. This state occurs when a user is signed in and actively connected to the device.
 
 ### -field WTSConnected
 
@@ -76,9 +74,7 @@ The WinStation is shadowing another WinStation.
 
 ### -field WTSDisconnected
 
-The WinStation is active but the client is disconnected.
-
-This state occurs when a user is signed in but not actively connected to the device, such as when the user has chosen to exit to the lock screen.
+The WinStation is active but the client is disconnected. This state occurs when a user is signed in but not actively connected to the device, such as when the user has chosen to exit to the lock screen.
 
 ### -field WTSIdle
 


### PR DESCRIPTION
While working with `WTS_CONNECTSTATE_CLASS` recently, both I and a colleague had difficulty interpreting all of the possible enumeration values based on this documentation. Through experimentation, we ascertained the information I've now added via this PR.

I think it would be great to add these clarifications to the documentation, but I also have some reservations, so I'm really sending this for a discussion. In particular, I'm not 100% satisfied with the following:

- I can't tell if the information is complete. I might have uncovered certain pieces of information, while inadvertently excluding others.
- The details are only being added for the two values I examined. It would be great to include similar details for the other values.

Ideally, it would be great if we could loop a Subject Matter Expert into this review as well.

I'm happy to make whatever changes we decide on, or to shelve this review entirely if favoured.