### PR TITLE
Add another scenario for when a DXGI_ERROR_INVALID_CALL is returned

### DIFF
--- a/sdk-api-src/content/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd.md
+++ b/sdk-api-src/content/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd.md
@@ -89,7 +89,7 @@ A pointer to a variable that receives a pointer to the <a href="/windows/desktop
 <li>S_OK if it successfully created a swap chain.</li>
 <li>E_OUTOFMEMORY if memory is unavailable to complete the operation.</li>
 <li>
-<a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_INVALID_CALL</a>  if the calling application provided invalid data, for example, if <i>pDesc</i> or <i>ppSwapChain</i> is <b>NULL</b>.</li>
+<a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR_INVALID_CALL</a>  if the calling application provided invalid data, for example, if <i>pDesc</i> or <i>ppSwapChain</i> is <b>NULL</b>, or <i>pDesc</i> data members are invalid.</li>
 <li>Possibly other error codes that are described in the <a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR</a> topic that are defined by the type of device that you pass to <i>pDevice</i>.</li>
 </ul>
 


### PR DESCRIPTION
I added another scenario when CreateSwapChainForHwnd() returns an DXGI_ERROR_INVALID_CALL even when pDesc is not NULL, which is when one or more of the pDesc members are invalid.