### PR TITLE
Update dead link to ID3D12StateObject

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-createstateobject.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-createstateobject.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Creates an <a href="https://msdn.microsoft.com/en-us/library/Mt815591(v=VS.85).aspx">ID3D12StateObject</a>.
+Creates an <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nn-d3d12-id3d12stateobject">ID3D12StateObject</a>.
 
 ## -parameters
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-createstateobject.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-createstateobject.md
@@ -1,13 +1,12 @@
 ---
 UID: NF:d3d12.ID3D12Device5.CreateStateObject
 title: ID3D12Device5::CreateStateObject (d3d12.h)
-description: Creates an ID3D12StateObject.
+description: Creates an [ID3D12StateObject](/windows/win32/api/d3d12/nn-d3d12-id3d12stateobject).
 helpviewer_keywords: ["CreateStateObject","CreateStateObject method","CreateStateObject method","ID3D12Device5 interface","ID3D12Device5 interface","CreateStateObject method","ID3D12Device5.CreateStateObject","ID3D12Device5::CreateStateObject","d3d12/ID3D12Device5::CreateStateObject","direct3d12.id3d12device5_createstateobject"]
 old-location: direct3d12\id3d12device5_createstateobject.htm
 tech.root: direct3d12
 ms.assetid: 9CC759D5-6414-4B05-B8F3-FA6056A0A9AF
 ms.date: 12/05/2018
-ms.keywords: CreateStateObject, CreateStateObject method, CreateStateObject method,ID3D12Device5 interface, ID3D12Device5 interface,CreateStateObject method, ID3D12Device5.CreateStateObject, ID3D12Device5::CreateStateObject, d3d12/ID3D12Device5::CreateStateObject, direct3d12.id3d12device5_createstateobject
 req.header: d3d12.h
 req.include-header: 
 req.target-type: Windows
@@ -45,12 +44,9 @@ api_name:
  - ID3D12Device5.CreateStateObject
 ---
 
-# ID3D12Device5::CreateStateObject
-
-
 ## -description
 
-Creates an <a href="https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nn-d3d12-id3d12stateobject">ID3D12StateObject</a>.
+Creates an [ID3D12StateObject](/windows/win32/api/d3d12/nn-d3d12-id3d12stateobject).
 
 ## -parameters
 
@@ -69,7 +65,6 @@ The returned state object.
 ## -returns
 
 Returns S_OK if successful; otherwise, returns one of the following values:
-              
 
 <ul>
 <li>E_INVALIDARG if one of the input parameters is invalid.</li>
@@ -80,4 +75,4 @@ Returns S_OK if successful; otherwise, returns one of the following values:
 
 ## -see-also
 
-<a href="https://msdn.microsoft.com/en-us/library/Mt847457(v=VS.85).aspx">ID3D12Device5</a>
+[ID3D12Device5](/windows/win32/api/d3d12/nn-d3d12-id3d12device5)


### PR DESCRIPTION
the link to ID3D12StateObject is dead and redirecting to the main docs page, i changed it so it points to the right docs page that has the ID3D12StateObject info.