### PR TITLE
Update nf-shlobj_core-shgetfolderpathw.md

### DIFF
--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetfolderpathw.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetfolderpathw.md
@@ -122,7 +122,7 @@ Retrieve the folder's default path.
 
 ### -param pszPath [out]
 
-Type: <b>LPTSTR</b>
+Type: <b>LPWSTR</b>
 
 A pointer to a <b>null</b>-terminated string of length MAX_PATH which will receive the path. If an error occurs or S_FALSE is returned, this string will be empty. The returned path does not include a trailing backslash. For example, "C:\Users" is returned rather than "C:\Users\\".
 


### PR DESCRIPTION
The parameter type for pszPath is incorrectly listed as LPTSTR, while ShlObj_core.h declares it as LPWSTR