### PR TITLE
Update nf-winuser-setcoalescabletimer.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-setcoalescabletimer.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setcoalescabletimer.md
@@ -179,6 +179,8 @@ The timer identifier, <i>nIDEvent</i>, is specific to the associated window. Ano
 
 When <i>uToleranceDelay</i> is set to 0, the system default timer coalescing is used and   <b>SetCoalescableTimer</b>  behaves the same as <a href="/windows/desktop/api/winuser/nf-winuser-settimer">SetTimer</a>.
 
+Before using **SetCoalescableTimer** or other timer-related functions, it is recommended to set the **UOI_TIMERPROC_EXCEPTION_SUPPRESSION** flag to **false** through the **SetUserObjectInformationW** function, otherwise the application could behave unpredictably and could be vulnerable to security exploits. For more info, see <a href="/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw">SetUserObjectInformationW</a>.
+
 ## -see-also
 
 <a href="https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/Official%20Windows%20Platform%20Sample/Windows%208.1%20desktop%20samples/99647-Windows%208.1%20desktop%20samples/Coalescing%20timers%20sample/C%2B%2B">Coalescing timers sample</a>


### PR DESCRIPTION
Problem:
By default, Windows sets up timer procs in a __try/__except statement, where it catches any SEH errors, including Access Violation, and swallows them. Note, that if users use C++, this problem is further complicated because __try/__except doesn't do any stack unwinding, and thus creates an unknown and corrupt app state. Some of the effects of skipping stack unwind are objects leaks, mutexes not released, pointers, files, not cleaned up, etc. Long story short, at this point app is in unknown state. After SEH is swallowed, Windows Apps go back to message processing as if nothing has happened, but of course App is still in an unknown, potentially corrupt state. Problems that are associated with such corrupt states are extremely difficult to investigate.

To avoid the above described problem, Microsoft recommends setting UOI_TIMERPROC_EXCEPTION_SUPPRESSION to false:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setuserobjectinformationw
There was a recent change to add that recommendation to SetTimer Api:
https://github.com/MicrosoftDocs/sdk-api/pull/734
The same recommendation should be added into SetCoalescableTimer Api too

Solution:
Microsoft SetCoalescableTimer documentation should promote its recommendation to set Windows UOI_TIMERPROC_EXCEPTION_SUPPRESSION flag to false before using SetCoalescableTimer Api.