### PR TITLE
Update BCrypt DSA structure documentation

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgeneratekeypair.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgeneratekeypair.md
@@ -88,9 +88,9 @@ The key size must be greater than or equal to 512 bits, less than or equal to 40
 </dl>
 </td>
 <td width="60%">
-Prior to Windows 8, the key size must be greater than or equal to 512 bits, less than or equal to 1024 bits, and must be a multiple of 64. 
+Prior to Windows 8, the key size must be greater than or equal to 512 bits, less than or equal to 1024 bits, and must be a multiple of 64.
 
-Beginning with Windows 8, the key size must be greater than or equal to 512 bits, less than or equal to 3072 bits, and must be a multiple of 64. Processing for key sizes less than or equal to 1024 bits adheres to FIPS-186-2. Processing for key sizes greater than 1024 and less than or equal to 3072 adheres to FIPS 186-3.
+Beginning with Windows 8, the key size must be greater than or equal to 512 bits, less than or equal to 3072 bits, and must be a multiple of 64. Processing for key sizes less than or equal to 1024 bits adheres to FIPS 186-2. Processing for key sizes greater than 1024 and less than or equal to 3072 adheres to FIPS 186-3.
 
 </td>
 </tr>

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob.md
@@ -109,7 +109,7 @@ The 160-bit prime factor, in big-endian format.
 
 ## -remarks
 
-The structure applies to DSA keys that equal or exceed 512 bits in length but are less  than or equal to 1024 bits.
+The structure applies to DSA keys that equal or exceed 512 bits in length but are less than or equal to 1024 bits.
 
 This structure is used as a header for a larger buffer. A DSA <a href="/windows/desktop/SecGloss/p-gly">public key BLOB</a> (BCRYPT_DSA_PUBLIC_BLOB) has the following format in contiguous memory. The Modulus, Generator, and Public numbers are in big-endian format.
 
@@ -133,6 +133,4 @@ PrivateExponent[20]   // Big-endian.
 
 <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptexportkey">BCryptExportKey</a>
 
-
-
-<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptimportkey">BCryptImportKey</a>
+<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptimportkeypair">BCryptImportKeyPair</a>

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob_v2.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_key_blob_v2.md
@@ -68,9 +68,9 @@ Determines the type of key this structure represents. This can be one of the fol
 <th>Meaning</th>
 </tr>
 <tr>
-<td width="40%"><a id="BCRYPT_DSA_PUBLIC_MAGIC"></a><a id="bcrypt_dsa_public_magic"></a><dl>
-<dt><b>BCRYPT_DSA_PUBLIC_MAGIC</b></dt>
-<dt>0x42505344</dt>
+<td width="40%"><a id="BCRYPT_DSA_PUBLIC_MAGIC_V2"></a><a id="bcrypt_dsa_public_magic_v2"></a><dl>
+<dt><b>BCRYPT_DSA_PUBLIC_MAGIC_V2</b></dt>
+<dt>0x32425044</dt>
 </dl>
 </td>
 <td width="60%">
@@ -79,9 +79,9 @@ The structure represents a DSA public key.
 </td>
 </tr>
 <tr>
-<td width="40%"><a id="BCRYPT_DSA_PRIVATE_MAGIC"></a><a id="bcrypt_dsa_private_magic"></a><dl>
-<dt><b>BCRYPT_DSA_PRIVATE_MAGIC</b></dt>
-<dt>0x56505344</dt>
+<td width="40%"><a id="BCRYPT_DSA_PRIVATE_MAGIC_V2"></a><a id="bcrypt_dsa_private_magic_v2"></a><dl>
+<dt><b>BCRYPT_DSA_PRIVATE_MAGIC_V2</b></dt>
+<dt>0x32565044</dt>
 </dl>
 </td>
 <td width="60%">
@@ -101,46 +101,48 @@ A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-hashalgorithm_enum">HASHALGORIT
 
 ### -field standardVersion
 
-A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-dsafipsversion_enum">DSAFIPSVERSION_ENUM</a> enumeration value that specifies the Federal Information Processing Standard(FIPS) to apply.
+A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-dsafipsversion_enum">DSAFIPSVERSION_ENUM</a> enumeration value that specifies the Federal Information Processing Standard (FIPS) to apply.
 
 ### -field cbSeedLength
 
-Length of the seed used to generate the prime number q.
+Length of the seed used to generate the prime number <i>q</i> in bytes.
 
 ### -field cbGroupSize
 
-Size of the prime number q . Currently, if the key is less than 128 bits, q is 20 bytes long. If the key exceeds 256 bits, q is 32 bytes long.
+Size of the prime number <i>q</i> in bytes. Currently, when the key exceeds 1024 bits in length, <i>q</i> is 32 bytes long.
 
 ### -field Count
 
-The number of iterations performed to generate the prime number q from the seed. For more information, see NIST standard FIPS186-3.
+The number of iterations performed to generate the prime number <i>q</i> from the seed. For more information, see NIST standard FIPS186-3.
 
 ## -remarks
 
-The structure applies to DSA keys that exceed 1024 bits in length but are less  than or equal to 3072 bits.
+The structure applies to DSA keys that exceed 1024 bits in length but are less than or equal to 3072 bits.
 
-This structure is used as a header for a larger buffer. A DSA <a href="/windows/desktop/SecGloss/p-gly">public key BLOB</a> (BCRYPT_DSA_PUBLIC_BLOB) has the following format in contiguous memory. The Modulus, Generator, and Public numbers are in big-endian format.
+This structure is used as a header for a larger buffer. A DSA <a href="/windows/desktop/SecGloss/p-gly">public key BLOB</a> (BCRYPT_DSA_PUBLIC_BLOB) has the following format in contiguous memory. The Seed, q, Modulus, Generator, and Public numbers are in big-endian format.
 
 <pre class="syntax" xml:space="preserve"><code>
 BCRYPT_DSA_KEY_BLOB_V2
-Modulus[cbKey]     // Big-endian.
-Generator[cbKey]   // Big-endian.
-Public[cbKey]      // Big-endian.
+Seed[cbSeedLength]  // Big-endian.
+q[cbGroupSize]      // Big-endian.
+Modulus[cbKey]      // Big-endian.
+Generator[cbKey]    // Big-endian.
+Public[cbKey]       // Big-endian.
 </code></pre>
-A DSA <a href="/windows/desktop/SecGloss/p-gly">private key BLOB</a> (BCRYPT_DSA_PRIVATE_BLOB) has the following format in contiguous memory. The Modulus, Generator, Public, and PrivateExponent numbers are in big-endian format.
+A DSA <a href="/windows/desktop/SecGloss/p-gly">private key BLOB</a> (BCRYPT_DSA_PRIVATE_BLOB) has the following format in contiguous memory. The Seed, q, Modulus, Generator, Public, and PrivateExponent numbers are in big-endian format.
 
 <pre class="syntax" xml:space="preserve"><code>
 BCRYPT_DSA_KEY_BLOB_V2
-Modulus[cbKey]         // Big-endian.
-Generator[cbKey]       // Big-endian.
-Public[cbKey]          // Big-endian.
-PrivateExponent[20]    // Big-endian.
+Seed[cbSeedLength]              // Big-endian.
+q[cbGroupSize]                  // Big-endian.
+Modulus[cbKey]                  // Big-endian.
+Generator[cbKey]                // Big-endian.
+Public[cbKey]                   // Big-endian.
+PrivateExponent[cbGroupSize]    // Big-endian.
 </code></pre>
 
 ## -see-also
 
 <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptexportkey">BCryptExportKey</a>
 
-
-
-<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptimportkey">BCryptImportKey</a>
+<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptimportkeypair">BCryptImportKeyPair</a>

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_parameter_header.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_parameter_header.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-The <b>BCRYPT_DSA_PARAMETER_HEADER</b> structure is used to contain parameter header information for a <a href="/windows/desktop/SecGloss/d-gly">Digital Signature Algorithm</a> (DSA) key. This structure is used with the <a href="/windows/desktop/SecCNG/cng-property-identifiers">BCRYPT_DSA_PARAMETERS</a> property in the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> function.
+The <b>BCRYPT_DSA_PARAMETER_HEADER</b> structure is used as a header for a <a href="/windows/desktop/SecGloss/d-gly">Digital Signature Algorithm</a> (DSA) parameters <a href="/windows/desktop/SecGloss/b-gly">BLOB</a> containing information for generating a DSA key. This structure is used with the <a href="/windows/desktop/SecCNG/cng-property-identifiers">BCRYPT_DSA_PARAMETERS</a> property in the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> function.
 
 ## -struct-fields
 
@@ -91,19 +91,22 @@ The 160-bit prime factor, in big-endian format.
 
 ## -remarks
 
-This structure is used as a header for a larger buffer. 
+When using this structure in a <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> call, to set the parameters for a DSA key created in a <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair">BCryptGenerateKeyPair</a> call, (cbKeyLength*8) must equal the previously set dwLength.
 
-The single memory block consists of the following items:
+The structure applies to DSA keys that equal or exceed 512 bits in length but are less than or equal to 1024 bits.
 
-<ul>
-<li>This structure followed by a buffer of <b>cbKeyLength</b> size that contains the DSA prime number, in big-endian format.</li>
-<li>Another buffer of <b>cbKeyLength</b> size that contains the DSA generator number, in big-endian format.</li>
-</ul>
+This structure is used as a header for a larger buffer. The DSA parameters blob has the following format in contiguous memory. The Modulus and Generator are in big-endian format.
+
+<pre class="syntax" xml:space="preserve"><code>
+BCRYPT_DSA_PARAMETER_HEADER
+Modulus[cbKeyLength]    // Big-endian.
+Generator[cbKeyLength]  // Big-endian.
+</code></pre>
 
 ## -see-also
 
+<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair">BCryptGenerateKeyPair</a>
+
 <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a>
-
-
 
 <a href="/windows/desktop/SecCNG/cng-property-identifiers">Cryptography Primitive Property Identifiers</a>

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_parameter_header_v2.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_dsa_parameter_header_v2.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-The <b>BCRYPT_DSA_PARAMETER_HEADER_V2</b> structure is contains parameter header information for a <a href="/windows/desktop/SecGloss/d-gly">Digital Signature Algorithm</a> (DSA) key. This structure is used with the <a href="/windows/desktop/SecCNG/cng-property-identifiers">BCRYPT_DSA_PARAMETERS</a> property in the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> function.
+The <b>BCRYPT_DSA_PARAMETER_HEADER_V2</b> structure is used as a header for a <a href="/windows/desktop/SecGloss/d-gly">Digital Signature Algorithm</a> (DSA) parameters <a href="/windows/desktop/SecGloss/b-gly">BLOB</a> containing information for generating a DSA key. This structure is used with the <a href="/windows/desktop/SecCNG/cng-property-identifiers">BCRYPT_DSA_PARAMETERS</a> property in the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> function.
 
 ## -struct-fields
 
@@ -83,24 +83,40 @@ A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-hashalgorithm_enum">HASHALGORIT
 
 ### -field standardVersion
 
-A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-dsafipsversion_enum">DSAFIPSVERSION_ENUM</a> enumeration value that specifies the Federal Information Processing Standard(FIPS) to apply.
+A <a href="/windows/desktop/api/bcrypt/ne-bcrypt-dsafipsversion_enum">DSAFIPSVERSION_ENUM</a> enumeration value that specifies the Federal Information Processing Standard (FIPS) to apply.
 
 ### -field cbSeedLength
 
-Length of the seed used to generate the prime number q.
+Length of the seed used to generate the prime number <i>q</i> in bytes.
 
 ### -field cbGroupSize
 
-Size of the prime number q . Currently, if the key is less than 128 bits, q is 20 bytes long. If the key exceeds 256 bits, q is 32 bytes long.
+Size of the prime number <i>q</i>. Currently, when the key exceeds 1024 bits in length, <i>q</i> is 32 bytes long.
 
 ### -field Count
 
 The number of iterations performed to generate the prime number q from the seed. For more information, see NIST standard FIPS186-3.
 
+## -remarks
+
+When using this structure in a <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a> call, to set the parameters for a DSA key created in a <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair">BCryptGenerateKeyPair</a> call, (cbKeyLength*8) must equal the previously set dwLength.
+
+The structure applies to DSA keys that exceed 1024 bits in length but are less than or equal to 3072 bits.
+
+This structure is used as a header for a larger buffer. The DSA parameters blob has the following format in contiguous memory. The Seed, q, Modulus, and Generator are in big-endian format.
+
+<pre class="syntax" xml:space="preserve"><code>
+BCRYPT_DSA_PARAMETER_HEADER_V2
+Seed[cbSeedLength]      // Big-endian.
+q[cbGroupSize]          // Big-endian.
+Modulus[cbKeyLength]    // Big-endian.
+Generator[cbKeyLength]  // Big-endian.
+</code></pre>
+
 ## -see-also
 
+<a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgeneratekeypair">BCryptGenerateKeyPair</a>
+
 <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptsetproperty">BCryptSetProperty</a>
-
-
 
 <a href="/windows/desktop/SecCNG/cng-property-identifiers">Cryptography Primitive Property Identifiers</a>


### PR DESCRIPTION
+ Fixes for various documentation bugs around DSA
  + Incorrect magic values
  + Reference to `ImportKey` instead of `ImportKeyPair`
  + Missing/incorrect information about layout of blobs in memory
  + Incorrect information about `cbGroupSize`