### PR TITLE
Update nf-cfapi-cfsetinsyncstate.md A parameter does not work as documented

### DIFF
--- a/sdk-api-src/content/cfapi/nf-cfapi-cfsetinsyncstate.md
+++ b/sdk-api-src/content/cfapi/nf-cfapi-cfsetinsyncstate.md
@@ -68,7 +68,7 @@ The in-sync state flags. See <a href="/windows/desktop/api/cfapi/ne-cfapi-cf_set
 
 ### -param InSyncUsn [in, out, optional]
 
-When specified, this instructs the platform to only perform in-sync setting if the file still has the same USN value as the one passed in. Passing a pointer to a USN value of 0 on input is the same as passing a NULL pointer.  On return, this is the final USN value after setting the in-sync state.
+This parameter needs to be a NULL pointer.
 
 ## -returns
 


### PR DESCRIPTION
The InSyncUsn parameter does not work. The operation will fail using anything but NULL (including the correct USN).

After the method returns it will not write the new USN to the paramater in any case.

This is demonstrated by [this sample](https://github.com/LokiMidgard/CloudTest).

There was also a [stackoverflow](https://stackoverflow.com/questions/60816543/cfsetinsyncstate-does-not-behave-as-documented-cfapi) discussion, but this did not lead to any results. (It desscribed a workaround to get the USN from a file but not to run the operation conditionally).