### PR TITLE
TIMERPROC fix unnamed parameters

### DIFF
--- a/sdk-api-src/content/winuser/nc-winuser-timerproc.md
+++ b/sdk-api-src/content/winuser/nc-winuser-timerproc.md
@@ -55,25 +55,25 @@ An application-defined callback function that processes <a href="/windows/deskto
 
 ## -parameters
 
-### -param unnamedParam1
+### -param hWnd
 
 Type: <b>HWND</b>
 
 A handle to the window associated with the timer.
 
-### -param unnamedParam2
+### -param uMsg
 
 Type: <b>UINT</b>
 
 The <a href="/windows/desktop/winmsg/wm-timer">WM_TIMER</a> message.
 
-### -param unnamedParam3
+### -param nIDEvent
 
 Type: <b>UINT_PTR</b>
 
 The timer's identifier.
 
-### -param unnamedParam4
+### -param dwTime
 
 Type: <b>DWORD</b>
 


### PR DESCRIPTION
The proper parameter names are missing. Technically the function prototype in windows.h *is* missing these names (`typedef VOID (CALLBACK* TIMERPROC)(HWND, UINT, UINT_PTR, DWORD);`), but you can tell from `SetTimer` what they're supposed to be (https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer). Note the naming distinction though between `dwTime` vs `uElapse`, since `dwTime` here is the current time since system startup, as opposed to SetTimer `uElapse` which is the timer interval.