### PR TITLE
Fix a link in DoEnvironmentSubstA pointing to wrong place

### DIFF
--- a/sdk-api-src/content/shellapi/nf-shellapi-doenvironmentsubsta.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-doenvironmentsubsta.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-<p class="CCE_Message">[This function is retained only for backward compatibility. Use <a href="/windows/desktop/api/rrascfg/nn-rrascfg-ieapproviderconfig">ExpandEnvironmentStrings</a> instead.]
+<p class="CCE_Message">[This function is retained only for backward compatibility. Use <a href="/windows/desktop/api/processenv/nf-processenv-expandenvironmentstringsa">ExpandEnvironmentStrings</a> instead.]
 
 Parses an input string that contains references to one or more environment variables and replaces them with their fully expanded values.
 

--- a/sdk-api-src/content/shellapi/nf-shellapi-doenvironmentsubsta.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-doenvironmentsubsta.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-<p class="CCE_Message">[This function is retained only for backward compatibility. Use <a href="/windows/desktop/api/processenv/nf-processenv-expandenvironmentstringsa">ExpandEnvironmentStrings</a> instead.]
+<p class="CCE_Message">[This function is retained only for backward compatibility. Use <a href="/windows/win32/api/processenv/nf-processenv-expandenvironmentstringsa">ExpandEnvironmentStrings</a> instead.]
 
 Parses an input string that contains references to one or more environment variables and replaces them with their fully expanded values.
 


### PR DESCRIPTION
The link for `ExpandEnvironmentStrings` in the article for `DoEnvironmentSubstA` is pointed to a wrong place. This PR fixes that.