### PR TITLE
Requested Changes to document:

### DIFF
--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_installationbehavior.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_installationbehavior.md
@@ -57,9 +57,13 @@ This property is read-only.
 
 ## -parameters
 
+## -return-value
+
+Returns S_OK if successful. Otherwise, returns a COM or Windows error code.
+
 ## -remarks
 
-If the current update represents a bundle, the <b>InstallationBehavior</b> property of the bundle will be determined by the <b>InstallationBehavior</b> property of the child updates of the bundle.
+If the current update represents a bundle, the <b>InstallationBehavior</b> property of the bundle will be determined by the <b>InstallationBehavior</b> property of the child updates of the bundle. This API can return a null pointer as the output, even when the return value is S_OK.
 
 ## -see-also
 


### PR DESCRIPTION
Under Return Value it should state: 
"Returns S_OK if successful. Otherwise, returns a COM or Windows error code."
Under Remarks, it should state: 
"This API can return a null pointer as the output, even when the return value is S_OK." 

(You may need to reformat this as these changes look strange in the preview.. perhaps this is automated?) 