### PR TITLE
videoprimaries.md: removed mix up and EBU 3212

### DIFF
--- a/sdk-api-src/content/dxva2api/ne-dxva2api-dxva2_videoprimaries.md
+++ b/sdk-api-src/content/dxva2api/ne-dxva2api-dxva2_videoprimaries.md
@@ -118,8 +118,8 @@ Color primaries define how to convert RGB colors into the CIE XYZ color space, a
             </td>
 </tr>
 <tr>
-<td>BT.470-2 System M;
-              EBU 3212
+<td>BT.470-2 System B,G;
+              EBU 3213
             </td>
 <td>(0.64, 0.33)</td>
 <td>(0.29, 0.60)</td>
@@ -129,7 +129,7 @@ Color primaries define how to convert RGB colors into the CIE XYZ color space, a
             </td>
 </tr>
 <tr>
-<td>BT.470-4 System B,G</td>
+<td>BT.470-4 System M</td>
 <td>(0.67, 0.33)</td>
 <td>(0.21, 0.71)</td>
 <td>(0.14, 0.08)</td>


### PR DESCRIPTION
No, EBU 3212 does not exist. Also System M uses Ill. C.
See ITU-T H.273 or ISO/IEC 23091-2:2019, free of charge.
I compared it, it is otherwise correct.


Please MERGE this ASAP, this is very bad!