### PR TITLE
Corrected DLL export for UnmapViewOfFile2

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-unmapviewoffile2.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-unmapviewoffile2.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: WindowsApp.lib
-req.dll: Kernel32.dll
+req.dll: Kernelbase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
UnmapViewOfFile2 is hosted in KERNELBASE