### PR TITLE
Fix typo in FileCreateW

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
@@ -220,7 +220,7 @@ The <b>lpSecurityDescriptor</b> member of the structure specifies a
        <b>lpSecurityDescriptor</b> member when opening an existing file or device, but continues 
        to use the <b>bInheritHandle</b> member.
 
-The <b>bInheritHandle</b>member of the structure specifies whether the returned handle 
+The <b>bInheritHandle</b> member of the structure specifies whether the returned handle 
        can be inherited.
 
 For more information, see the Remarks section.


### PR DESCRIPTION
Missing space in the `lpSecurityAttributes` parameter under the `Parameters` section.
https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew#parameters