### PR TITLE
Printf typo supressing variable output

### DIFF
--- a/sdk-api-src/content/iptypes/ns-iptypes-ip_adapter_info.md
+++ b/sdk-api-src/content/iptypes/ns-iptypes-ip_adapter_info.md
@@ -339,7 +339,7 @@ int __cdecl main()
     if ((dwRetVal = GetAdaptersInfo(pAdapterInfo, &ulOutBufLen)) == NO_ERROR) {
         pAdapter = pAdapterInfo;
         while (pAdapter) {
-            printf("\tComboIndex: \t5d\n", pAdapter->ComboIndex);
+            printf("\tComboIndex: \t%d\n", pAdapter->ComboIndex);
             printf("\tAdapter Name: \t%s\n", pAdapter->AdapterName);
             printf("\tAdapter Desc: \t%s\n", pAdapter->Description);
             printf("\tAdapter Addr: \t");


### PR DESCRIPTION
the line: printf("\tComboIndex: \t5d\n", pAdapter->ComboIndex);
needs to be changed to: printf("\tComboIndex: \t%d\n", pAdapter->ComboIndex);