### PR TITLE
Remove note about MAX_PATH limitation

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspeca.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspeca.md
@@ -63,13 +63,13 @@ Searches a string using a Microsoft MS-DOS wildcard match type.
 
 Type: <b>LPCSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the path to be searched.
+A pointer to a null-terminated string that contains the path to be searched.
 
 ### -param pszSpec [in]
 
 Type: <b>LPCSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the file type for which to search. For example, to test whether <i>pszFile</i> is a .doc file, <i>pszSpec</i> should be set to "*.doc".
+A pointer to a null-terminated string that contains the file type for which to search. For example, to test whether <i>pszFile</i> is a .doc file, <i>pszSpec</i> should be set to "*.doc".
 
 ## -returns
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspeca.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspeca.md
@@ -79,6 +79,8 @@ Returns <b>TRUE</b> if the string matches, or <b>FALSE</b> otherwise.
 
 ## -remarks
 
+The strings that *pszFile* and *pszSpec* point to may have a maximum length of MAX_PATH in some environments. For more information, see [Maximum Path Length Limitation](/windows/win32/fileio/maximum-file-path-limitation).
+
 > [!NOTE]
 > The shlwapi.h header defines PathMatchSpec as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexa.md
@@ -136,5 +136,7 @@ No file name pattern specified in <i>pszSpec</i> matched the file name found in 
 
 ## -remarks
 
+The strings that *pszFile* and *pszSpec* point to may have a maximum length of MAX_PATH in some environments. For more information, see [Maximum Path Length Limitation](/windows/win32/fileio/maximum-file-path-limitation).
+
 > [!NOTE]
 > The shlwapi.h header defines PathMatchSpecEx as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexa.md
@@ -63,13 +63,13 @@ Matches a file name from a path against one or more file name patterns.
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the path from which the file name to be matched is taken.
+A pointer to a null-terminated string that contains the path from which the file name to be matched is taken.
 
 ### -param pszSpec [in]
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the file name pattern for which to search. This can be the exact name, or it can contain wildcard characters. If exactly one pattern is specified, set the <b>PMSF_NORMAL</b> flag in <i>dwFlags</i>. If more than one pattern is specified, separate them with semicolons and set the <b>PMSF_MULTIPLE</b> flag.
+A pointer to a null-terminated string that contains the file name pattern for which to search. This can be the exact name, or it can contain wildcard characters. If exactly one pattern is specified, set the <b>PMSF_NORMAL</b> flag in <i>dwFlags</i>. If more than one pattern is specified, separate them with semicolons and set the <b>PMSF_MULTIPLE</b> flag.
 
 ### -param dwFlags [in]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexw.md
@@ -63,13 +63,13 @@ Matches a file name from a path against one or more file name patterns.
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the path from which the file name to be matched is taken.
+A pointer to a null-terminated string that contains the path from which the file name to be matched is taken.
 
 ### -param pszSpec [in]
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the file name pattern for which to search. This can be the exact name, or it can contain wildcard characters. If exactly one pattern is specified, set the <b>PMSF_NORMAL</b> flag in <i>dwFlags</i>. If more than one pattern is specified, separate them with semicolons and set the <b>PMSF_MULTIPLE</b> flag.
+A pointer to a null-terminated string that contains the file name pattern for which to search. This can be the exact name, or it can contain wildcard characters. If exactly one pattern is specified, set the <b>PMSF_NORMAL</b> flag in <i>dwFlags</i>. If more than one pattern is specified, separate them with semicolons and set the <b>PMSF_MULTIPLE</b> flag.
 
 ### -param dwFlags [in]
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecexw.md
@@ -151,5 +151,7 @@ No file name pattern specified in <i>pszSpec</i> matched the file name found in 
 
 ## -remarks
 
+The strings that *pszFile* and *pszSpec* point to may have a maximum length of MAX_PATH in some environments. For more information, see [Maximum Path Length Limitation](/windows/win32/fileio/maximum-file-path-limitation).
+
 > [!NOTE]
 > The shlwapi.h header defines PathMatchSpecEx as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecw.md
@@ -63,13 +63,13 @@ Searches a string using a Microsoft MS-DOS wildcard match type.
 
 Type: <b>LPCSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the path to be searched.
+A pointer to a null-terminated string that contains the path to be searched.
 
 ### -param pszSpec [in]
 
 Type: <b>LPCSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the file type for which to search. For example, to test whether <i>pszFile</i> is a .doc file, <i>pszSpec</i> should be set to "*.doc".
+A pointer to a null-terminated string that contains the file type for which to search. For example, to test whether <i>pszFile</i> is a .doc file, <i>pszSpec</i> should be set to "*.doc".
 
 ## -returns
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathmatchspecw.md
@@ -79,6 +79,8 @@ Returns <b>TRUE</b> if the string matches, or <b>FALSE</b> otherwise.
 
 ## -remarks
 
+The strings that *pszFile* and *pszSpec* point to may have a maximum length of MAX_PATH in some environments. For more information, see [Maximum Path Length Limitation](/windows/win32/fileio/maximum-file-path-limitation).
+
 > [!NOTE]
 > The shlwapi.h header defines PathMatchSpec as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 


### PR DESCRIPTION
This limitation doesn't really exist, and just confuses as of whether these functions can be used with long paths - they can.