### PR TITLE
Update nf-synchapi-createmutexw.md

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexw.md
@@ -104,7 +104,7 @@ If the function succeeds, the return value is a handle to the newly created mute
 If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 If the mutex is a named mutex and the object existed before this function call, the return value is a handle to the existing object, 
-[OpenMutex](./nf-synchapi-openmutexw.md) function.
+and the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> function returns <b>ERROR_ALREADY_EXISTS</b>.
 
 ## -remarks
 


### PR DESCRIPTION
An earlier revision removed important information about the API. Change should be reverted