### PR TITLE
Update ns-winsvc-service_status.md

### DIFF
--- a/sdk-api-src/content/winsvc/ns-winsvc-service_status.md
+++ b/sdk-api-src/content/winsvc/ns-winsvc-service_status.md
@@ -442,8 +442,8 @@ The service is notified when an event for which the service has registered  occu
 </td>
 </tr>
 <tr>
-<td width="40%"><a id="SERVICE_ACCEPT_USERMODEREBOOT"></a><a id="service_accept_usermodereboot"></a><dl>
-<dt><b>SERVICE_ACCEPT_USERMODEREBOOT</b></dt>
+<td width="40%"><a id="SERVICE_ACCEPT_USER_LOGOFF"></a><a id="service_accept_usermodereboot"></a><dl>
+<dt><b>SERVICE_ACCEPT_USER_LOGOFF</b></dt>
 <dt>0x00000800</dt>
 </dl>
 </td>


### PR DESCRIPTION
The constant SERVICE_ACCEPT_USERMODEREBOOT does not seem to exist in the SDK header winsvc.h. Instead, this is defined SERVICE_ACCEPT_USER_LOGOFF with the same value (0x800).
Also, missing the control code that is sent to the service (SERVICE_CONTROL_USER_LOGOFF), which is commented out in the header.