### PR TITLE
Update XPS_GLYPH_MAPPING link.

### DIFF
--- a/sdk-api-src/content/xpsobjectmodel/nf-xpsobjectmodel-ixpsomglyphseditor-setglyphmappings.md
+++ b/sdk-api-src/content/xpsobjectmodel/nf-xpsobjectmodel-ixpsomglyphseditor-setglyphmappings.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Sets an array of <a href="/windows/win32/api/xpsobjectmodel/ns-xpsobjectmodel-xps_glyph_index">XPS_GLYPH_MAPPING</a> structures that describe how to map the UTF-16 scalar values in the <b>UnicodeString</b> property to entries in the array of <a href="/windows/win32/api/xpsobjectmodel/ns-xpsobjectmodel-xps_glyph_index">XPS_GLYPH_INDEX</a> structures.
+Sets an array of <a href="/windows/win32/api/xpsobjectmodel/ns-xpsobjectmodel-xps_glyph_mapping">XPS_GLYPH_MAPPING</a> structures that describe how to map the UTF-16 scalar values in the <b>UnicodeString</b> property to entries in the array of <a href="/windows/win32/api/xpsobjectmodel/ns-xpsobjectmodel-xps_glyph_index">XPS_GLYPH_INDEX</a> structures.
 
 ## -parameters
 


### PR DESCRIPTION
The first mention of XPS_GLYPH_MAPPING was linked to the documentation for XPS_GLYPH_INDEX. Link to the documentation for XPS_GLYPH_MAPPING instead.