### PR TITLE
Update nf-dwrite_2-idwritefontfallbackbuilder-addmappings.md

### DIFF
--- a/sdk-api-src/content/dwrite_2/nf-dwrite_2-idwritefontfallbackbuilder-addmappings.md
+++ b/sdk-api-src/content/dwrite_2/nf-dwrite_2-idwritefontfallbackbuilder-addmappings.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Add all the mappings from an existing font fallback object.
+Adds all the mappings from an existing font fallback object, which can be used to compose larger fallback definitions. A common scenario is to start with the system fallback from `IDWriteFactory2::GetSystemFontFallback` to cover the majority of Unicode characters, but then customize a few ranges with additional application-specific entries, either appending them first (to have priority over the system default) before calling AddMappings, or calling AddMappings first and then appending custom ranges to fill in any custom gaps.
 
 ## -parameters
 

--- a/sdk-api-src/content/dwrite_2/nf-dwrite_2-idwritefontfallbackbuilder-addmappings.md
+++ b/sdk-api-src/content/dwrite_2/nf-dwrite_2-idwritefontfallbackbuilder-addmappings.md
@@ -45,12 +45,9 @@ api_name:
  - IDWriteFontFallbackBuilder.AddMappings
 ---
 
-# IDWriteFontFallbackBuilder::AddMappings
-
-
 ## -description
 
-Adds all the mappings from an existing font fallback object, which can be used to compose larger fallback definitions. A common scenario is to start with the system fallback from `IDWriteFactory2::GetSystemFontFallback` to cover the majority of Unicode characters, but then customize a few ranges with additional application-specific entries, either appending them first (to have priority over the system default) before calling AddMappings, or calling AddMappings first and then appending custom ranges to fill in any custom gaps.
+Adds all the mappings from an existing font fallback object, which can be used to compose larger fallback definitions. A common scenario is to start with the system fallback from [IDWriteFactory2::GetSystemFontFallback](/windows/win32/api/dwrite_2/nf-dwrite_2-idwritefactory2-getsystemfontfallback) to cover the majority of Unicode characters, but then customize a few ranges with additional application-specific entries, either appending them first (to have priority over the system default) before calling **AddMappings**; or calling **AddMappings** first, and then appending custom ranges to fill in any custom gaps.
 
 ## -parameters
 


### PR DESCRIPTION
Elaborate on the usage of this function, and the relationship between it and GetSystemFontFallback (which currently isn't mentioned here, even though it was one of the reasons I specifically added that API, for composition of large font fallback definitions).