### PR TITLE
Add ConnectEx links to Connect and WSAConnect

### DIFF
--- a/sdk-api-src/content/winsock2/nf-winsock2-connect.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-connect.md
@@ -504,6 +504,10 @@ IrDA implements the connect function with addresses of the form sockaddr_irda. T
 
 
 
+<a href="/windows/desktop/api/mswsock/nc-mswsock-lpfn_connectex">ConnectEx</a>
+
+
+
 <a href="/windows/desktop/WinSock/winsock-functions">Winsock Functions</a>
 
 

--- a/sdk-api-src/content/winsock2/nf-winsock2-wsaconnect.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsaconnect.md
@@ -442,6 +442,10 @@ When connected sockets become closed for whatever reason, they should be discard
 
 
 
+<a href="/windows/desktop/api/mswsock/nc-mswsock-lpfn_connectex">ConnectEx</a>
+
+
+
 <a href="/windows/desktop/api/winsock2/nf-winsock2-wsaconnectbylist">WSAConnectByList</a>
 
 


### PR DESCRIPTION
These changes add "see also" links to the ConnectEx function in the Connect and WSAConnect function documentation.