### PR TITLE
Fix damaged link

### DIFF
--- a/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getversion.md
+++ b/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getversion.md
@@ -58,7 +58,7 @@ api_name:
 
 ## -description
 
-<p class="CCE_Message"><b>GetVersion</b> may be altered or unavailable for releases after Windows 8.1. Instead, use the <a href="/windows/desktop/SysInfo/version-helper-apis">Version Helper functions</a>. For Windows 10 apps, please see [Targeting your applications for Windows](/windows/win32/sysinfo/targeting-your-application-at-windows-8-1).
+<b>GetVersion</b> may be altered or unavailable for releases after Windows 8.1. Instead, use the <a href="/windows/desktop/SysInfo/version-helper-apis">Version Helper functions</a>. For Windows 10 apps, please see [Targeting your applications for Windows](/windows/win32/sysinfo/targeting-your-application-at-windows-8-1).
 
 With the release of Windows 8.1, the behavior of the <b>GetVersion</b> API has changed in the value it will return for the operating system version. The value returned by the <b>GetVersion</b> function now depends on how the application is manifested. 
 
@@ -121,28 +121,10 @@ void main()
 
 ## -see-also
 
-<a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversionexa">GetVersionEx</a>
-
-
-
-<a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoa">OSVERSIONINFO</a>
-
-
-
-<a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoexa">OSVERSIONINFOEX</a>
-
-
-
-<a href="/windows/desktop/SysInfo/operating-system-version">Operating System Version</a>
-
-
-
-<a href="/windows/desktop/SysInfo/system-information-functions">System Information Functions</a>
-
-
-
-<a href="/windows/desktop/api/winbase/nf-winbase-verifyversioninfoa">VerifyVersionInfo</a>
-
-
-
-<a href="/windows/desktop/SysInfo/version-helper-apis">Version Helper functions</a>
+- <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversionexa">GetVersionEx</a>
+- <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoa">OSVERSIONINFO</a>
+- <a href="/windows/desktop/api/winnt/ns-winnt-osversioninfoexa">OSVERSIONINFOEX</a>
+- <a href="/windows/desktop/SysInfo/operating-system-version">Operating System Version</a>
+- <a href="/windows/desktop/SysInfo/system-information-functions">System Information Functions</a>
+- <a href="/windows/desktop/api/winbase/nf-winbase-verifyversioninfoa">VerifyVersionInfo</a>
+- <a href="/windows/desktop/SysInfo/version-helper-apis">Version Helper functions</a>


### PR DESCRIPTION
I fixed a link that didn't render correctly, even though its Markdown syntax was correct. The reason was a stray P tag.

I also converted a loose list into a bulleted list. Past experience tells me this change is coveted in Microsoft Docs repos. But if you don't want it, feel free to cherry-pick without even asking me.