### PR TITLE
format the table for better user experience

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_flags.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_flags.md
@@ -46,109 +46,154 @@ api_name:
 ---
 
 # D3D12_RESOURCE_FLAGS enumeration
-
-
-## -description
-
-Specifies options for working with resources.
-
 ## -enum-fields
-
 ### -field D3D12_RESOURCE_FLAG_NONE
-
-No options are specified.
-
 ### -field D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET
-
-Allows a render target view to be created for the resource, as well as enables the resource to transition into the state of D3D12_RESOURCE_STATE_RENDER_TARGET. Some adapter architectures allocate extra memory for textures with this flag to reduce the effective bandwidth during common rendering. This characteristic may not be beneficial for textures that are never rendered to, nor is it available for textures compressed with BC formats. Applications should avoid setting this flag when rendering will never occur.
-
-
-The following restrictions and interactions apply:
-
-<ul>
-<li> Either the texture format must support render target capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support render target capabilities at the current feature level.</li>
-<li>Cannot be set in conjunction with textures that have D3D12_TEXTURE_LAYOUT_ROW_MAJOR when <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options">D3D12_FEATURE_DATA_D3D12_OPTIONS</a>::<b>CrossAdapterRowMajorTextureSupported</b> is FALSE nor in conjunction with textures that have D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE when     <b>D3D12_FEATURE_DATA_D3D12_OPTIONS</b>::<b>StandardSwizzle64KBSupported</b> is FALSE.
-</li>
-<li>Cannot be used with 4KB alignment, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL, nor usage with heaps that have D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES.</li>
-</ul>
-
 ### -field D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL
-
-Allows a depth stencil view to be created for the resource, as well as enables the resource to transition into the state of D3D12_RESOURCE_STATE_DEPTH_WRITE and/or D3D12_RESOURCE_STATE_DEPTH_READ. Most adapter architectures allocate extra memory for textures with this flag to reduce the effective bandwidth and maximize optimizations for early depth-test. Applications should avoid setting this flag when depth operations will never occur.
-
-
-The following restrictions and interactions apply:
-
-<ul>
-<li>Either the texture format must support depth stencil capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support depth stencil capabilities at the current feature level.</li>
-<li>Cannot be used with D3D12_RESOURCE_DIMENSION_BUFFER, 4KB alignment, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS, D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS, D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE, D3D12_TEXTURE_LAYOUT_ROW_MAJOR, nor used with heaps that have D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES or D3D12_HEAP_FLAG_ALLOW_DISPLAY.
-</li>
-<li>Precludes usage of <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-writetosubresource">WriteToSubresource</a> and <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-readfromsubresource">ReadFromSubresource</a>.
-</li>
-<li>Precludes GPU copying of a subregion. <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> must copy a whole subresource to or from resources with this flag.</li>
-</ul>
-
 ### -field D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS
-
-Allows an unordered access view to be created for the resource, as well as enables the resource to transition into the state of D3D12_RESOURCE_STATE_UNORDERED_ACCESS. Some adapter architectures must resort to less efficient texture layouts in order to provide this functionality. If a texture is rarely used for unordered access, it may be worth having two textures around and copying between them. One texture would have this flag, while the other wouldn't. Applications should avoid setting this flag when unordered access operations will never occur.
-
-
-The following restrictions and interactions apply:
-
-<ul>
-<li>Either the texture format must support unordered access capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support unordered access capabilities at the current feature level.
-</li>
-<li>Cannot be set in conjunction with textures that have D3D12_TEXTURE_LAYOUT_ROW_MAJOR when <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options">D3D12_FEATURE_DATA_D3D12_OPTIONS</a>::<b>CrossAdapterRowMajorTextureSupported</b> is FALSE nor in conjunction with textures that have D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE when <b>D3D12_FEATURE_DATA_D3D12_OPTIONS</b>::<b>StandardSwizzle64KBSupported</b> is FALSE, nor when the feature level is less than 11.0.
-</li>
-<li>Cannot be used with MSAA textures. </li>
-</ul>
-
 ### -field D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE
-
-Disallows a shader resource view to be created for the resource, as well as disables the resource to transition into the state of D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE or D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE. Some adapter architectures experience increased bandwidth for depth stencil textures when shader resource views are precluded. If a texture is rarely used for shader resource, it may be worth having two textures around and copying between them. One texture would have this flag and the other wouldn't. Applications should set this flag when depth stencil textures will never be used from shader resource views.
-
-
-The following restrictions and interactions apply:
-
-
-<ul>
-<li>Must be used with D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL. 
-</li>
-</ul>
-
 ### -field D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER
-
-Allows the resource to be used for cross-adapter data, as well as the same features enabled by ALLOW_SIMULTANEOUS_ACCESS. Cross adapter resources commonly preclude techniques that reduce effective texture bandwidth during usage, and some adapter architectures may require different caching behavior. Applications should avoid setting this flag when the resource data will never be used with another adapter.
-
-The following restrictions and interactions apply:
-
-
-<ul>
-<li>Must be used with heaps that have D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER.</li>
-<li>Cannot be used with heaps that have D3D12_HEAP_FLAG_ALLOW_DISPLAY.</li>
-</ul>
-
 ### -field D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS
-
-Allows a resource to be simultaneously accessed by multiple different queues, devices or processes (for example, allows a resource to be used with <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resourcebarrier">ResourceBarrier</a> transitions performed in more than one command list 
-	executing at the same time). 
-
-Simultaneous access allows multiple readers and one writer, as long as the writer doesn't concurrently modify the texels that other readers are accessing. Some adapter architectures cannot leverage techniques to reduce effective texture bandwidth during usage. 
-
-However, applications should avoid setting this flag when multiple readers are not required during frequent, non-overlapping writes to textures. Use of this flag can compromise resource fences to perform waits, and prevents any compression being used with a resource.
-
-These restrictions and interactions apply.
-
-- Can't be used with [D3D12_RESOURCE_DIMENSION_BUFFER](./ne-d3d12-d3d12_resource_dimension.md); but buffers always have the properties represented by this flag.
-- Can't be used with MSAA textures.
-- Can't be used with [D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL]().
-
 ### -field D3D12_RESOURCE_FLAG_VIDEO_DECODE_REFERENCE_ONLY
 
-This resource may only be used as a decode reference frame.  It may only be written to or read by the video decode operation.  
 
-[D3D12_VIDEO_DECODE_TIER_1](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) and [D3D12_VIDEO_DECODE_TIER_2](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) may report     [D3D12_VIDEO_DECODE_CONFIGURATION_FLAG_REFERENCE_ONLY_ALLOCATIONS_REQUIRED](../d3d12video/ne-d3d12video-d3d12_video_decode_configuration_flags) in the [D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT](../d3d12video/ns-d3d12video-d3d12_feature_data_video_decode_support) structure configuration flag.  If so, the application must allocate reference frames with the new **D3D12\_RESOURCE\_VIDEO\_DECODE\_REFERENCE\_ONLY** resource flag.  [D3D12_VIDEO_DECODE_TIER_3](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) must not set the [D3D12_VIDEO_DECODE_CONFIGURATION_FLAG_REFERENCE_ONLY_ALLOCATIONS_REQUIRED]
-(../d3d12video/ne-d3d12video-d3d12_video_decode_configuration_flags)) configuration flag and must not require the use of this resource flag.
+<table>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_NONE</th>
+    </tr>
+    <tr>
+        <td>No options are specified.</td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET</th>
+    </tr>
+    <tr>
+        <td>
+            Allows a render target view to be created for the resource, as well as enables the resource to transition into the state of D3D12_RESOURCE_STATE_RENDER_TARGET.<br/>
+            Some adapter architectures allocate extra memory for textures with this flag to reduce the effective bandwidth during common rendering. This characteristic may not be 	beneficial for textures that are never rendered to, nor is it available for textures compressed with BC formats.<br/>
+            Applications should avoid setting this flag when rendering will never occur.<br/><br/>
+            The following restrictions and interactions apply:
+	    <ul>
+            <li>
+            Either the texture format must support render target capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support render target capabilities at the current feature level.
+            </li>
+            <li>
+            Cannot be set in conjunction with textures that have D3D12_TEXTURE_LAYOUT_ROW_MAJOR when <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options">D3D12_FEATURE_DATA_D3D12_OPTIONS</a>::<b>CrossAdapterRowMajorTextureSupported</b> is FALSE nor in conjunction with textures that have D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE when <b>D3D12_FEATURE_DATA_D3D12_OPTIONS</b>::<b>StandardSwizzle64KBSupported</b> is FALSE.
+            </li>
+            <li>Cannot be used with 4KB alignment, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL, nor usage with heaps that have D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES.
+            </li>
+	    </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL</th>
+    </tr>
+    <tr>
+        <td>Allows a depth stencil view to be created for the resource, as well as enables the resource to transition into the state of D3D12_RESOURCE_STATE_DEPTH_WRITE and/or 	D3D12_RESOURCE_STATE_DEPTH_READ.<br/>
+	Most adapter architectures allocate extra memory for textures with this flag to reduce the effective bandwidth and maximize optimizations for early depth-test. <br/>
+	Applications should avoid setting this flag when depth operations will never occur.<br/> <br/>
+        The following restrictions and interactions apply:
+        <ul>
+        <li>Either the texture format must support depth stencil capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support depth stencil capabilities at the current feature level.</li>
+        <li>Cannot be used with D3D12_RESOURCE_DIMENSION_BUFFER, 4KB alignment,<br/>
+	D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET,<br/>
+	D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS,<br/>
+	D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS,<br/>
+	D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE,<br/>
+	D3D12_TEXTURE_LAYOUT_ROW_MAJOR,<br/>
+	nor used with heaps that have D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES or D3D12_HEAP_FLAG_ALLOW_DISPLAY.
+        </li>
+        <li>Precludes usage of <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-writetosubresource">WriteToSubresource</a> and <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-readfromsubresource">ReadFromSubresource</a>.
+        </li>
+        <li>Precludes GPU copying of a subregion. <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> must copy a whole subresource to or from resources with this flag.</li>
+        </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS</th>
+    </tr>
+    <tr>
+        <td>
+        Allows an unordered access view to be created for the resource, as well as enables the resource to transition into the 
+	state of D3D12_RESOURCE_STATE_UNORDERED_ACCESS.<br/>
+	Some adapter architectures must resort to less efficient texture layouts in order to provide this functionality.
+	If a texture is rarely used for unordered access, it may be worth having two textures around and copying between them. One texture would have this flag,
+	while the other wouldn't. <br/>
+	Applications should avoid setting this flag when unordered access operations will never occur.<br/><br/>
+        The following restrictions and interactions apply:
+        <ul>
+        <li>Either the texture format must support unordered access capabilities at the current feature level. Or, when the format is a typeless format, a format within the same typeless group must support unordered access capabilities at the current feature level.
+        </li>
+        <li>Cannot be set in conjunction with textures that have D3D12_TEXTURE_LAYOUT_ROW_MAJOR when <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options">D3D12_FEATURE_DATA_D3D12_OPTIONS</a>::<b>CrossAdapterRowMajorTextureSupported</b> is FALSE nor in conjunction with textures that have D3D12_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE when <b>D3D12_FEATURE_DATA_D3D12_OPTIONS</b>::<b>StandardSwizzle64KBSupported</b> is FALSE, nor when the feature level is less than 11.0.
+        </li>
+        <li>Cannot be used with MSAA textures. </li>
+        </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE</th>
+    </tr>
+    <tr>
+        <td>
+        Disallows a shader resource view to be created for the resource, as well as disables the resource to transition into the state of D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE or D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE.<br/>
+	Some adapter architectures experience increased bandwidth for depth stencil textures when shader resource views are precluded.
+	If a texture is rarely used for shader resource, it may be worth having two textures around and copying between them.
+	One texture would have this flag and the other wouldn't.<br/>
+	Applications should set this flag when depth stencil textures will never be used from shader resource views. <br/><br/>
+        The following restrictions and interactions apply:
+        <ul>
+            <li>Must be used with D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL. 
+            </li>
+        </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER</th>
+    </tr>
+    <tr>
+        <td>
+        Allows the resource to be used for cross-adapter data, as well as the same features enabled by ALLOW_SIMULTANEOUS_ACCESS.<br/>
+	Cross adapter resources commonly preclude techniques that reduce effective texture bandwidth during usage,
+	and some adapter architectures may require different caching behavior.<br/>
+	Applications should avoid setting this flag when the resource data will never be used with another adapter.<br/><br/>
+        The following restrictions and interactions apply:
+        <ul>
+            <li>Must be used with heaps that have D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER.</li>
+            <li>Cannot be used with heaps that have D3D12_HEAP_FLAG_ALLOW_DISPLAY.</li>
+        </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS</th>
+    </tr>
+    <tr>
+        <td>
+        Allows a resource to be simultaneously accessed by multiple different queues, devices or processes (for example, allows a resource to be used with <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resourcebarrier">ResourceBarrier</a> transitions performed in more than one command list 
+        executing at the same time).<br/><br/>
+        Simultaneous access allows multiple readers and one writer, as long as the writer doesn't concurrently modify the texels that other readers are accessing. Some adapter architectures cannot leverage techniques to reduce effective texture bandwidth during usage.<br/><br/>
+        However, applications should avoid setting this flag when multiple readers are not required during frequent, non-overlapping writes to textures. Use of this flag can compromise resource fences to perform waits, and prevents any compression being used with a resource.<br/><br/>
+        These restrictions and interactions apply:<br/>
+	    <ul>
+            <li>Can't be used with <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_dimension">D3D12_RESOURCE_DIMENSION_BUFFER</a>
+                but buffers always have the properties represented by this flag</li>
+            <li>Can't be used with MSAA textures.</li>
+            <li>Can't be used with 
+                <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_flags">D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL</a>.</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>D3D12_RESOURCE_FLAG_VIDEO_DECODE_REFERENCE_ONLY</th>
+    </tr>
+    <tr>
+        <td>This resource may only be used as a decode reference frame.  It may only be written to or read by the video decode operation.<br/>
+            
+[D3D12_VIDEO_DECODE_TIER_1](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) and [D3D12_VIDEO_DECODE_TIER_2](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) may report [D3D12_VIDEO_DECODE_CONFIGURATION_FLAG_REFERENCE_ONLY_ALLOCATIONS_REQUIRED](../d3d12video/ne-d3d12video-d3d12_video_decode_configuration_flags) in the [D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT](../d3d12video/ns-d3d12video-d3d12_feature_data_video_decode_support) structure configuration flag.  If so, the application must allocate reference frames with the new **D3D12\_RESOURCE\_VIDEO\_DECODE\_REFERENCE\_ONLY** resource flag.<br/>
+[D3D12_VIDEO_DECODE_TIER_3](../d3d12video/ne-d3d12video-d3d12_video_decode_tier) must not set the
+[D3D12_VIDEO_DECODE_CONFIGURATION_FLAG_REFERENCE_ONLY_ALLOCATIONS_REQUIRED](../d3d12video/ne-d3d12video-d3d12_video_decode_configuration_flags) configuration flag and must not require the use of this resource flag.
+        </td>
+    </tr>
+</table>
 
 ## -remarks
 


### PR DESCRIPTION
I updated the table to make it easier to read its long content, Including updating the formatting for better readability when needed based on the context, also fixed an issue where the markdown code is outputted instead of a link.

**Reasons behind this change**:
* The second column `Description` in the table is way larger than the first one `Name`, making it a scrollable table, but because it is a very long table, the scrollbar is way down the page, not a user-friendly interaction for most screen sizes.
* This bothered me personally, but also was reported by another person on the DirectX discord mentioning the same issue, so i thought i'd open a pull request fixing all those issues at once.

**Things this edit fixes**:
* I fixed a markdown error that does not make the link show up, instead it showed the actual markdown code on the page.
* The overall user-experience is improved by using a one column table instead, the `Description` column was bigger than the `Name` column making it hard to read and follow, now it is way easier to browse and read.

**Reasons behind editing it this way**:
* I used `html` because markdown table syntax is not suitable due to the formatting of the page content.
* I had to use `<a href=""></a>` when needed because the markdown link syntax does not work inside `html` tags.

**Things to check before applying this edit**:
* [ ] Make sure that the C++ enum code at the top of the page under `Syntax` is outputted correctly, i could not check that because i have no idea how to build the docs, i guessed the previous code for `-enum-fields` and `-field` was responsible for it, so i kept at the top.
* [ ] Double-check the links and where they take (it was not possible to use the `[]()` syntax in some places because they are not parsed by markdown inside `html` tags. 

Feel free to comment further on this, thanks.