### PR TITLE
LoadKeyboardLayout(): Returns NULL when the library is loaded from the wrong directory

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
@@ -170,7 +170,11 @@ This flag is unsupported. Use the <a href="/windows/desktop/api/winuser/nf-winus
 
 Type: <b>HKL</b>
 
-If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system.
+
+If the function fails, the return value is NULL. A possible cause is the layout's library being loaded from the application's directory.
+
+To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
@@ -172,7 +172,7 @@ Type: <b>HKL</b>
 
 If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system.
 
-If the function fails, the return value is NULL. A possible cause is the layout's library being loaded from the application's directory.
+If the function fails, the return value is NULL. This can occur if the layout library is loaded from the application directory.
 
 To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
@@ -170,7 +170,11 @@ This flag is unsupported. Use the <a href="/windows/desktop/api/winuser/nf-winus
 
 Type: <b>HKL</b>
 
-If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system.
+
+If the function fails, the return value is NULL. A possible cause is the layout's library being loaded from the application's directory.
+
+To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
@@ -172,7 +172,7 @@ Type: <b>HKL</b>
 
 If the function succeeds, the return value is the input locale identifier corresponding to the name specified in <i>pwszKLID</i>. If no matching locale is available, the return value is the default language of the system.
 
-If the function fails, the return value is NULL. A possible cause is the layout's library being loaded from the application's directory.
+If the function fails, the return value is NULL. This can occur if the layout library is loaded from the application directory.
 
 To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 


### PR DESCRIPTION
`GetLastError()` returns 0 too.

Behavior encountered on Windows 10, 8.1 and 7. I didn't try on older versions.

---

CMake project: [Test.zip](https://github.com/MicrosoftDocs/sdk-api/files/6199791/Test.zip)
Registry import file: [a0000409.zip](https://github.com/MicrosoftDocs/sdk-api/files/6138520/a0000409.zip)