### PR TITLE
Update nf-bcrypt-bcryptgenrandom.md

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgenrandom.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgenrandom.md
@@ -100,7 +100,7 @@ Use the system-preferred random number generator algorithm. The <i>hAlgorithm</i
 
 BCRYPT_USE_SYSTEM_PREFERRED_RNG is only supported at <b>PASSIVE_LEVEL</b> <a href="/windows/desktop/SecGloss/i-gly">IRQL</a>. For more information, see Remarks.
 
-<b>Windows Vista:  </b>This flag is not supported.
+<b>Windows Vista:  </b>This flag is not supported without SP2.
 
 </td>
 </tr>


### PR DESCRIPTION
correcting support for flag on Vista. It is supported with SP2.