### PR TITLE
Update nf-libloaderapi-loadlibraryexw.md

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
@@ -352,6 +352,8 @@ This value cannot be combined with any <b>LOAD_LIBRARY_SEARCH</b> flag.
 <td width="60%">
 Specifies that the digital signature of the binary image must be checked at load time.
 
+This value requires Windows 8.1, Windows 10 or later.
+
 </td>
 </tr>
 


### PR DESCRIPTION
Important note about a flag that's not supported on Windows 7.