### PR TITLE
Add DLL host information to pages missing kernel32 dependency

### DIFF
--- a/sdk-api-src/content/heapapi/nf-heapapi-heapsummary.md
+++ b/sdk-api-src/content/heapapi/nf-heapapi-heapsummary.md
@@ -7,13 +7,13 @@ targetos: Windows
 req.assembly: 
 req.construct-type: function
 req.ddi-compliance: 
-req.dll: 
+req.dll: kernel32.dll
 req.header: heapapi.h
 req.idl: 
 req.include-header: 
 req.irql: 
 req.kmdf-ver: 
-req.lib: 
+req.lib: kernel32.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
@@ -33,7 +33,9 @@ topic_type:
 api_type:
  - DllExport
 api_location:
+ - kernel32.dll
  - api-ms-win-core-heap-l1-1-0.dll
+ - kernelbase.dll
 api_name:
  - HeapSummary
 ---

--- a/sdk-api-src/content/processenv/nf-processenv-setenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setenvironmentstringsw.md
@@ -7,13 +7,13 @@ targetos: Windows
 req.assembly: 
 req.construct-type: function
 req.ddi-compliance: 
-req.dll: 
+req.dll: kernel32.dll
 req.header: processenv.h
 req.idl: 
 req.include-header: 
 req.irql: 
 req.kmdf-ver: 
-req.lib: 
+req.lib: kernel32.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
@@ -33,7 +33,10 @@ topic_type:
 api_type:
  - DllExport
 api_location:
+ - kernel32.dll
  - api-ms-win-core-processenvironment-l1-1-0.dll
+ - kernelbase.dll
+ - api-ms-win-downlevel-kernel32-l1-1-0.dll
 api_name:
  - SetEnvironmentStringsW
 ---


### PR DESCRIPTION
Add metadata naming kernel32 as the host for HeapSummary and SetEnvironmentStringsW so APIScan can find them.