### PR TITLE
Document MiniDumpWithAvxXStateContext, MiniDumpWithIptTrace, and MiniDumpScanInaccessiblePartialPages.

### DIFF
--- a/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
+++ b/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
@@ -239,7 +239,7 @@ Adds Intel Processor Trace related data.
 
 ### -field MiniDumpScanInaccessiblePartialPages
 
-Adds Inaccessible Partial memory pages.
+Scans inaccessible partial memory pages.
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 

--- a/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
+++ b/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
@@ -227,7 +227,21 @@ Adds filter triage related data.
 
 ### -field MiniDumpWithAvxXStateContext
 
+Adds AVX crash state context registers.
+
+<b>Prior to DbgHelp 6.1:  </b>This value is not supported.
+
 ### -field MiniDumpWithIptTrace
+
+Adds Ipt Trace related data. 
+
+<b>Prior to DbgHelp 6.1:  </b>This value is not supported.
+
+### -field MiniDumpScanInaccessiblePartialPages
+
+Adds Inaccessible Partial memory pages.
+
+<b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpValidTypeFlags
 

--- a/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
+++ b/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
@@ -233,7 +233,7 @@ Adds AVX crash state context registers.
 
 ### -field MiniDumpWithIptTrace
 
-Adds Ipt Trace related data. 
+Adds Intel Processor Trace related data. 
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 


### PR DESCRIPTION
For some reasons documentations was not provided to these.

I did my best guess as to what these are for by googling what all I did not know (like the AvxXStateContext part of the flag to try to figure out what type of data it includes).