### PR TITLE
Update nf-wlanapi-wlansetprofileeapxmluserdata.md

### DIFF
--- a/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
+++ b/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
@@ -45,18 +45,15 @@ api_name:
  - WlanSetProfileEapXmlUserData
 ---
 
-# WlanSetProfileEapXmlUserData function
-
-
 ## -description
 
-The <b>WlanSetProfileEapXmlUserData</b> function sets the Extensible Authentication Protocol (EAP) user credentials as specified by an XML string. The user credentials apply to a profile on an adapter. These credentials can only be used by the caller.
+The **WlanSetProfileEapXmlUserData** function sets the Extensible Authentication Protocol (EAP) user credentials as specified by an XML string. The user credentials apply to a profile on an adapter. These credentials can be used only by the caller.
 
 ## -parameters
 
 ### -param hClientHandle [in]
 
-The client's session handle, obtained by a previous call to the <a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlanopenhandle">WlanOpenHandle</a> function.
+The client's session handle, obtained by a previous call to the <a href="/windows/win32/api/wlanapi/nf-wlanapi-wlanopenhandle">WlanOpenHandle</a> function.
 
 ### -param pInterfaceGuid [in]
 
@@ -188,7 +185,7 @@ The request is not supported.
 
 This value is returned when profile settings do not permit storage of user data. This can occur when single signon (SSO) is enabled. 
 
-On Windows 7, Windows Server 2008 R2 ,  and later, this value is returned if the <a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata">WlanSetProfileEapXmlUserData</a> function was called on a profile that uses a method other than 802.1X for authentication. 
+On Windows 7, Windows Server 2008 R2 ,  and later, this value is returned if the <a href="/windows/win32/api/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata">WlanSetProfileEapXmlUserData</a> function was called on a profile that uses a method other than 802.1X for authentication. 
 
 </td>
 </tr>
@@ -218,52 +215,50 @@ Various error codes.
 
 ## -remarks
 
-The  <b>WlanSetProfileEapXmlUserData</b> function sets the EAP user credentials to use on a profile.  This function can only be called on a profile that uses 802.1X for authentication. On Windows Vista and Windows Server 2008, these credentials can only be used by the caller.
+The  **WlanSetProfileEapXmlUserData** function sets the EAP user credentials to use on a profile. This function can be called only on a profile that uses 802.1X for authentication. On Windows Vista and Windows Server 2008, these credentials can only be used by the caller.
 
-The <i>eapType</i> parameter is an  <a href="/windows/desktop/api/eaptypes/ns-eaptypes-eap_method_type">EAP_METHOD_TYPE</a> structure that contains type, identification, and author information about an EAP method. The <b>eapType</b> member of the <b>EAP_METHOD_TYPE</b> structure is an  <a href="/windows/desktop/api/eaptypes/ns-eaptypes-eap_type">EAP_TYPE</a> structure that contains the type and vendor identification information for an EAP method.
-
+The <i>eapType</i> parameter is an  <a href="/windows/win32/api/eaptypes/ns-eaptypes-eap_method_type">EAP_METHOD_TYPE</a> structure that contains type, identification, and author information about an EAP method. The <b>eapType</b> member of the <b>EAP_METHOD_TYPE</b> structure is an  <a href="/windows/win32/api/eaptypes/ns-eaptypes-eap_type">EAP_TYPE</a> structure that contains the type and vendor identification information for an EAP method.
 
 For more information on the allocation of EAP method types, see section 6.2 of <a href="http://tools.ietf.org/html/rfc3748">RFC 3748</a> published by the IETF.
 
-On Windows 10, Windows Server 2016,  and later, the  <b>WlanSetProfileEapXmlUserData</b> function is enhanced. EAP user credentials can be set for all users of  a profile if the <i>dwFlags</i> parameter contains <b>WLAN_SET_EAPHOST_DATA_ALL_USERS</b>. 
+On Windows 10, Windows Server 2016,  and later, the  **WlanSetProfileEapXmlUserData** function is enhanced. EAP user credentials can be set for all users of  a profile if the <i>dwFlags</i> parameter contains <b>WLAN_SET_EAPHOST_DATA_ALL_USERS</b>. 
 
 All wireless LAN functions require an interface GUID for the wireless interface when performing profile operations. When a wireless interface is removed, its state is cleared from Wireless LAN Service (WLANSVC)  and no profile operations are possible.
 
-The <b>WlanSetProfileEapXmlUserData</b> function can fail with <b>ERROR_INVALID_PARAMETER</b> if the wireless interface specified in the <i>pInterfaceGuid</i> parameter has been removed from the system (a USB  wireless adapter that has been removed, for example). 
+The **WlanSetProfileEapXmlUserData** function can fail with <b>ERROR_INVALID_PARAMETER</b> if the wireless interface specified in the <i>pInterfaceGuid</i> parameter has been removed from the system (a USB  wireless adapter that has been removed, for example). 
 
-The <b>WlanSetProfileEapXmlUserData</b> may cause wireless conenction fail when use EAP-TTLS if the API is called from 32-bit builds application but the OS Platform is 64-Bit.
-Your application should be built by the same CPU architecture of the OS Platform. 
+The **WlanSetProfileEapXmlUserData** might cause wireless connection failure when you use **EAP-TTLS** and the API is called from a 32-bit application running on a 64-bit operating system (OS). Your application should be built for the same CPU architecture as the target OS.
 
-<b>Windows XP with SP3 and Wireless LAN API for Windows XP with SP2:  </b>This function can only be used for Protected EAP (PEAP) credentials. It cannot be used for other EAP types.
+<b>Windows XP with SP3 and Wireless LAN API for Windows XP with SP2: </b>This function can only be used for Protected EAP (PEAP) credentials. It can't be used for other EAP types.
 
 ## -see-also
 
-<a href="/windows/desktop/api/eaptypes/ns-eaptypes-eap_method_type">EAP_METHOD_TYPE</a>
+<a href="/windows/win32/api/eaptypes/ns-eaptypes-eap_method_type">EAP_METHOD_TYPE</a>
 
 
 
-<a href="/windows/desktop/api/eaptypes/ns-eaptypes-eap_type">EAP_TYPE</a>
+<a href="/windows/win32/api/eaptypes/ns-eaptypes-eap_type">EAP_TYPE</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlangetprofile">WlanGetProfile</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlangetprofile">WlanGetProfile</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlangetprofilecustomuserdata">WlanGetProfileCustomUserData</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlangetprofilecustomuserdata">WlanGetProfileCustomUserData</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlangetprofilelist">WlanGetProfileList</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlangetprofilelist">WlanGetProfileList</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofile">WlanSetProfile</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlansetprofile">WlanSetProfile</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofilecustomuserdata">WlanSetProfileCustomUserData</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlansetprofilecustomuserdata">WlanSetProfileCustomUserData</a>
 
 
 
-<a href="/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofileeapuserdata">WlanSetProfileEapUserData</a>
+<a href="/windows/win32/api/wlanapi/nf-wlanapi-wlansetprofileeapuserdata">WlanSetProfileEapUserData</a>

--- a/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
+++ b/sdk-api-src/content/wlanapi/nf-wlanapi-wlansetprofileeapxmluserdata.md
@@ -231,6 +231,9 @@ All wireless LAN functions require an interface GUID for the wireless interface 
 
 The <b>WlanSetProfileEapXmlUserData</b> function can fail with <b>ERROR_INVALID_PARAMETER</b> if the wireless interface specified in the <i>pInterfaceGuid</i> parameter has been removed from the system (a USB  wireless adapter that has been removed, for example). 
 
+The <b>WlanSetProfileEapXmlUserData</b> may cause wireless conenction fail when use EAP-TTLS if the API is called from 32-bit builds application but the OS Platform is 64-Bit.
+Your application should be built by the same CPU architecture of the OS Platform. 
+
 <b>Windows XP with SP3 and Wireless LAN API for Windows XP with SP2:  </b>This function can only be used for Protected EAP (PEAP) credentials. It cannot be used for other EAP types.
 
 ## -see-also


### PR DESCRIPTION
I have found that  TtlsCfg always use 64 bit buffer to convert the user BLOB.
This API should mentioned that for EAP-TTLS, the application builds should be the same as OS Platform.
There is also a forum that discussed this problem:
WlanSetProfileEapXmlUserData for EAP-TTLS with inner method EAP-MSCHAPv2(not MSCHAPv2)
https://social.msdn.microsoft.com/Forums/en-US/f013931c-e9cc-4c14-bc62-363219c9dd69/wlansetprofileeapxmluserdata-for-eapttls-with-inner-method-eapmschapv2not-mschapv2

Doc fix suggestion:
------
The WlanSetProfileEapXmlUserData may cause wireless conenction fail when use EAP-TTLS if the API is called from 32-bit builds application but the OS Platform is 64-Bit. Your application should be built by the same CPU architecture of the OS Platform.
------