### PR TITLE
Update nf-wuapi-iupdate-get_image.md

### DIFF
--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
@@ -57,11 +57,17 @@ This property is read-only.
 
 ## -parameters
 
+## -return-value
+
+Returns S_OK if successful. Otherwise, returns a COM or Windows error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.
 
 If a language preference is not specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property of <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a>, or if the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is not  created by using <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a>, the information that is returned by  this property is for the default user interface (UI) language of the user. If the default UI language of the user is unavailable, Windows Update Agent (WUA) uses the default UI language of the computer.   If the default language of the computer is unavailable, WUA uses the language  that  the provider of the  update recommends.
+
+This API can return a null pointer as the output, even when the return value is S_OK.
 
 ## -see-also
 

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
@@ -57,7 +57,7 @@ This property is read-only.
 
 ## -parameters
 
-## -return-value
+## -returns
 
 Returns S_OK if successful. Otherwise, returns a COM or Windows error code.
 


### PR DESCRIPTION
Under Return Value it should state:
"Returns S_OK if successful. Otherwise, returns a COM or Windows error code."
Under Remarks, it should state:
"This API can return a null pointer as the output, even when the return value is S_OK."

(You may need to reformat this as these changes look strange in the preview.. perhaps this is automated?)