### PR TITLE
CreateProcessApis: Fixed creation flags meaning of 0 for two of the process creation APIs

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-createprocesswithlogonw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createprocesswithlogonw.md
@@ -182,7 +182,7 @@ This parameter also controls the new process's priority class, which is used to 
 
 If the dwCreationFlags parameter has a value of 0:
 
-- The process inherits both the error mode of the caller and the parent's console. 
+- The process gets the default error mode, creates a new console and creates a new process group. 
 - The environment block for the new process is assumed to contain ANSI characters (see *lpEnvironment* parameter for additional information).
 - A 16-bit Windows-based application runs in a shared Virtual DOS machine (VDM).
 

--- a/sdk-api-src/content/winbase/nf-winbase-createprocesswithtokenw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createprocesswithtokenw.md
@@ -173,7 +173,7 @@ This parameter also controls the new process's priority class, which is used to 
 
 If the dwCreationFlags parameter has a value of 0:
 
-- The process inherits both the error mode of the caller and the parent's console. 
+- The process gets the default error mode, creates a new console and creates a new process group. 
 - The environment block for the new process is assumed to contain ANSI characters (see *lpEnvironment* parameter for additional information).
 - A 16-bit Windows-based application runs in a shared Virtual DOS machine (VDM).
 


### PR DESCRIPTION
See comment I did on GitHub on the 21cf29976fbf8e89452762249375d5ff549a406d commit

This is related to #592