### PR TITLE
Update ns-sspi-securityfunctiontablew.md

### DIFF
--- a/sdk-api-src/content/sspi/ns-sspi-securityfunctiontablew.md
+++ b/sdk-api-src/content/sspi/ns-sspi-securityfunctiontablew.md
@@ -226,3 +226,5 @@ Pointer to the   <a href="/windows/desktop/api/sspi/nf-sspi-setcontextattributes
 
 > [!NOTE]
 > The sspi.h header defines SecurityFunctionTable as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
+
+QueryContextAttributesExW and QueryCredentialsAttributesW are not initialized.


### PR DESCRIPTION
QueryContextAttributesExW and QueryCredentialsAttributesW are not initialized.