### PR TITLE
Remove "api requires packaging" errors

### DIFF
--- a/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-rogetmetadatafile.md
+++ b/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-rogetmetadatafile.md
@@ -148,17 +148,6 @@ The input string is an existing namespace rather than a typename.
 
 </td>
 </tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>HR_RESULT_FROM_WIN32(ERROR_NO_PACKAGE)</b></dt>
-</dl>
-</td>
-<td width="60%">
-The function was called from a process that is not in a Windows Store app.
-
-</td>
-</tr>
 </table>
 
 ## -remarks

--- a/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roisapicontractmajorversionpresent.md
+++ b/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roisapicontractmajorversionpresent.md
@@ -107,16 +107,6 @@ The input string is not an API contract defined in any examined .winmd file.
 The input string is an existing namespace rather than an API contract name.
 </td>
 </tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>HR_RESULT_FROM_WIN32(ERROR_NO_PACKAGE)</b></dt>
-</dl>
-</td>
-<td width="60%">
-The function was called from a process that is not in a UWP app container.
-</td>
-</tr>
 </table>
 
 ## -remarks

--- a/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roisapicontractpresent.md
+++ b/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roisapicontractpresent.md
@@ -113,16 +113,6 @@ The input string is not an API contract defined in any examined .winmd file.
 The input string is an existing namespace rather than an API contract name.
 </td>
 </tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>HR_RESULT_FROM_WIN32(ERROR_NO_PACKAGE)</b></dt>
-</dl>
-</td>
-<td width="60%">
-The function was called from a process that is not in a UWP app container.
-</td>
-</tr>
 </table>
 
 ## -remarks

--- a/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roresolvenamespace.md
+++ b/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roresolvenamespace.md
@@ -149,17 +149,6 @@ Indicates one of the following:
 <tr>
 <td width="40%">
 <dl>
-<dt><b>HRESULT_FROM_WIN32(ERROR_NO_PACKAGE)</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <a href="/windows/desktop/api/rometadataresolution/nf-rometadataresolution-roresolvenamespace">RoResolveNamespace</a> function  is called from a process that is not in a Windows Store app to resolve a 3rd-party namespace when  <i>packageGraphDirs</i> parameter is <b>nullptr</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
 <dt><b>E_INVALIDARG</b></dt>
 </dl>
 </td>


### PR DESCRIPTION
Metadata resolution APIs work for packaged and unpackaged applications.  Some metadata lookup uses the package graph, but "do the right thing" if the process has no package graph.