### PR TITLE
Fix incorrectly escaped backslash

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathcompactpathexw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathcompactpathexw.md
@@ -88,7 +88,7 @@ Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise.
 
 ## -remarks
 
-The '/' separator will be used instead of '\' if the original string used it. If <i>pszSrc</i> points to a file name that is too long, instead of a path, the file name will be truncated to <i>cchMax</i> characters, including the ellipsis and the terminating <b>NULL</b> character. For example, if the input file name is "My Filename" and <i>cchMax</i> is 10, <b>PathCompactPathEx</b> will return "My Fil...".
+The '/' separator will be used instead of '\\' if the original string used it. If <i>pszSrc</i> points to a file name that is too long, instead of a path, the file name will be truncated to <i>cchMax</i> characters, including the ellipsis and the terminating <b>NULL</b> character. For example, if the input file name is "My Filename" and <i>cchMax</i> is 10, <b>PathCompactPathEx</b> will return "My Fil...".
 
 
 


### PR DESCRIPTION
Text was supposed to contain a backslash character in quotes. `'\'` was wrong, `'\\'` should be correct.