### PR TITLE
Update nf-shlobj_core-shgetknownfolderpath.md

### DIFF
--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetknownfolderpath.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetknownfolderpath.md
@@ -88,7 +88,7 @@ Assigning the <i>hToken</i> parameter a value of -1 indicates the Default User. 
 
 Type: <b>PWSTR*</b>
 
-When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the path of the known folder. The calling process is responsible for freeing this resource once it is no longer needed by calling <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>. The returned path does not include a trailing backslash. For example, "C:\Users" is returned rather than "C:\Users\\".
+When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the path of the known folder. The calling process is responsible for freeing this resource once it is no longer needed by calling <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>, whether SHGetKnownFolderPath succeeds or not. The returned path does not include a trailing backslash. For example, "C:\Users" is returned rather than "C:\Users\\".
 
 ## -returns
 

--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetknownfolderpath.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetknownfolderpath.md
@@ -88,7 +88,7 @@ Assigning the <i>hToken</i> parameter a value of -1 indicates the Default User. 
 
 Type: <b>PWSTR*</b>
 
-When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the path of the known folder. The calling process is responsible for freeing this resource once it is no longer needed by calling <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>, whether SHGetKnownFolderPath succeeds or not. The returned path does not include a trailing backslash. For example, "C:\Users" is returned rather than "C:\Users\\".
+When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the path of the known folder. The calling process is responsible for freeing this resource once it is no longer needed by calling <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>, whether <b>SHGetKnownFolderPath</b> succeeds or not. The returned path does not include a trailing backslash. For example, "C:\Users" is returned rather than "C:\Users\\".
 
 ## -returns
 


### PR DESCRIPTION
It is unclear for developers that whether they need to free ppszPath even when SHGetKnownFolderPath fails. Since CoTaskMemFree can accept NULL, I think it would be better if the description has such suggestion.