### PR TITLE
English usage: missing "is" in sentence.

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulehandleexa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulehandleexa.md
@@ -141,7 +141,7 @@ To compile an application that uses this function, define _WIN32_WINNT as 0x0501
 
 
 > [!NOTE]
-> The libloaderapi.h header defines GetModuleHandleEx as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
+> The libloaderapi.h header defines GetModuleHandleEx as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that is not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 


### PR DESCRIPTION
English language usage error: missing "is" in sentence.