### PR TITLE
Fix formatting in ITaskbarList3::SetProgressValue

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressvalue.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressvalue.md
@@ -121,7 +121,7 @@ In the case of a priority collision where two windows are broadcasting determina
 
 Based on that priority, this determinate (specific percentage) progress indicator can be displayed in these cases:
     
-                    <ul>
+<ul>
 <li>The taskbar button does not represent a group and the single window that it represents is broadcasting determinate progress information through this method.</li>
 <li>The taskbar button represents a group, only one window in that group is broadcasting progress information, and that window is broadcasting determinate progress information through this method.</li>
 <li>The taskbar button represents a group, multiple windows in that group are broadcasting progress information, at least one of those windows is broadcasting progress information through this method, and none of those windows has set the <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-itaskbarlist3-setprogressstate">TBPF_ERROR</a> or <b>TBPF_PAUSED</b> state.</li>


### PR DESCRIPTION
Because of indentation before the `<ul>` tag in Markdown, the tag was recognised as code in code block.

![Screenshot of the code block containing indentation and an <ul> tag](https://user-images.githubusercontent.com/12915102/106212407-d3d26080-61ca-11eb-85b8-883d0c532759.png)

Removing the indentation causes the tag to be correctly recognised as the beginning of an unordered list.\
Another (maybe better) way to fix it would be rewriting the HTML list using Markdown syntax.