### PR TITLE
Add remarks on TerminateProcess for already terminated processes

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminateprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminateprocess.md
@@ -98,6 +98,8 @@ to the process.
 
 A process cannot prevent itself from being terminated.
 
+After a process has terminated, call to <b>TerminateProcess</b> with open handles to the process fails with <b>ERROR_ACCESS_DENIED</b> (5) error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-exitprocess">ExitProcess</a>


### PR DESCRIPTION
Calling `TerminateProcess` to terminate an already terminated process results in access denied error. There are multiple threads on the Internet discussing `TerminateProcess` failure with `ERROR_ACCESS_DENIED` despite having the handle opened with full access. But none of them have clarity on this special case.