### PR TITLE
Note where 'Current User' should not be used

### DIFF
--- a/sdk-api-src/content/icm/nf-icm-wcssetdefaultcolorprofile.md
+++ b/sdk-api-src/content/icm/nf-icm-wcssetdefaultcolorprofile.md
@@ -83,6 +83,8 @@ If the *pProfileName* parameter is **NULL** and the *profileManagementScope* par
 
 If *profileManagementScope* is WCS\_PROFILE\_MANAGEMENT\_SCOPE\_CURRENT\_USER, this function is executable in Least-Privileged User Account (LUA) context. Otherwise, administrative privileges are required. The specified profile must already be installed, but it may be not yet associated with the specified device in the specified profile management scope.
 
+If *profileManagementScope* is WCS\_PROFILE\_MANAGEMENT\_SCOPE\_CURRENT\_USER, this function will not correctly function if launched from system context and not a User Account.
+
 When WcsSetDefaultColorProfile is called to set a device model profile DMP as the default profile for the RGB or custom working space, only a DMP profile that is of type RGBVirtualDevice, LCD, or CRT is valid; all others are invalid.
 
 When WcsSetDefaultColorProfile is called to set an International Color Consortium (ICC) profile as the default profile for the RGB or custom working space, only an ICC profile with class "spac" or "disp", and "RGB" color space is valid; all others are invalid.


### PR DESCRIPTION
Calling this function from system context (i.e. using psexec to launch a system context program outside of a user account) is not supported. This is just to update the docs to point that out.