### PR TITLE
Update nf-sddl-convertsecuritydescriptortostringsecuritydescriptorw.md

### DIFF
--- a/sdk-api-src/content/sddl/nf-sddl-convertsecuritydescriptortostringsecuritydescriptorw.md
+++ b/sdk-api-src/content/sddl/nf-sddl-convertsecuritydescriptortostringsecuritydescriptorw.md
@@ -76,10 +76,7 @@ Specifies the revision level of the output <i>StringSecurityDescriptor</i> strin
 Specifies a combination of the 
 <a href="/windows/desktop/SecAuthZ/security-information">SECURITY_INFORMATION</a> bit flags to indicate the components of the security descriptor to include in the output string. 
 
-
-
-
-					The BACKUP_SECURITY_INFORMATION 	flag is not applicable to this function. If the BACKUP_SECURITY_INFORMATION 	flag is passed in, the <i>SecurityInformation</i> parameter returns TRUE with <b>null</b> string output.
+The BACKUP_SECURITY_INFORMATION flag is not applicable to this function. If the BACKUP_SECURITY_INFORMATION flag is passed in, the <i>SecurityInformation</i> parameter returns TRUE with <b>null</b> string output.
 
 ### -param StringSecurityDescriptor [out]
 


### PR DESCRIPTION
Fixed formatting.

And while there is no immediate way to provide feedback, let me abuse this issue to report, that the documentation for the `StringSecurityDescriptorLen` needs to be fixed as well (for both the -W as well as the -A API variant). The following issues need to be addressed:

* Remove references to `TCHAR`. Neither API variant uses the generic-text mappings.
* Make it clear what *"The size represents the size of the buffer in WCHARs, not the number of WCHARs in the string."* really means (is this just a convoluted way of saying "number of characters including the NUL terminator" or is there something more to it?).
* References to `WCHAR` need to be removed from the -A API variant (presumably).