### PR TITLE
Incorrect reference to SYSTEMTIME structure in liCreateTimestamp field

### DIFF
--- a/sdk-api-src/content/tcpmib/ns-tcpmib-mib_tcprow_owner_module.md
+++ b/sdk-api-src/content/tcpmib/ns-tcpmib-mib_tcprow_owner_module.md
@@ -263,7 +263,7 @@ The PID of the process that issued a context bind for this TCP connection.
 
 Type: <b>LARGE_INTEGER</b>
 
-A <a href="/windows/desktop/api/minwinbase/ns-minwinbase-systemtime">SYSTEMTIME</a> structure that  indicates when the context bind operation that created this TCP link occurred.
+A <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure that indicates when the context bind operation that created this TCP link occurred.
 
 ### -field OwningModuleInfo
 


### PR DESCRIPTION
For the `liCreateTimestamp` field, change reference from `SYSTEMTIME` to `FILETIME`. In testing, this proves out to work with supporting functions. Additionally, this has to be the case since both `FILETIME` and `LARGE_INTEGER` are 8-byte structure while `SYSTEMTIME` is a 16-byte structure.