### PR TITLE
Add reference to SetCoalescableTimer into SetTimer Api

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-settimer.md
+++ b/sdk-api-src/content/winuser/nf-winuser-settimer.md
@@ -150,3 +150,5 @@ For an example, see <a href="/windows/desktop/winmsg/using-timers">Creating a Ti
 
 
 <a href="/windows/desktop/winmsg/wm-timer">WM_TIMER</a>
+
+<a href="/windows/win32/api/winuser/nf-winuser-setcoalescabletimer">SetCoalescableTimer</a>


### PR DESCRIPTION
SetCoalescableTimer is an battery and performance optimized Api which can be considered for usage instead of classic SetTimer.

Thus, SetTimer documentation should promote SetCoalescableTimer Api by having a reference to it