### PR TITLE
Update nf-winuser-settimer.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-settimer.md
+++ b/sdk-api-src/content/winuser/nf-winuser-settimer.md
@@ -110,8 +110,8 @@ The <i>wParam</i> parameter of the <a href="/windows/desktop/winmsg/wm-timer">WM
 The timer identifier, <i>nIDEvent</i>, is specific to the associated window. Another window can have its own timer which has the same identifier as a timer owned by another window. The timers are distinct. 
 
 <b>SetTimer</b> can reuse timer IDs in the case where <i>hWnd</i> is <b>NULL</b>. 
-			
-
+	
+Before using **SetTimer** or other timer-related functions, it is recommended to set **UOI_TIMERPROC_EXCEPTION_SUPPRESSION** flag to **false** through **SetUserObjectInformationW** function, otherwise the application could behave unpredictably and could be vulnerable to security exploits. For more info, see <a href="/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw">SetUserObjectInformationW</a>.
 
 #### Examples
 

--- a/sdk-api-src/content/winuser/nf-winuser-settimer.md
+++ b/sdk-api-src/content/winuser/nf-winuser-settimer.md
@@ -111,7 +111,7 @@ The timer identifier, <i>nIDEvent</i>, is specific to the associated window. Ano
 
 <b>SetTimer</b> can reuse timer IDs in the case where <i>hWnd</i> is <b>NULL</b>. 
 	
-Before using **SetTimer** or other timer-related functions, it is recommended to set **UOI_TIMERPROC_EXCEPTION_SUPPRESSION** flag to **false** through **SetUserObjectInformationW** function, otherwise the application could behave unpredictably and could be vulnerable to security exploits. For more info, see <a href="/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw">SetUserObjectInformationW</a>.
+Before using **SetTimer** or other timer-related functions, it is recommended to set the **UOI_TIMERPROC_EXCEPTION_SUPPRESSION** flag to **false** through the **SetUserObjectInformationW** function, otherwise the application could behave unpredictably and could be vulnerable to security exploits. For more info, see <a href="/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw">SetUserObjectInformationW</a>.
 
 #### Examples
 


### PR DESCRIPTION
Problem:
By default, Windows sets up timer procs in a __try/__except statement, where it catches any SEH errors, including Access Violation, and swallows them. Note, that if users use C++, this problem is further complicated because __try/__except doesn't do any stack unwinding, and thus creates an unknown and corrupt app state. Some of the effects of skipping stack unwind are objects leaks, mutexes not released, pointers, files, not cleaned up, etc. Long story short, at this point app is in unknown state. After SEH is swallowed, Windows Apps go back to message processing as if nothing has happened, but of course App is still in an unknown, potentially corrupt state. Problems that are associated with such corrupt states are extremely difficult to investigate.

To avoid the above described problem, Microsoft recommends setting UOI_TIMERPROC_EXCEPTION_SUPPRESSION to false:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw
However, that recommendation is not linked to SetTimer Api in any way, thus is hard to discover.

Solution:
Microsoft SetTimer documentation should promote its recommendation to set Windows UOI_TIMERPROC_EXCEPTION_SUPPRESSION flag to false before using SetTimer Api.