### PR TITLE
Update API doc for SystemParametersInfoA/SystemParemetersInfoW on SPI_SETTHREADLOCALINPUTSETTINGS parameter

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-systemparametersinfoa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-systemparametersinfoa.md
@@ -1578,7 +1578,7 @@ Enables or disables the snap-to-default-button feature. If enabled, the mouse cu
 </dl>
 </td>
 <td width="60%">
-<b>Starting with Windows 8:</b> Determines whether the active input settings have Local (per-thread, <b>TRUE</b>) or Global (session, <b>FALSE</b>) scope. The <i>pvParam</i> parameter must point to a <b>BOOL</b> variable, casted by PVOID.
+<b>Starting with Windows 8:</b> Determines whether the active input settings have Local (per-thread, <b>TRUE</b>) or Global (session, <b>FALSE</b>) scope. The <i>pvParam</i> parameter must be a <b>BOOL</b> variable, casted by PVOID.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-systemparametersinfow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-systemparametersinfow.md
@@ -1578,7 +1578,7 @@ Enables or disables the snap-to-default-button feature. If enabled, the mouse cu
 </dl>
 </td>
 <td width="60%">
-<b>Starting with Windows 8:</b> Determines whether the active input settings have Local (per-thread, <b>TRUE</b>) or Global (session, <b>FALSE</b>) scope. The <i>pvParam</i> parameter must point to a <b>BOOL</b> variable, casted by PVOID.
+<b>Starting with Windows 8:</b> Determines whether the active input settings have Local (per-thread, <b>TRUE</b>) or Global (session, <b>FALSE</b>) scope. The <i>pvParam</i> parameter must be a <b>BOOL</b> variable, casted by PVOID.
 
 </td>
 </tr>


### PR DESCRIPTION
When we call APIs SystemParametersInfoA/SystemParemetersInfoW to set active input settings using SPI_SETTHREADLOCALINPUTSETTINGS action, the parameter pvParam accepts a BOOL variable casted by PVOID instead of a pointer to a BOOL variable. If we use a pointer to BOOL variable here, the APIs always treat it as Local (per-thread, TRUE) because a pointer to BOOL variable cannot be zero.