### PR TITLE
Incorrect IStream inheritance

### DIFF
--- a/sdk-api-src/content/objidl/nn-objidl-istream.md
+++ b/sdk-api-src/content/objidl/nn-objidl-istream.md
@@ -101,7 +101,7 @@ For general information on this topic, see
 
 ## -inheritance
 
-The <b xmlns:loc="http://microsoft.com/wdcml/l10n">IStream</b> interface inherits from the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>IStream</b> also has these types of members:
+The <b xmlns:loc="http://microsoft.com/wdcml/l10n">IStream</b> interface inherits from the <a href="/windows/win32/api/objidl/nn-objidl-isequentialstream">ISequentialStream</a> interface. <b>IStream</b> also has these types of members:
 <ul>
 <li><a href="https://docs.microsoft.com/">Methods</a></li>
 </ul>


### PR DESCRIPTION
Please note that IStream inherits directly from ISequentialStream.