### PR TITLE
Fix incorrect MI_Flags

### DIFF
--- a/sdk-api-src/content/mi/nf-mi-mi_context_writestreamparameter.md
+++ b/sdk-api-src/content/mi/nf-mi-mi_context_writestreamparameter.md
@@ -78,7 +78,7 @@ Must be 0 or
 
 
 
-#### MI_FLAG_NULL (0x1000000)
+#### MI_FLAG_NULL (0x20000000)
 
 The end of the stream has been reached.
 

--- a/sdk-api-src/content/mi/nf-mi-mi_instance_addelement.md
+++ b/sdk-api-src/content/mi/nf-mi-mi_instance_addelement.md
@@ -106,19 +106,19 @@ Method parameter will be streamed back to the client from the provider.
 
 
 
-#### MI_FLAG_BORROW (0x4000000)
+#### MI_FLAG_BORROW (0x40000000)
 
 Used while adding and setting properties on an <a href="/windows/desktop/api/mi/ns-mi-mi_instance">MI_Instance</a> to indicate that the instance will not copy the value. The value must stay valid until the instance is deleted.
 
 
 
-#### MI_FLAG_ADOPT (0x8000000)
+#### MI_FLAG_ADOPT (0x80000000)
 
 Used while adding and setting properties on an <a href="/windows/desktop/api/mi/ns-mi-mi_instance">MI_Instance</a> to indicate that the instance will adopt the pointer and will be responsible for deleting it.
 
 
 
-#### MI_FLAG_NULL (0x2000000)
+#### MI_FLAG_NULL (0x20000000)
 
 Element value is <b>Null</b>.
 

--- a/sdk-api-src/content/mi/nf-mi-mi_instance_getelementat.md
+++ b/sdk-api-src/content/mi/nf-mi-mi_instance_getelementat.md
@@ -80,7 +80,7 @@ Returned combination of the following values.
 
 
 
-#### MI_FLAG_NULL (0x2000000)
+#### MI_FLAG_NULL (0x20000000)
 
 Element value is <b>Null</b>.
 


### PR DESCRIPTION
I noticed while writing code against the MI API that the documentation had values that do not match the values provided by the mi.h header. In all but one case, this appears to be because a 0 was left off the end of a hexadecimal value. 

Here are the correct values as specified in the mi.h header:

| Flag field | mi.h header value | Decimal representation | Hexadecimal representation |
|-|-|-|-|
| `MI_FLAG_NULL` | `(1 << 29)` | `536870912` | `0x20000000` |
| `MI_FLAG_BORROW` | `(1 << 30)` | `1073741824` | `0x40000000` |
| `MI_FLAG_ADOPT` | `((MI_Uint32)(1 << 31))` | `2147483648` | `0x80000000` |

You can quickly verify these values using PowerShell: 

```PowerShell
1 -shl 29
```

I actually only noticed this typo on one document with one flag, but as it turns out, it existed on three separate docs/flags. I used the following PowerShell to identify all the documents in the doc set that had MI_Flag references, and verified that they were correct. 

```PowerShell
Get-ChildItem -Recurse | `
    Where-Object { $_.Extension -eq ".md" } | `
    Select-String -Pattern "MI_FLAG_\w+\s" | `
    Group-Object Path -NoElement | `
    Select-Object -ExpandProperty Name
```

Most used the header notation, although some used the hexadecimal notation. The issues only appeared in articles that used the hexadecimal notation, so I just fixed in place and left in the hexadecimal notation.

Please let me know if you have any questions. Thanks!