### PR TITLE
Update nf-wuapi-iupdate-get_uninstallationbehavior.md

### DIFF
--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
@@ -57,6 +57,14 @@ This property is read-only.
 
 ## -parameters
 
+## -return-value
+
+Returns S_OK if successful. Otherwise, returns a COM or Windows error code.
+
+## -remarks
+
+This API can return a null pointer as the output, even when the return value is S_OK.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
@@ -57,7 +57,7 @@ This property is read-only.
 
 ## -parameters
 
-## -return-value
+## -returns
 
 Returns S_OK if successful. Otherwise, returns a COM or Windows error code.
 


### PR DESCRIPTION
Under Return Value it should state: 
"Returns S_OK if successful. Otherwise, returns a COM or Windows error code."
Under Remarks, it should state: 
"This API can return a null pointer as the output, even when the return value is S_OK." 

(You may need to reformat this as these changes look strange in the preview.. perhaps this is automated?)