### PR TITLE
WaitForMultipleObjects: Clearer explanation of ret val when wait all is specified 

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
@@ -108,7 +108,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, the return value indicates that the state of all specified objects is signaled. 
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value in this range indicates that the state of all specified objects is signaled. 
 
 
 

--- a/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
@@ -108,7 +108,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, a return value in this range indicates that the state of all specified objects is signaled. 
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value within the specified range indicates that the state of all specified objects is signaled. 
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
@@ -289,7 +289,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, the return value indicates that the state of all specified objects is signaled. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that satisfied the wait.
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value in this range indicates that the state of all specified objects is signaled. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that satisfied the wait.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
@@ -289,7 +289,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, a return value in this range indicates that the state of all specified objects is signaled. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that satisfied the wait.
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value within the specified range indicates that the state of all specified objects is signaled. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that satisfied the wait.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
@@ -353,7 +353,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If the <b>MWMO_WAITALL</b> flag is used, the return value indicates that the state of all specified objects is signaled. Otherwise, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that caused the function to return.
+If the <b>MWMO_WAITALL</b> flag is used, a return value in this range indicates that the state of all specified objects is signaled. Otherwise, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that caused the function to return.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
@@ -353,7 +353,7 @@ If the function succeeds, the return value indicates the event that caused the f
 </dl>
 </td>
 <td width="60%">
-If the <b>MWMO_WAITALL</b> flag is used, a return value in this range indicates that the state of all specified objects is signaled. Otherwise, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that caused the function to return.
+If the <b>MWMO_WAITALL</b> flag is used, a return value within the specified range indicates that the state of all specified objects is signaled. Otherwise, the return value minus <b>WAIT_OBJECT_0</b> indicates the <i>pHandles</i> array index of the object that caused the function to return.
 
 </td>
 </tr>


### PR DESCRIPTION
Problem: Currently the signaled return value in the WaitForMultipleObjects, MsgWaitForMultipleObjects and MsgWaitForMultipleObjectsEx functions is not clear in the case of wait for all objects.

Solution: Use the more clear explanation from WaitForMultipleObjectsEx that clearly specifies the range of the success ret vals in case you wait for all objects