### PR TITLE
Clarify RelativeFileName after kb4592449 fix

### DIFF
--- a/sdk-api-src/content/cfapi/nf-cfapi-cfcreateplaceholders.md
+++ b/sdk-api-src/content/cfapi/nf-cfapi-cfcreateplaceholders.md
@@ -57,6 +57,8 @@ Creates one or more new placeholder files or directories under a sync root tree.
 ### -param BaseDirectoryPath [in]
 
 Local directory path under which placeholders are created.
+Note that this represents the directory where the placeholder needs to be created. Hence it will be sync root only
+if the placeholder is being created in the sync root, else it will be a successor of the sync root. E.g. ({BaseDirectoryPath = c:\SyncRoot} {CF_PLACEHOLDER_CREATE_INFO.RelativeFileName = Placeholder}) should be used if the Placeholder is being created in the SyncRoot. ({BaseDirectoryPath = c:\SyncRoot\Successor} {CF_PLACEHOLDER_CREATE_INFO.RelativeFileName = Placeholder}) should be used if the Placeholder is being created in a child of the SyncRoot which is c:\SyncRoot\Successor.
 
 ### -param PlaceholderArray [in, out]
 

--- a/sdk-api-src/content/cfapi/nf-cfapi-cfcreateplaceholders.md
+++ b/sdk-api-src/content/cfapi/nf-cfapi-cfcreateplaceholders.md
@@ -57,8 +57,8 @@ Creates one or more new placeholder files or directories under a sync root tree.
 ### -param BaseDirectoryPath [in]
 
 Local directory path under which placeholders are created.
-Note that this represents the directory where the placeholder needs to be created. Hence it will be sync root only
-if the placeholder is being created in the sync root, else it will be a successor of the sync root. E.g. ({BaseDirectoryPath = c:\SyncRoot} {CF_PLACEHOLDER_CREATE_INFO.RelativeFileName = Placeholder}) should be used if the Placeholder is being created in the SyncRoot. ({BaseDirectoryPath = c:\SyncRoot\Successor} {CF_PLACEHOLDER_CREATE_INFO.RelativeFileName = Placeholder}) should be used if the Placeholder is being created in a child of the SyncRoot which is c:\SyncRoot\Successor.
+
+Note that this directory must be the immediate parent directory of the placeholders being created. For example, if the sync root of the provider is c:\SyncRoot and a placeholder is being created in a child directory of the sync root such as c:\SyncRoot\ChildDir, then BaseDirectoryPath = c:\SyncRoot\ChildDir.
 
 ### -param PlaceholderArray [in, out]
 

--- a/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
+++ b/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
@@ -56,7 +56,9 @@ Contains placeholder information for creating new placeholder files or directori
 
 ### -field RelativeFileName
 
-The name of the child placeholder file or directory to be created.
+The name of the child placeholder file or directory to be created. 
+This shouldn't be a path or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
+E.g. BaseDirectoryPath = (“C:\foo\bar”, { RelativeFileName = “baz”}) is allowed, where as BaseDirectoryPath = (“C:\foo”, { RelativeFileName = “bar\baz” }) is incorrect.
 
 ### -field FsMetadata
 

--- a/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
+++ b/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
@@ -59,7 +59,7 @@ Contains placeholder information for creating new placeholder files or directori
 The name of the child placeholder file or directory to be created. 
 
 This parameter must not contain a relative path or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
-For example if the sync root of the provider is c:\SyncRoot and a placeholder named "pl.txt" is being created in a child directory of the sync root such as c:\SyncRoot\ChildDir, then BaseDirectoryPath = c:\SyncRoot\ChildDir and RelativeFileName = pl.txt is expected. It is an error to specify BaseDirectoryPath = c:\SyncRoot and RelativeFileName = child\pl.txt.
+For example if the sync root of the provider is c:\SyncRoot and a placeholder named "pl.txt" is being created in a child directory of the sync root such as c:\SyncRoot\ChildDir, then BaseDirectoryPath = c:\SyncRoot\ChildDir and RelativeFileName = pl.txt is expected. It is an error to specify BaseDirectoryPath = c:\SyncRoot and RelativeFileName = ChildDir\pl.txt.
 
 ### -field FsMetadata
 

--- a/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
+++ b/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
@@ -58,7 +58,7 @@ Contains placeholder information for creating new placeholder files or directori
 
 The name of the child placeholder file or directory to be created. 
 This shouldn't be a path or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
-E.g. BaseDirectoryPath = (“C:\foo\bar”, { RelativeFileName = “baz”}) is allowed, where as BaseDirectoryPath = (“C:\foo”, { RelativeFileName = “bar\baz” }) is incorrect.
+E.g. ({BaseDirectoryPath = “C:\foo\bar”}, { RelativeFileName = “baz”}) is allowed, where as ({BaseDirectoryPath = “C:\foo”}, { RelativeFileName = “bar\baz” }) is incorrect.
 
 ### -field FsMetadata
 

--- a/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
+++ b/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
@@ -57,7 +57,7 @@ Contains placeholder information for creating new placeholder files or directori
 ### -field RelativeFileName
 
 The name of the child placeholder file or directory to be created. 
-This shouldn't be a path or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
+This parameter must be a file name rather than a path or or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
 E.g. ({BaseDirectoryPath = “C:\foo\bar”}, { RelativeFileName = “baz”}) is allowed, where as ({BaseDirectoryPath = “C:\foo”}, { RelativeFileName = “bar\baz” }) is incorrect.
 
 ### -field FsMetadata

--- a/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
+++ b/sdk-api-src/content/cfapi/ns-cfapi-cf_placeholder_create_info.md
@@ -57,8 +57,9 @@ Contains placeholder information for creating new placeholder files or directori
 ### -field RelativeFileName
 
 The name of the child placeholder file or directory to be created. 
-This parameter must be a file name rather than a path or or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
-E.g. ({BaseDirectoryPath = “C:\foo\bar”}, { RelativeFileName = “baz”}) is allowed, where as ({BaseDirectoryPath = “C:\foo”}, { RelativeFileName = “bar\baz” }) is incorrect.
+
+This parameter must not contain a relative path or else CfCreatePlaceholders will fail with ERROR_CLOUD_FILE_INVALID_REQUEST.
+For example if the sync root of the provider is c:\SyncRoot and a placeholder named "pl.txt" is being created in a child directory of the sync root such as c:\SyncRoot\ChildDir, then BaseDirectoryPath = c:\SyncRoot\ChildDir and RelativeFileName = pl.txt is expected. It is an error to specify BaseDirectoryPath = c:\SyncRoot and RelativeFileName = child\pl.txt.
 
 ### -field FsMetadata
 


### PR DESCRIPTION
While the earlier description is clear enough, lots of developers have taken a dependency on older behavior which was changed post kb4592449. So clarifying via this change.