### PR TITLE
Update nf-windows-foundation-istringable-tostring.md

### DIFF
--- a/sdk-api-src/content/windows.foundation/nf-windows-foundation-istringable-tostring.md
+++ b/sdk-api-src/content/windows.foundation/nf-windows-foundation-istringable-tostring.md
@@ -11,8 +11,8 @@ ms.keywords: IStringable interface [Windows Runtime],ToString method, IStringabl
 req.header: windows.foundation.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 8.1 [desktop apps | UWP apps]
+req.target-min-winversvr: Windows Server 2012 R2 [desktop apps | UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
Fixes IStringable documentation. It's also available for UWP apps.