### PR TITLE
Update ns-commdlg-openfilenamea.md

### DIFF
--- a/sdk-api-src/content/commdlg/ns-commdlg-openfilenamea.md
+++ b/sdk-api-src/content/commdlg/ns-commdlg-openfilenamea.md
@@ -87,7 +87,7 @@ Type: <b>LPCTSTR</b>
 
 A buffer containing pairs of null-terminated filter strings. The last string in the buffer must be terminated by two <b>NULL</b> characters. 
 
-The first string in each pair is a display string that describes the filter (for example, "Text Files"), and the second string specifies the filter pattern (for example, "*.TXT"). To specify multiple filter patterns for a single display string, use a semicolon to separate the patterns (for example, "*.TXT;*.DOC;*.BAK"). A pattern string can be a combination of valid file name characters and the asterisk (*) wildcard character. Do not include spaces in the pattern string.
+The first string in each pair is a display string that describes the filter (for example, "Text Files"), and the second string specifies the filter pattern (for example, <code>"*.TXT"</code>). To specify multiple filter patterns for a single display string, use a semicolon to separate the patterns (for example, <code>"*.TXT;*.DOC;*.BAK"</code>). A pattern string can be a combination of valid file name characters and the asterisk (\*) wildcard character. Do not include spaces in the pattern string.
 
 The system does not change the order of the filters. It displays them in the <b>File Types</b> combo box in the order specified in <b>lpstrFilter</b>.
 


### PR DESCRIPTION
codify the example filter strings so people stop being confused by stray italic text and missing asterisks.

I just came from helping someone being confused by this and only barely caught the italics hinting at asterisks that needed to be in the example string. 

So I added code tags to match the other example string where the asterisks are properly rendered and escaped the stray one to avoid future issues.