### PR TITLE
Toolhelp32ReadProcessMemory(): Recommend ReadProcessMemory() if several reads are planned

### DIFF
--- a/sdk-api-src/content/tlhelp32/nf-tlhelp32-toolhelp32readprocessmemory.md
+++ b/sdk-api-src/content/tlhelp32/nf-tlhelp32-toolhelp32readprocessmemory.md
@@ -78,6 +78,12 @@ The number of bytes copied to the specified buffer. If this parameter is <b>NULL
 
 Returns <b>TRUE</b> if successful.
 
+## -remarks
+
+The function opens an handle to the target process and closes it once the read operation is completed.
+
+As such, it's recommended to use [ReadProcessMemory](../memoryapi/nf-memoryapi-readprocessmemory.md) instead if you're planning to perform several reads.
+
 ## -see-also
 
 <a href="/windows/desktop/api/tlhelp32/nf-tlhelp32-process32first">Process32First</a>

--- a/sdk-api-src/content/tlhelp32/nf-tlhelp32-toolhelp32readprocessmemory.md
+++ b/sdk-api-src/content/tlhelp32/nf-tlhelp32-toolhelp32readprocessmemory.md
@@ -80,9 +80,7 @@ Returns <b>TRUE</b> if successful.
 
 ## -remarks
 
-The function opens an handle to the target process and closes it once the read operation is completed.
-
-As such, it's recommended to use [ReadProcessMemory](../memoryapi/nf-memoryapi-readprocessmemory.md) instead if you're planning to perform several reads.
+This function opens a handle to the target process and closes it once the read operation has completed. If you're planning to perform several reads, use [ReadProcessMemory](../memoryapi/nf-memoryapi-readprocessmemory.md) instead.
 
 ## -see-also
 


### PR DESCRIPTION
The function is just a wrapper for `ReadProcessMemory()` that takes care of opening an handle to the process and closing it.

```c
BOOL Toolhelp32ReadProcessMemory(DWORD th32ProcessID, LPCVOID lpBaseAddress, LPVOID lpBuffer, SIZE_T cbRead, SIZE_T *lpNumberOfBytesRead)
{
	BOOL bRet = FALSE;

	HANDLE hProcess = OpenProcess(PROCESS_VM_READ, FALSE, th32ProcessID);
	if (hProcess) {
		bRet = ReadProcessMemory(hProcess, lpBaseAddress, lpBuffer, cbRead, lpNumberOfBytesRead);
		CloseHandle(hProcess);
	}

	return bRet;
}
```