### PR TITLE
Incorrect reference to SYSTEMTIME structure in liCreateTimestamp field

### DIFF
--- a/sdk-api-src/content/udpmib/ns-udpmib-mib_udp6row_owner_module.md
+++ b/sdk-api-src/content/udpmib/ns-udpmib-mib_udp6row_owner_module.md
@@ -90,7 +90,7 @@ The PID of the process that issued a context bind for this endpoint. If this val
 
 Type: <b>LARGE_INTEGER</b>
 
-A <a href="/windows/desktop/api/minwinbase/ns-minwinbase-systemtime">SYSTEMTIME</a> structure that indicates when the context bind operation that created this endpoint occurred.
+A <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure that indicates when the context bind operation that created this endpoint occurred.
 
 ### -field SpecificPortBind
 


### PR DESCRIPTION
For the `liCreateTimestamp` field, change reference from `SYSTEMTIME` to `FILETIME`. In testing, this proves out to work with supporting functions. Additionally, this has to be the case since both `FILETIME` and `LARGE_INTEGER` are 8-byte structure while `SYSTEMTIME` is a 16-byte structure.