### PR TITLE
SwitchToThread() return value is retrospective

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-switchtothread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-switchtothread.md
@@ -64,7 +64,7 @@ Causes the calling thread to yield execution to another thread that is ready to 
 ## -returns
 
 If calling the 
-<b>SwitchToThread</b> function causes the operating system to switch execution to another thread, the return value is nonzero.
+<b>SwitchToThread</b> function caused the operating system to switch execution to another thread, the return value is nonzero.
 
 If there are no other threads ready to execute, the operating system does not switch execution to another thread, and the return value is zero.
 


### PR DESCRIPTION
It seems more correct to use the past tense when talking about the return value, since the "switching away" action has long-since occurred.