### PR TITLE
Update nf-winuser-setfocus.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-setfocus.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setfocus.md
@@ -78,6 +78,8 @@ Type: **HWND**
 
 If the function succeeds, the return value is the handle to the window that previously had the keyboard focus. If the *hWnd* parameter is invalid or the window is not attached to the calling thread's message queue, the return value is NULL. To get extended error information, call [GetLastError function](../errhandlingapi/nf-errhandlingapi-getlasterror.md).
 
+Extended error ERROR_INVALID_PARAMETER (0x57) means that window is in disabled state.
+
 ## -remarks
 
 This function sends a [WM_KILLFOCUS](/windows/desktop/inputdev/wm-killfocus) message to the window that loses the keyboard focus and a [WM_SETFOCUS](/windows/desktop/inputdev/wm-setfocus) message to the window that receives the keyboard focus. It also activates either the window that receives the focus or the parent of the window that receives the focus.


### PR DESCRIPTION
Documentation should specify what causes different errors. For example, during debugging of large app, I got ERROR_INVALID_PARAMETER, it it's really not obvious why.

Adding comment:
Extended error ERROR_INVALID_PARAMETER (0x57) means that window is in disabled state.