### PR TITLE
Explain dwData correctly

### DIFF
--- a/sdk-api-src/content/winuser/ns-winuser-copydatastruct.md
+++ b/sdk-api-src/content/winuser/ns-winuser-copydatastruct.md
@@ -62,7 +62,7 @@ Contains data to be passed to another application by the <a href="/windows/deskt
 
 Type: <b>ULONG_PTR</b>
 
-The data to be passed to the receiving application.
+The type of the data to be passed to the receiving application. The receiving application defines the valid types.
 
 ### -field cbData
 


### PR DESCRIPTION
It's silly to have identical descriptions for two fields in the same struct.