### PR TITLE
Enable passing NULL to HeapFree

### DIFF
--- a/sdk-api-src/content/heapapi/nf-heapapi-heapfree.md
+++ b/sdk-api-src/content/heapapi/nf-heapapi-heapfree.md
@@ -101,7 +101,7 @@ Do not specify this value when accessing the process heap. The system may create
 
 A pointer to the memory block to be freed. This pointer is returned by the 
 <a href="/windows/desktop/api/heapapi/nf-heapapi-heapalloc">HeapAlloc</a> or 
-<a href="/windows/desktop/api/heapapi/nf-heapapi-heaprealloc">HeapReAlloc</a> function. If this pointer is <b>NULL</b>, the behavior is undefined.
+<a href="/windows/desktop/api/heapapi/nf-heapapi-heaprealloc">HeapReAlloc</a> function. This pointer can be <b>NULL</b>.
 
 ## -returns
 


### PR DESCRIPTION
From `heapapi.h` in the SDK, the annotation on `HeapFree` says `lpMem` can be `_opt_` (meaning `nullptr`).

```c
WINBASEAPI
_Success_(return != FALSE)
BOOL
WINAPI
HeapFree(
    _Inout_ HANDLE hHeap,
    _In_ DWORD dwFlags,
    __drv_freesMem(Mem) _Frees_ptr_opt_ LPVOID lpMem
    );
```

The implementation agrees as well.