### PR TITLE
WaitForMultipleApis: Added more clear explanation for abandoned ret vals

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjects.md
@@ -124,7 +124,7 @@ If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_OBJECT_0</b> 
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, the return value indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. 
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value within the specified range indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. 
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjects.md
@@ -323,7 +323,7 @@ This value is also returned upon the occurrence of a system event that requires 
 </dl>
 </td>
 <td width="60%">
-If <i>bWaitAll</i> is <b>TRUE</b>, the return value indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_ABANDONED_0</b> indicates the <i>pHandles</i> array index of an abandoned mutex object that satisfied the wait. Ownership of the mutex object is granted to the calling thread, and the mutex is set to nonsignaled.
+If <i>bWaitAll</i> is <b>TRUE</b>, a return value within the specified range indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. If <i>bWaitAll</i> is <b>FALSE</b>, the return value minus <b>WAIT_ABANDONED_0</b> indicates the <i>pHandles</i> array index of an abandoned mutex object that satisfied the wait. Ownership of the mutex object is granted to the calling thread, and the mutex is set to nonsignaled.
 
 If the mutex was protecting persistent state information, you should check it for consistency.
 

--- a/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-msgwaitformultipleobjectsex.md
@@ -388,7 +388,7 @@ This value is also returned upon the occurrence of a system event that requires 
 </dl>
 </td>
 <td width="60%">
-If the <b>MWMO_WAITALL</b> flag is used, the return value indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. Otherwise, the return value minus <b>WAIT_ABANDONED_0</b> indicates the <i>pHandles</i> array index of an abandoned mutex object that caused the function to return. Ownership of the mutex object is granted to the calling thread, and the mutex is set to nonsignaled.
+If the <b>MWMO_WAITALL</b> flag is used, a return value within the specified range indicates that the state of all specified objects is signaled and at least one of the objects is an abandoned mutex object. Otherwise, the return value minus <b>WAIT_ABANDONED_0</b> indicates the <i>pHandles</i> array index of an abandoned mutex object that caused the function to return. Ownership of the mutex object is granted to the calling thread, and the mutex is set to nonsignaled.
 
 If the mutex was protecting persistent state information, you should check it for consistency.
 


### PR DESCRIPTION
Related to #607

This PR adds a clearer explanation for the abandoned range of return values as well.

Thanks :)