### PR TITLE
Fix parameter name in RoGetAgileReference doc

### DIFF
--- a/sdk-api-src/content/combaseapi/nf-combaseapi-rogetagilereference.md
+++ b/sdk-api-src/content/combaseapi/nf-combaseapi-rogetagilereference.md
@@ -56,7 +56,7 @@ Creates an agile reference for an object specified by the given interface.
 
 ## -parameters
 
-### -param arg1 [in]
+### -param options [in]
 
 The registration options.
 


### PR DESCRIPTION
The parameter appears twice in this doc, each with a unique name. This fixes the incorrect name to match what's in the header file.