### PR TITLE
Docs page confuses GetLastError with return value

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-createdibsection.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-createdibsection.md
@@ -120,13 +120,13 @@ The offset from the beginning of the file-mapping object referenced by <i>hSecti
 
 If the function succeeds, the return value is a handle to the newly created DIB, and *<i>ppvBits</i> points to the bitmap bit values.
 
-If the function fails, the return value is <b>NULL</b>, and *<i>ppvBits</i> is <b>NULL</b>.
+If the function fails, the return value is <b>NULL</b>, and *<i>ppvBits</i> is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
-This function can return the following value.
+<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> can return the following value:
 
 <table>
 <tr>
-<th>Return code</th>
+<th>Error code</th>
 <th>Description</th>
 </tr>
 <tr>


### PR DESCRIPTION
The docs page is wrong when it lists ERROR_INVALID_PARAMETER as a "return value" and fails to mention GetLastError: https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createdibsection#return-value

You can verify this by passing an invalid value to the `usage` parameter, such as 12345. CreateDIBSection then returns `0` and GetLastError returns ERROR_INVALID_PARAMETER.

Hans Passant (a reliable source in this area) says the same thing here: https://stackoverflow.com/questions/7932153/windows-gdi-context-createdibsection#comment9693188_7932153