### PR TITLE
Fixing Broken "Method" hyperlink in D3D12DescriptorHeap Page

### DIFF
--- a/sdk-api-src/content/d3d12/nn-d3d12-id3d12descriptorheap.md
+++ b/sdk-api-src/content/d3d12/nn-d3d12-id3d12descriptorheap.md
@@ -54,10 +54,7 @@ A descriptor heap is a collection of contiguous allocations of descriptors, one 
 
 ## -inheritance
 
-The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3D12DescriptorHeap</b> interface inherits from <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12pageable">ID3D12Pageable</a>. <b>ID3D12DescriptorHeap</b> also has these types of members:
-<ul>
-<li><a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nn-d3d12-id3d12descriptorheap#methods">Methods</a></li>
-</ul>
+The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3D12DescriptorHeap</b> interface inherits from <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12pageable">ID3D12Pageable</a>.
 
 ## -members
 

--- a/sdk-api-src/content/d3d12/nn-d3d12-id3d12descriptorheap.md
+++ b/sdk-api-src/content/d3d12/nn-d3d12-id3d12descriptorheap.md
@@ -56,7 +56,7 @@ A descriptor heap is a collection of contiguous allocations of descriptors, one 
 
 The <b xmlns:loc="http://microsoft.com/wdcml/l10n">ID3D12DescriptorHeap</b> interface inherits from <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12pageable">ID3D12Pageable</a>. <b>ID3D12DescriptorHeap</b> also has these types of members:
 <ul>
-<li><a href="https://docs.microsoft.com/">Methods</a></li>
+<li><a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nn-d3d12-id3d12descriptorheap#methods">Methods</a></li>
 </ul>
 
 ## -members


### PR DESCRIPTION
Changing "Method" Hyperlink from docs.microsoft.com to https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nn-d3d12-id3d12descriptorheap#methods