### PR TITLE
Fix broken link to SIO_TCP_INFO page

### DIFF
--- a/sdk-api-src/content/mstcpip/ns-mstcpip-tcp_info_v0.md
+++ b/sdk-api-src/content/mstcpip/ns-mstcpip-tcp_info_v0.md
@@ -142,7 +142,7 @@ To get an instance of this structure,  call the
 
 ## -see-also
 
-<a href="/previous-versions/windows/desktop/legacy/mt823415(v=vs.85)">SIO_TCP_INFO</a>
+<a href="/windows/win32/winsock/sio-tcp-info">SIO_TCP_INFO</a>
 
 
 


### PR DESCRIPTION
The link should be https://docs.microsoft.com/en-us/windows/win32/winsock/sio-tcp-info. The links in these pages seem to be some sort of sub-URL, though. Did I do it right?