### PR TITLE
Update nf-winbase-createprocesswithtokenw.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-createprocesswithtokenw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createprocesswithtokenw.md
@@ -71,8 +71,7 @@ To get a primary token that represents the specified user, call the
 <a href="/windows/desktop/api/winbase/nf-winbase-logonusera">LogonUser</a> function. Alternatively, you can call the 
 <a href="/windows/desktop/api/securitybaseapi/nf-securitybaseapi-duplicatetokenex">DuplicateTokenEx</a> function to convert an impersonation token into a primary token. This allows a server application that is impersonating a client to create a process that has the security context of the client.
 
-<b>Terminal Services:  </b>The process is run in the session specified in the token. By default, this is the same session that called <a href="/windows/desktop/api/winbase/nf-winbase-logonusera">LogonUser</a>. To change the session, use the 
-<a href="/windows/desktop/api/securitybaseapi/nf-securitybaseapi-settokeninformation">SetTokenInformation</a> function.
+<b>Terminal Services:  </b>The caller's process always runs in the caller's session, not in the session specified in the token. To run a process in the session specified in the token, use the CreateProcessAsUser function.
 
 ### -param dwLogonFlags [in]
 


### PR DESCRIPTION
This change is based on attempts to use this API to start a process in an existing interactive desktop session and as the desktop user, from a session 0 process running as local system. I finally found the page below, where then-Microsoft dev Eric Perlin says that CreateProcessWithTokenW and CreateProcessWithLogon start the new process in the caller's session.
https://social.msdn.microsoft.com/Forums/en-US/f38b0dd4-d69f-4b7e-b85c-af40a1425636/createprocesswithtokenw-succeeds-but-is-not-using-the-token