### PR TITLE
Corrections to MI_ClassDecl

### DIFF
--- a/sdk-api-src/content/mi/ns-mi-mi_classdecl.md
+++ b/sdk-api-src/content/mi/ns-mi-mi_classdecl.md
@@ -102,8 +102,6 @@ Name of this feature.
 
 Describes extra metadata for classes, properties, methods, and parameters.
 
-### -field _MI_Qualifier
-
 ### -field numQualifiers
 
 Length of <b>qualifiers</b> array.
@@ -111,8 +109,6 @@ Length of <b>qualifiers</b> array.
 ### -field properties
 
 The properties of this object.
-
-### -field _MI_PropertyDecl
 
 ### -field numProperties
 
@@ -134,8 +130,6 @@ The classDecl for the parent class <b>superClass</b>.
 
 The methods of this class.
 
-### -field _MI_MethodDecl
-
 ### -field numMethods
 
 Number of  methods in this class.
@@ -143,8 +137,6 @@ Number of  methods in this class.
 ### -field schema
 
 Pointer to schema this class belongs to.
-
-### -field _MI_SchemaDecl
 
 ### -field providerFT
 


### PR DESCRIPTION
The "Syntax" section has inappropriately broken the definitions for the "qualifiers", "properties", "methods", and "schema" members into two lines apiece.
_MI_Qualifier is a type, not a field. _MI_PropertyDecl is a type, not a field. _MI_MethodDecl is a type, not a field. _MI_SchemaDecl is a type, not a field.
I do not know where the page pulls the syntax from. The lines should be:
struct _MI_Qualifier MI_CONST* MI_CONST* qualifiers;
struct _MI_PropertyDecl MI_CONST* MI_CONST* properties;
struct _MI_MethodDecl MI_CONST* MI_CONST* methods;
struct _MI_SchemaDecl MI_CONST* schema;