### PR TITLE
Add info on Keyboard Type values from RID_DEVICE_INFO_KEYBOARD/KEYBOARD_ATTRIBUTES/GetKeyboardType()

### DIFF
--- a/sdk-api-src/content/ntddkbd/ns-ntddkbd-keyboard_attributes.md
+++ b/sdk-api-src/content/ntddkbd/ns-ntddkbd-keyboard_attributes.md
@@ -73,6 +73,13 @@ typedef struct _KEYBOARD_ID {
 
 Specifies the keyboard type.
 
+| Value | Description                                          |
+|:-----:|------------------------------------------------------|
+|  0x4  | Enhanced 101- or 102-key keyboards (and compatibles) |
+|  0x7  | Japanese Keyboard                                    |
+|  0x8  | Korean Keyboard                                      |
+| 0x51  | Unknown type or HID keyboard                         |
+
 #### Subtype
 
 Specifies the keyboard subtype, which is a vendor-specific value.

--- a/sdk-api-src/content/ntddkbd/ns-ntddkbd-keyboard_attributes.md
+++ b/sdk-api-src/content/ntddkbd/ns-ntddkbd-keyboard_attributes.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["*PKEYBOARD_ATTRIBUTES","KEYBOARD_ATTRIBUTES","KEYBOARD_AT
 old-location: hid\keyboard_attributes.htm
 tech.root: hid
 ms.assetid: 060e93de-b84e-4755-a5f8-cbc52d900310
-ms.date: 08/06/2020
+ms.date: 02/25/2021
 ms.keywords: '*PKEYBOARD_ATTRIBUTES, KEYBOARD_ATTRIBUTES, KEYBOARD_ATTRIBUTES structure [Human Input Devices], PKEYBOARD_ATTRIBUTES, PKEYBOARD_ATTRIBUTES structure pointer [Human Input Devices], hid.keyboard_attributes, kref_430bedf0-40bc-4d93-b382-3fe4c69fcbb5.xml, ntddkbd/KEYBOARD_ATTRIBUTES, ntddkbd/PKEYBOARD_ATTRIBUTES'
 req.header: ntddkbd.h
 req.include-header: Ntddkbd.h
@@ -54,7 +54,7 @@ api_name:
 
 ## -description
 
-KEYBOARD_ATTRIBUTES specifies the attributes of a keyboard.
+Specifies the attributes of a keyboard.
 
 ## -struct-fields
 

--- a/sdk-api-src/content/winuser/nf-winuser-getkeyboardtype.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeyboardtype.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["GetKeyboardType","GetKeyboardType function [Keyboard and 
 old-location: inputdev\getkeyboardtype.htm
 tech.root: inputdev
 ms.assetid: 39b9ba8b-0cab-465c-9a58-2b69eea7de76
-ms.date: 12/05/2018
+ms.date: 02/25/2021
 ms.keywords: GetKeyboardType, GetKeyboardType function [Keyboard and Mouse Input], _win32_getkeyboardtype, base.getkeyboardtype, inputdev.getkeyboardtype, winui.getkeyboardtype, winuser/GetKeyboardType
 req.header: winuser.h
 req.include-header: Windows.h
@@ -78,12 +78,11 @@ Type: <b>int</b>
 
 If the function succeeds, the return value specifies the requested information.
 
-If the function fails and <i>nTypeFlag</i> is not one, the return value is zero; zero is a valid return value when <i>nTypeFlag</i> is one (keyboard subtype). To get extended error information, call 
-<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails and <i>nTypeFlag</i> is not 1, the return value is 0; 0 is a valid return value when <i>nTypeFlag</i> is 1 (keyboard subtype). To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 
-The type may be one of the following values:
+Valid keyboard types are:
 
 | Value | Description                                          |
 |:-----:|------------------------------------------------------|
@@ -92,7 +91,7 @@ The type may be one of the following values:
 |  0x8  | Korean Keyboard                                      |
 | 0x51  | Unknown type or HID keyboard                         |
 
-The subtype is an original equipment manufacturer (OEM)-dependent value.
+Keyboard subtypes are original equipment manufacturer (OEM)-dependent values.
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-getkeyboardtype.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeyboardtype.md
@@ -66,45 +66,11 @@ Type: <b>int</b>
 
 The type of keyboard information to be retrieved. This parameter can be one of the following values.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt>0</dt>
-</dl>
-</td>
-<td width="60%">
-Keyboard type
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt>1</dt>
-</dl>
-</td>
-<td width="60%">
-Keyboard subtype
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt>2</dt>
-</dl>
-</td>
-<td width="60%">
-The number of function keys on the keyboard
-
-</td>
-</tr>
-</table>
+| Value | Meaning                                     |
+|:-----:|---------------------------------------------|
+|   0   | Keyboard type                               |
+|   1   | Keyboard subtype                            |
+|   2   | The number of function keys on the keyboard |
 
 ## -returns
 
@@ -117,169 +83,16 @@ If the function fails and <i>nTypeFlag</i> is not one, the return value is zero;
 
 ## -remarks
 
-The type may be one of the following values.
+The type may be one of the following values:
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td>
-1
-
-</td>
-<td>
-IBM PC/XT or compatible (83-key) keyboard
-
-</td>
-</tr>
-<tr>
-<td>
-2
-
-</td>
-<td>
-Olivetti "ICO" (102-key) keyboard
-
-</td>
-</tr>
-<tr>
-<td>
-3
-
-</td>
-<td>
-IBM PC/AT (84-key) or similar keyboard
-
-</td>
-</tr>
-<tr>
-<td>
-4
-
-</td>
-<td>
-IBM enhanced (101- or 102-key) keyboard
-
-</td>
-</tr>
-<tr>
-<td>
-5
-
-</td>
-<td>
-Nokia 1050 and similar keyboards
-
-</td>
-</tr>
-<tr>
-<td>
-6
-
-</td>
-<td>
-Nokia 9140 and similar keyboards
-
-</td>
-</tr>
-<tr>
-<td>
-7
-
-</td>
-<td>
-Japanese keyboard
-
-</td>
-</tr>
-</table>
- 
+| Value | Description                                          |
+|:-----:|------------------------------------------------------|
+|  0x4  | Enhanced 101- or 102-key keyboards (and compatibles) |
+|  0x7  | Japanese Keyboard                                    |
+|  0x8  | Korean Keyboard                                      |
+| 0x51  | Unknown type or HID keyboard                         |
 
 The subtype is an original equipment manufacturer (OEM)-dependent value.
-
-The application can also determine the number of function keys on a keyboard from the keyboard type. Following are the number of function keys for each keyboard type.
-
-<table>
-<tr>
-<th>Type</th>
-<th>Number of function keys</th>
-</tr>
-<tr>
-<td>
-1
-
-</td>
-<td>
-10
-
-</td>
-</tr>
-<tr>
-<td>
-2
-
-</td>
-<td>
-12 (sometimes 18)
-
-</td>
-</tr>
-<tr>
-<td>
-3
-
-</td>
-<td>
-10
-
-</td>
-</tr>
-<tr>
-<td>
-4
-
-</td>
-<td>
-12
-
-</td>
-</tr>
-<tr>
-<td>
-5
-
-</td>
-<td>
-10
-
-</td>
-</tr>
-<tr>
-<td>
-6
-
-</td>
-<td>
-24
-
-</td>
-</tr>
-<tr>
-<td>
-7
-
-</td>
-<td>
-Hardware dependent and specified by the OEM
-
-</td>
-</tr>
-</table>
- 
-
-When a single USB keyboard is connected to the computer, this function returns the code 81.
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/ns-winuser-rid_device_info_keyboard.md
+++ b/sdk-api-src/content/winuser/ns-winuser-rid_device_info_keyboard.md
@@ -62,19 +62,28 @@ Defines the raw input data coming from the specified keyboard.
 
 Type: <b>DWORD</b>
 
-The type of the keyboard. See the Remarks section.
+The type of the keyboard.
+
+| Value | Description                                          |
+|:-----:|------------------------------------------------------|
+|  0x4  | Enhanced 101- or 102-key keyboards (and compatibles) |
+|  0x7  | Japanese Keyboard                                    |
+|  0x8  | Korean Keyboard                                      |
+| 0x51  | Unknown type or HID keyboard                         |
+
+See the Remarks section.
 
 ### -field dwSubType
 
 Type: <b>DWORD</b>
 
-The subtype of the keyboard. See the Remarks section.
+The vendor-specific subtype of the keyboard. See the Remarks section.
 
 ### -field dwKeyboardMode
 
 Type: <b>DWORD</b>
 
-The scan code mode. See the Remarks section.
+The scan code mode. Usually 1 which means that *Scan Code Set 1* is used. See [Keyboard Scan Code Specification](http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/scancode.doc).
 
 ### -field dwNumberOfFunctionKeys
 

--- a/sdk-api-src/content/winuser/ns-winuser-rid_device_info_keyboard.md
+++ b/sdk-api-src/content/winuser/ns-winuser-rid_device_info_keyboard.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["*PRID_DEVICE_INFO_KEYBOARD","PRID_DEVICE_INFO_KEYBOARD","
 old-location: inputdev\rid_device_info_keyboard.htm
 tech.root: inputdev
 ms.assetid: VS|winui|~\winui\windowsuserinterface\userinput\rawinput\rawinputreference\rawinputstructures\rid_device_info_keyboard.htm
-ms.date: 12/05/2018
+ms.date: 02/25/2021
 ms.keywords: '*PRID_DEVICE_INFO_KEYBOARD, PRID_DEVICE_INFO_KEYBOARD, PRID_DEVICE_INFO_KEYBOARD structure pointer [Keyboard and Mouse Input], RID_DEVICE_INFO_KEYBOARD, RID_DEVICE_INFO_KEYBOARD structure [Keyboard and Mouse Input], _win32_RID_DEVICE_INFO_KEYBOARD_str, _win32_rid_device_info_keyboard_str_cpp, inputdev.rid_device_info_keyboard, winui._win32_rid_device_info_keyboard_str, winuser/PRID_DEVICE_INFO_KEYBOARD, winuser/RID_DEVICE_INFO_KEYBOARD'
 req.header: winuser.h
 req.include-header: Windows.h
@@ -62,7 +62,7 @@ Defines the raw input data coming from the specified keyboard.
 
 Type: <b>DWORD</b>
 
-The type of the keyboard.
+The type of keyboard. See [Remarks](#remarks).
 
 | Value | Description                                          |
 |:-----:|------------------------------------------------------|
@@ -71,19 +71,17 @@ The type of the keyboard.
 |  0x8  | Korean Keyboard                                      |
 | 0x51  | Unknown type or HID keyboard                         |
 
-See the Remarks section.
-
 ### -field dwSubType
 
 Type: <b>DWORD</b>
 
-The vendor-specific subtype of the keyboard. See the Remarks section.
+The vendor-specific subtype of the keyboard. See [Remarks](#remarks).
 
 ### -field dwKeyboardMode
 
 Type: <b>DWORD</b>
 
-The scan code mode. Usually 1 which means that *Scan Code Set 1* is used. See [Keyboard Scan Code Specification](http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/scancode.doc).
+The scan code mode. Usually 1, which means that *Scan Code Set 1* is used. See [Keyboard Scan Code Specification](http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/scancode.doc).
 
 ### -field dwNumberOfFunctionKeys
 


### PR DESCRIPTION
Added info on `dwKeyboardMode` from RID_DEVICE_INFO_KEYBOARD.
Removed outdated Keyboard Types and KeyboardType->NumberOfFunction table in GetKeyboardType() docs.