### PR TITLE
DirectXMath 3.16 updates for Windows 10 SDK (10.0.20348.0)

### DIFF
--- a/sdk-api-src/content/directxmath/nf-directxmath-xmcolorrgbtoyuv_uhd.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmcolorrgbtoyuv_uhd.md
@@ -3,9 +3,7 @@ UID: NF:directxmath.XMColorRGBToYUV_UHD
 title: XMColorRGBToYUV_UHD function (directxmath.h)
 description: Converts RGB color values to YUV UHD color values.
 helpviewer_keywords: ["Use DirectX..XMColorRGBToYUV_UHD","XMColorRGBToYUV_UHD","XMColorRGBToYUV_UHD method [DirectX Math Support APIs]","dxmath.xmcolorrgbtoyuv_uhd"]
-old-location: dxmath\xmcolorrgbtoyuv_uhd.htm
 tech.root: dxmath
-ms.assetid: M:Microsoft.directx_sdk.color.XMColorRGBToYUV_UHD(XMVECTOR)
 ms.date: 06/06/2021
 ms.keywords: Use DirectX..XMColorRGBToYUV_UHD, XMColorRGBToYUV_UHD, XMColorRGBToYUV_UHD method [DirectX Math Support APIs], dxmath.xmcolorrgbtoyuv_uhd
 req.header: directxmath.h

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmcolorrgbtoyuv_uhd.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmcolorrgbtoyuv_uhd.md
@@ -1,0 +1,81 @@
+---
+UID: NF:directxmath.XMColorRGBToYUV_UHD
+title: XMColorRGBToYUV_UHD function (directxmath.h)
+description: Converts RGB color values to YUV UHD color values.
+helpviewer_keywords: ["Use DirectX..XMColorRGBToYUV_UHD","XMColorRGBToYUV_UHD","XMColorRGBToYUV_UHD method [DirectX Math Support APIs]","dxmath.xmcolorrgbtoyuv_uhd"]
+old-location: dxmath\xmcolorrgbtoyuv_uhd.htm
+tech.root: dxmath
+ms.assetid: M:Microsoft.directx_sdk.color.XMColorRGBToYUV_UHD(XMVECTOR)
+ms.date: 06/06/2021
+ms.keywords: Use DirectX..XMColorRGBToYUV_UHD, XMColorRGBToYUV_UHD, XMColorRGBToYUV_UHD method [DirectX Math Support APIs], dxmath.xmcolorrgbtoyuv_uhd
+req.header: directxmath.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace: Use DirectX.
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+targetos: Windows
+req.typenames:
+req.redist:
+ms.custom: FE
+f1_keywords:
+ - XMColorRGBToYUV_UHD
+ - directxmath/XMColorRGBToYUV_UHD
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - COM
+api_location:
+ - DirectXMath.h
+api_name:
+ - XMColorRGBToYUV_UHD
+---
+
+# XMColorRGBToYUV_UHD function
+
+
+## -description
+
+Converts RGB color values to YUV UHD color values.
+
+## -parameters
+
+### -param rgb [in]
+
+Color value to convert. X element is Red, Y element is Green, Z element is Blue, and W element is Alpha. Each has a range of 0.0 to 1.0.
+
+## -returns
+
+ Returns the converted color value in Luma-Chrominance (YUV) aka YCbCr. The X element contains Luma (Y, 0.0 to 1.0), the Y element contains
+       Blue-difference chroma (-0.5 to 0.5), the Z element contains the Red-difference chroma (-0.5 to 0.5), and the W element contains the Alpha (a copy of rgb.w).
+
+## -remarks
+
+ Converts using ITU-R BT.2020 W(r) = 0.2627 W(b) = 0.0-593 U(max) = 0.4351 V(max) = 0.6150.
+
+> This function is new to DirectXMath 3.16
+
+<h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+
+## -see-also
+
+<a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-color">DirectXMath Library Color Functions</a>
+
+
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmcoloryuvtorgb_uhd">XMColorYUVToRGB_UHD</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmcoloryuvtorgb_uhd.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmcoloryuvtorgb_uhd.md
@@ -1,0 +1,80 @@
+---
+UID: NF:directxmath.XMColorYUVToRGB_UHD
+title: XMColorYUVToRGB_UHD function (directxmath.h)
+description: Converts YUV color values to RGB UHD color values.
+helpviewer_keywords: ["Use DirectX..XMColorYUVToRGB_UHD","XMColorYUVToRGB_UHD","XMColorYUVToRGB_UHD method [DirectX Math Support APIs]","dxmath.xmcoloryuvtorgb_uhd"]
+tech.root: dxmath
+ms.assetid: M:Microsoft.directx_sdk.color.XMColorYUVToRGB_UHD(XMVECTOR)
+ms.date: 06/06/2021
+ms.keywords: Use DirectX..XMColorYUVToRGB_UHD, XMColorYUVToRGB_UHD, XMColorYUVToRGB_UHD method [DirectX Math Support APIs], dxmath.xmcoloryuvtorgb_uhd
+req.header: directxmath.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace: Use DirectX.
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+targetos: Windows
+req.typenames:
+req.redist:
+ms.custom: FE
+f1_keywords:
+ - XMColorYUVToRGB_UHD
+ - directxmath/XMColorYUVToRGB_UHD
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - COM
+api_location:
+ - DirectXMath.h
+api_name:
+ - XMColorYUVToRGB_UHD
+---
+
+# XMColorYUVToRGB_UHD function
+
+
+## -description
+
+Converts YUV color values to RGB UHD color values.
+
+## -parameters
+
+### -param yuv [in]
+
+Color value to convert in Luma-Chrominance (YUV) aka YCbCr. The X element contains Luma (Y, 0.0 to 1.0), the Y element
+        contains Blue-difference chroma (U, -0.5 to 0.5), the Z element contains the Red-difference chroma (V, -0.5 to 0.5), and the W element contains the Alpha (0.0 to 1.0).
+
+## -returns
+
+The converted color value. X element is Red, Y element is Green, Z element is Blue, and W element is Alpha (a copy of yuv.w). Each has a range of 0.0 to 1.0.
+
+## -remarks
+
+ Converts using ITU-R BT.2020 W(r) = 0.2627 W(b) = 0.0-593 U(max) = 0.4351 V(max) = 0.6150.
+
+> This function is new to DirectXMath 3.16
+
+<h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+
+## -see-also
+
+<a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-color">DirectXMath Library Color Functions</a>
+
+
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmcolorrgbtoyuv_uhd">XMColorRGBToYUV_UHD</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmcoloryuvtorgb_uhd.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmcoloryuvtorgb_uhd.md
@@ -4,7 +4,6 @@ title: XMColorYUVToRGB_UHD function (directxmath.h)
 description: Converts YUV color values to RGB UHD color values.
 helpviewer_keywords: ["Use DirectX..XMColorYUVToRGB_UHD","XMColorYUVToRGB_UHD","XMColorYUVToRGB_UHD method [DirectX Math Support APIs]","dxmath.xmcoloryuvtorgb_uhd"]
 tech.root: dxmath
-ms.assetid: M:Microsoft.directx_sdk.color.XMColorYUVToRGB_UHD(XMVECTOR)
 ms.date: 06/06/2021
 ms.keywords: Use DirectX..XMColorYUVToRGB_UHD, XMColorYUVToRGB_UHD, XMColorYUVToRGB_UHD method [DirectX Math Support APIs], dxmath.xmcoloryuvtorgb_uhd
 req.header: directxmath.h

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat2-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat2-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT2.operator = (const XMFLOAT
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMFLOAT2.operator =, Use DirectX::::XMFLOAT2::operator =, XMFLOAT2 structure [DirectX Math Support APIs],operator = method, XMFLOAT2.operator =, XMFLOAT2.operator-assign, XMFLOAT2.operator=, XMFLOAT2::operator-assign, XMFLOAT2::operator=, dxmath.xmfloat2_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT2 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT2::operator=
  - directxmath/XMFLOAT2::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMFLOAT2</code> whose vector component data has be
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat2">XMFLOAT2</a>
 
-<a href="https://msdn.microsoft.com/91b6d6e3-7953-461c-8b64-c50f394caa63">XMFLOAT2 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat2-operators">XMFLOAT2 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT3.operator = (const XMFLOAT
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMFLOAT3.operator =, Use DirectX::::XMFLOAT3::operator =, XMFLOAT3 structure [DirectX Math Support APIs],operator = method, XMFLOAT3.operator =, XMFLOAT3.operator-assign, XMFLOAT3.operator=, XMFLOAT3::operator-assign, XMFLOAT3::operator=, dxmath.xmfloat3_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT3 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT3::operator=
  - directxmath/XMFLOAT3::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMFLOAT3</code> whose vector component data has be
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat3">XMFLOAT3</a>
 
-<a href="https://msdn.microsoft.com/dc98a2ed-da87-4ba3-8394-682143b378b8">XMFLOAT3 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat3-operators">XMFLOAT3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3x3-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3x3-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT3X3.operator = (const XMFLO
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMFLOAT3X3.operator =, Use DirectX::::XMFLOAT3X3::operator =, XMFLOAT3X3 structure [DirectX Math Support APIs],operator = method, XMFLOAT3X3.operator =, XMFLOAT3X3.operator-assign, XMFLOAT3X3.operator=, XMFLOAT3X3::operator-assign, XMFLOAT3X3::operator=, dxmath.xmfloat3x3_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT3X3 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT3X3::operator=
  - directxmath/XMFLOAT3X3::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMFLOAT3X3</code> whose vector component data has 
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat3x3">XMFLOAT3X3</a>
 
-<a href="https://msdn.microsoft.com/cf055247-b19a-41fd-8090-33714a188ec3">XMFLOAT3X3 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat3x3-operators">XMFLOAT3X3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3x3-operator-function-call(size_t_size_t).md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat3x3-operator-function-call(size_t_size_t).md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT3X3.operator ()(size_t,size
 ms.date: 12/05/2018
 ms.keywords: XMFLOAT3X3 structure [DirectX Math Support APIs],operator () method, XMFLOAT3X3.operator ()(size_t,size_t), XMFLOAT3X3.operator (size_t,size_t), XMFLOAT3X3.operator(), XMFLOAT3X3.operator-function-call(size_t,size_t), XMFLOAT3X3::operator(), XMFLOAT3X3::operator-function-call(size_t,size_t), dxmath.xmfloat3x3_operator_parens_1, operator () method [DirectX Math Support APIs], operator () method [DirectX Math Support APIs],XMFLOAT3X3 structure, operator()
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT3X3::operator()
  - directxmath/XMFLOAT3X3::operator()
@@ -51,7 +51,7 @@ api_name:
 
 Returns a <code>reference</code> to a matrix element of an instance <code>XMFLOAT3X3</code> as
 	specified by row and column arguments.
-    
+
 
 This operator returns a <code>reference</code> to a matrix element of an instance <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat3x3">XMFLOAT3X3 </a> as specified by row and column arguments.
 <div class="alert"><b>Note</b>  This operator is only available under C++.
@@ -76,10 +76,10 @@ A <code>reference</code> to the matrix element specified by the operator's
 
 As a <code>reference</code> to the matrix element is returned, this operator can be used
 	    to update the value of an element of an instance of <code>XMFLOAT3X3</code>.
-	
+
 
 The following example:
-	
+
 
 <div class="code"><span codelanguage=""><table>
 <tr>
@@ -107,5 +107,4 @@ will set the value of the <i>mat.m[1,2]</i> (or equivalently mat._23) to 42.0.
 
 
 
-<a href="https://msdn.microsoft.com/19daf862-df81-40d7-b0c7-809015d7f7c8">operator ()</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat3x3-operators">XMFLOAT3X3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4-operator-assign(xmfloat4__).md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4-operator-assign(xmfloat4__).md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4.operator = (const XMFLOAT
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMFLOAT4.operator =, Use DirectX::::XMFLOAT4::operator =, XMFLOAT4 structure [DirectX Math Support APIs],operator = method, XMFLOAT4.operator =, XMFLOAT4.operator-assign(XMFLOAT4 &&), XMFLOAT4.operator=, XMFLOAT4::operator-assign(XMFLOAT4 &&), XMFLOAT4::operator=, dxmath.xmfloat4_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT4 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4::operator=
  - directxmath/XMFLOAT4::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMFLOAT4</code> whose vector component data has be
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4">XMFLOAT4</a>
 
-<a href="https://msdn.microsoft.com/edbc8450-b5a2-476a-bbe8-b66676552607">XMFLOAT4 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat4-operators">XMFLOAT4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4.operator = (const XMFLOAT
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMFLOAT4.operator =, Use DirectX::::XMFLOAT4::operator =, XMFLOAT4 structure [DirectX Math Support APIs],operator = method, XMFLOAT4.operator =, XMFLOAT4.operator-assign, XMFLOAT4.operator=, XMFLOAT4::operator-assign, XMFLOAT4::operator=, dxmath.xmfloat4_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT4 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4::operator=
  - directxmath/XMFLOAT4::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMFLOAT4</code> whose vector component data has be
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4">XMFLOAT4</a>
 
-<a href="https://msdn.microsoft.com/edbc8450-b5a2-476a-bbe8-b66676552607">XMFLOAT4 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat4-operators">XMFLOAT4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x3-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x3-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4X3.operator = (const XMFLO
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMFLOAT4X3.operator =, Use DirectX::::XMFLOAT4X3::operator =, XMFLOAT4X3 structure [DirectX Math Support APIs],operator = method, XMFLOAT4X3.operator =, XMFLOAT4X3.operator-assign, XMFLOAT4X3.operator=, XMFLOAT4X3::operator-assign, XMFLOAT4X3::operator=, dxmath.xmfloat4x3_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT4X3 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4X3::operator=
  - directxmath/XMFLOAT4X3::operator=
@@ -47,7 +47,7 @@ api_name:
 ## -description
 
 Assigns the vector component data from one instance of <code>XMFLOAT4X3</code> to the current instance of <code>XMFLOAT4X3</code>.
-    
+
 This operator assigns the vector component data from one instance of <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4x3">XMFLOAT4X3</a> to the current instance of <code>XMFLOAT4X3</code>.
 
 > [!NOTE]
@@ -67,4 +67,4 @@ The current instance of <code>XMFLOAT4X3</code> whose vector component data has 
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4x3">XMFLOAT4X3</a>
 
-<a href="https://msdn.microsoft.com/bcf2420c-cd66-4a50-9222-d74039867871">XMFLOAT4X3 Operators</a>
+<a href="/windows/win32/dxmath/ovw-xmfloat4x3-operators">XMFLOAT4X3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x3-operator-function-call(size_t_size_t).md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x3-operator-function-call(size_t_size_t).md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4X3.operator ()(size_t,size
 ms.date: 12/05/2018
 ms.keywords: XMFLOAT4X3 structure [DirectX Math Support APIs],operator () method, XMFLOAT4X3.operator ()(size_t,size_t), XMFLOAT4X3.operator (size_t,size_t), XMFLOAT4X3.operator(), XMFLOAT4X3.operator-function-call(size_t,size_t), XMFLOAT4X3::operator(), XMFLOAT4X3::operator-function-call(size_t,size_t), dxmath.xmfloat4x3_operator_parens_1, operator () method [DirectX Math Support APIs], operator () method [DirectX Math Support APIs],XMFLOAT4X3 structure, operator()
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4X3::operator()
  - directxmath/XMFLOAT4X3::operator()
@@ -103,5 +103,4 @@ will set the value of the <i>mat.m[3,2]</i> (or equivalently mat._43) to 42.0.
 
 
 
-<a href="https://msdn.microsoft.com/7abe65f9-41c0-43cd-9f6d-99cee5682191">operator ()</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat4x3-operators">XMFLOAT4X3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x4-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x4-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4X4.operator = (const XMFLO
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMFLOAT4X4.operator =, Use DirectX::::XMFLOAT4X4::operator =, XMFLOAT4X4 structure [DirectX Math Support APIs],operator = method, XMFLOAT4X4.operator =, XMFLOAT4X4.operator-assign, XMFLOAT4X4.operator=, XMFLOAT4X4::operator-assign, XMFLOAT4X4::operator=, dxmath.xmfloat4x4_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMFLOAT4X4 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4X4::operator=
  - directxmath/XMFLOAT4X4::operator=
@@ -67,4 +67,4 @@ The current instance of <code>XMFLOAT4X4</code> whose vector component data has 
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4x4">XMFLOAT4X4</a>
 
-<a href="https://msdn.microsoft.com/e52712dc-2d94-4bc1-a0e8-2ea274bc3062">XMFLOAT4X4 Operators</a>
+<a href="/windows/win32/dxmath/ovw-xmfloat4x4-operators">XMFLOAT4X4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x4-operator-function-call(size_t_size_t).md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmfloat4x4-operator-function-call(size_t_size_t).md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMFLOAT4X4.operator ()(size_t,size
 ms.date: 12/05/2018
 ms.keywords: XMFLOAT4X4 structure [DirectX Math Support APIs],operator () method, XMFLOAT4X4.operator ()(size_t,size_t), XMFLOAT4X4.operator (size_t,size_t), XMFLOAT4X4.operator(), XMFLOAT4X4.operator-function-call(size_t,size_t), XMFLOAT4X4::operator(), XMFLOAT4X4::operator-function-call(size_t,size_t), dxmath.xmfloat4x4_operator_parens_1, operator () method [DirectX Math Support APIs], operator () method [DirectX Math Support APIs],XMFLOAT4X4 structure, operator()
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT4X4::operator()
  - directxmath/XMFLOAT4X4::operator()
@@ -100,5 +100,4 @@ will set the value of the <i>mat.m[2,3]</i> (or equivalently mat._34) to 42.0.
 
 
 
-<a href="https://msdn.microsoft.com/de367692-6974-4e54-9f1e-d8c56b3aa752">operator ()</a>
-
+<a href="/windows/win32/dxmath/ovw-xmfloat4x4-operators">XMFLOAT4X4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmint2-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmint2-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMINT2.operator = (const XMINT2)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMINT2.operator =, Use DirectX::::XMINT2::operator =, XMINT2 structure [DirectX Math Support APIs],operator = method, XMINT2.operator =, XMINT2.operator-assign, XMINT2.operator=, XMINT2::operator-assign, XMINT2::operator=, dxmath.xmint2_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMINT2 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMINT2::operator=
  - directxmath/XMINT2::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMINT2</code> whose vector component data has been
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmint2">XMINT2</a>
 
-<a href="https://msdn.microsoft.com/98822959-f4ef-4f73-8011-f9eba201dcc0">XMINT2 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmint2-operators">XMINT2 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmint3-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmint3-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMINT3.operator = (const XMINT3)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMINT3.operator =, Use DirectX::::XMINT3::operator =, XMINT3 structure [DirectX Math Support APIs],operator = method, XMINT3.operator =, XMINT3.operator-assign, XMINT3.operator=, XMINT3::operator-assign, XMINT3::operator=, dxmath.xmint3_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMINT3 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMINT3::operator=
  - directxmath/XMINT3::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMINT3</code> whose vector component data has been
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmint3">XMINT3</a>
 
-<a href="https://msdn.microsoft.com/4c78cb57-52e7-4a06-91d9-2fb3f73a0f0e">XMINT3 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmint3-operators">XMINT3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmint4-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmint4-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMINT4.operator = (const XMINT4)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMINT4.operator =, Use DirectX::::XMINT4::operator =, XMINT4 structure [DirectX Math Support APIs],operator = method, XMINT4.operator =, XMINT4.operator-assign, XMINT4.operator=, XMINT4::operator-assign, XMINT4::operator=, dxmath.xmint4_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMINT4 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMINT4::operator=
  - directxmath/XMINT4::operator=
@@ -51,7 +51,7 @@ api_name:
 
 Assigns the vector component data from one instance of <code>XMINT4</code> to the current instance of <code>XMINT4</code>.
 
-This operator assigns the vector component data from one instance of <a href="https://msdn.microsoft.com/4562AF48-FC7E-4737-AB7B-7A76789DC70B">XMINT4</a> to the current instance of <code>XMINT4</code>.
+This operator assigns the vector component data from one instance of <a href="/windows/win32/api/directxmath/ns-directxmath-xmint4">XMINT4</a> to the current instance of <code>XMINT4</code>.
 
 <div class="alert"><b>Note</b>  This operator is only available under C++.</div>
 
@@ -67,7 +67,6 @@ The current instance of <code>XMINT4</code> whose vector component data has been
 
 ## -see-also
 
-<a href="https://msdn.microsoft.com/4562AF48-FC7E-4737-AB7B-7A76789DC70B">XMINT4</a>
+<a href="/windows/win32/api/directxmath/ns-directxmath-xmint4">XMINT4</a>
 
-<a href="https://msdn.microsoft.com/efb42dbb-30ea-426a-a281-b5b732085805">XMINT4 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmint4-operators">XMINT4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMMATRIX.operator =(const XMMATRIX
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMATRIX.operator =, Use DirectX::::XMMATRIX::operator =, XMMATRIX structure [DirectX Math Support APIs],operator = method, XMMATRIX.operator =, XMMATRIX.operator-assign, XMMATRIX.operator=, XMMATRIX::operator-assign, XMMATRIX::operator=, dxmath.xmmatrix_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMMATRIX structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMMATRIX::operator=
  - directxmath/XMMATRIX::operator=
@@ -51,7 +51,7 @@ api_name:
 
 Assigns the matrix data of one instance of <code>XMMATRIX</code> to the current instance of
 	<code>XMMATRIX</code> and returns a <code>reference</code> to the current instance.  
-    
+
 
 This operator assigns the matrix data of one instance of <a href="/windows/win32/api/directxmath/ns-directxmath-xmmatrix">XMMATRIX</a>to the current instance of <code>XMMATRIX</code> and returns a <code>reference</code> to the current
 	instance.
@@ -79,7 +79,7 @@ The following pseudocode demonstrates the operation of this operator:
 <tr>
 <td>
 <pre>
-   
+
    XMMATRIX mat1;
    XMMATRIX M;
    // mat1=mat1*M
@@ -103,5 +103,4 @@ The following pseudocode demonstrates the operation of this operator:
 
 
 
-<a href="https://msdn.microsoft.com/74deddbd-0472-43fd-8ad6-2e933812eb14">XMMATRIX Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmmatrix-operators">XMMATRIX Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-function-call(size_t_size_t).md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-function-call(size_t_size_t).md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMMATRIX.operator ()(size_t,size_t
 ms.date: 12/05/2018
 ms.keywords: XMMATRIX structure [DirectX Math Support APIs],operator () method, XMMATRIX.operator ()(size_t,size_t), XMMATRIX.operator (size_t,size_t), XMMATRIX.operator(), XMMATRIX.operator-function-call(size_t,size_t), XMMATRIX::operator(), XMMATRIX::operator-function-call(size_t,size_t), dxmath.xmmatrix_operator_parens_1, operator () method [DirectX Math Support APIs], operator () method [DirectX Math Support APIs],XMMATRIX structure, operator()
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMMATRIX::operator()
  - directxmath/XMMATRIX::operator()
@@ -103,5 +103,4 @@ will set the value of the <i>mat.m[1][2]</i> to 42.0.
 
 
 
-<a href="https://msdn.microsoft.com/917d44b0-4625-412f-b3ad-5955856689d5">operator ()</a>
-
+<a href="/windows/win32/dxmath/ovw-xmmatrix-operators">XMMATRIX Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-mult-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-mult-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMMATRIX.operator *=(const XMMATRI
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMATRIX.operator *=, Use DirectX::::XMMATRIX::operator *=, XMMATRIX structure [DirectX Math Support APIs],operator *= method, XMMATRIX.operator *=, XMMATRIX.operator*=, XMMATRIX.operator-mult-assign, XMMATRIX::operator*=, XMMATRIX::operator-mult-assign, dxmath.xmmatrix_operator_muleq, operator *= method [DirectX Math Support APIs], operator *= method [DirectX Math Support APIs],XMMATRIX structure, operator*=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMMATRIX::operator*=
  - directxmath/XMMATRIX::operator*=
@@ -49,7 +49,7 @@ api_name:
 
 ## -description
 
-Performs a matrix multiplication of the current instance of <code>XMMATRIX</code> by another instance of <code>XMMATRIX</code> and returns a reference to the current instance, which has been updated. 
+Performs a matrix multiplication of the current instance of <code>XMMATRIX</code> by another instance of <code>XMMATRIX</code> and returns a reference to the current instance, which has been updated.
 
 This operator performs a matrix multiplication of the current instance of <a href="/windows/win32/api/directxmath/ns-directxmath-xmmatrix">XMMATRIX</a> by another instance of <code>XMMATRIX</code> and returns a reference to the current instance, which has been updated.
 <div class="alert"><b>Note</b>  This operator is only available when developing with C++.</div><div> </div>
@@ -67,7 +67,7 @@ Reference to the current instance of <code>XMMATRIX</code>, which has been updat
 ## -remarks
 
 The current <code>XMMATRIX</code> is the left hand side of the matrix multiplication.  That is  the matrix operation <i>mat1 =  mat1 * M  </i> can be implemented as:
-      
+
 
 <div class="code"><span codelanguage=""><table>
 <tr>
@@ -82,7 +82,7 @@ The current <code>XMMATRIX</code> is the left hand side of the matrix multiplica
 </td>
 </tr>
 </table></span></div>
-And is equivalent to using <a href="https://msdn.microsoft.com/13acd0b4-7fa6-4663-a613-1e63f24aed5f"> and
+And is equivalent to using operator* and
 	 assigning the result to the call's first argument.</a>
 
 
@@ -110,5 +110,4 @@ And is equivalent to using <a href="https://msdn.microsoft.com/13acd0b4-7fa6-466
 
 
 
-<a href="https://msdn.microsoft.com/74deddbd-0472-43fd-8ad6-2e933812eb14">XMMATRIX Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmmatrix-operators">XMMATRIX Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-mult.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrix-operator-mult.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMMATRIX.operator *(const XMMATRIX
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMATRIX.operator *, Use DirectX::::XMMATRIX::operator *, XMMATRIX structure [DirectX Math Support APIs],operator * method, XMMATRIX.operator *, XMMATRIX.operator*, XMMATRIX.operator-mult, XMMATRIX::operator*, XMMATRIX::operator-mult, dxmath.xmmatrix_operator_mul, operator * method [DirectX Math Support APIs], operator * method [DirectX Math Support APIs],XMMATRIX structure, operator*
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMMATRIX::operator*
  - directxmath/XMMATRIX::operator*
@@ -67,7 +67,7 @@ An instance of <code>XMMATRIX</code> containing the result of the matrix multipl
 ## -remarks
 
 The current <code>XMMATRIX</code> is the left hand side of the matrix multiplication.  That is  the matrix operation <i>mat2 =  mat1 * M  </i> can be implemented as:
-      
+
 
 <div class="code"><span codelanguage=""><table>
 <tr>
@@ -83,8 +83,6 @@ The current <code>XMMATRIX</code> is the left hand side of the matrix multiplica
 </td>
 </tr>
 </table></span></div>
-And is equivalent to using <a href="https://msdn.microsoft.com/13acd0b4-7fa6-4663-a613-1e63f24aed5f"> and
-	 assigning the result to the call's first argument.</a>
 
 
 <div class="code"><span codelanguage=""><table>
@@ -112,5 +110,4 @@ And is equivalent to using <a href="https://msdn.microsoft.com/13acd0b4-7fa6-466
 
 
 
-<a href="https://msdn.microsoft.com/74deddbd-0472-43fd-8ad6-2e933812eb14">XMMATRIX Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmmatrix-operators">XMMATRIX Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixvectortensorproduct.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixvectortensorproduct.md
@@ -1,0 +1,80 @@
+---
+UID: NF:directxmath.XMMatrixVectorTensorProduct
+title: XMMatrixVectorTensorProduct function (directxmath.h)
+description: Builds an matrix from two vectors
+helpviewer_keywords: ["Use DirectX..XMMatrixVectorTensorProduct","XMMatrixVectorTensorProduct","XMMatrixVectorTensorProduct method [DirectX Math Support APIs]","dxmath.xmmatrixvectortensorproduct"]
+old-location: dxmath\xmmatrixaffinetransformation.htm
+tech.root: dxmath
+ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixVectorTensorProduct(XMVECTOR,XMVECTOR)
+ms.date: 06/06/2021
+ms.keywords: Use DirectX..XMMatrixVectorTensorProduct,XMMatrixVectorTensorProduct,XMMatrixVectorTensorProduct method [DirectX Math Support APIs], dxmath.xmmatrixvectortensorproduct
+req.header: directxmath.h
+req.include-header:
+req.target-type: Windows
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace: Use DirectX.
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+targetos: Windows
+req.typenames:
+req.redist:
+ms.custom: MN
+f1_keywords:
+ - XMMatrixVectorTensorProduct
+ - directxmath/XMMatrixVectorTensorProduct
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - COM
+api_location:
+ - DirectXMath.h
+api_name:
+ - XMMatrixVectorTensorProduct
+---
+
+# XMMatrixVectorTensorProduct function
+
+
+## -description
+
+Builds a matrix from two vectors by computing the outer tensor product.
+
+## -parameters
+
+### -param V1 [in]
+
+3D vector.
+
+### -param V2 [in]
+
+3D vector.
+
+## -returns
+
+Returns the outer tensor product of <i>V1</i> and <i>V2</i>.
+
+## -remarks
+
+See [Wikipedia](https://en.wikipedia.org/wiki/Outer_product) for more information on the *outer product*.
+
+> This function was added in DirectXMath 3.15.
+
+<h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+
+## -see-also
+
+<a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-matrix">DirectXMath Library Matrix Functions</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixvectortensorproduct.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixvectortensorproduct.md
@@ -3,9 +3,7 @@ UID: NF:directxmath.XMMatrixVectorTensorProduct
 title: XMMatrixVectorTensorProduct function (directxmath.h)
 description: Builds an matrix from two vectors
 helpviewer_keywords: ["Use DirectX..XMMatrixVectorTensorProduct","XMMatrixVectorTensorProduct","XMMatrixVectorTensorProduct method [DirectX Math Support APIs]","dxmath.xmmatrixvectortensorproduct"]
-old-location: dxmath\xmmatrixaffinetransformation.htm
 tech.root: dxmath
-ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixVectorTensorProduct(XMVECTOR,XMVECTOR)
 ms.date: 06/06/2021
 ms.keywords: Use DirectX..XMMatrixVectorTensorProduct,XMMatrixVectorTensorProduct,XMMatrixVectorTensorProduct method [DirectX Math Support APIs], dxmath.xmmatrixvectortensorproduct
 req.header: directxmath.h

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmuint2-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmuint2-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMUINT2.operator = (const XMUINT2)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMUINT2.operator =, Use DirectX::::XMUINT2::operator =, XMUINT2 structure [DirectX Math Support APIs],operator = method, XMUINT2.operator =, XMUINT2.operator-assign, XMUINT2.operator=, XMUINT2::operator-assign, XMUINT2::operator=, dxmath.xmuint2_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMUINT2 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMUINT2::operator=
  - directxmath/XMUINT2::operator=
@@ -51,7 +51,7 @@ api_name:
 
 Assigns the vector component data from one instance of <code>XMUINT2</code> to the current instance of <code>XMUINT2</code>.
 
-This operator assigns the vector component data from one instance of <a href="https://msdn.microsoft.com/33240440-20A8-4320-AF2F-40BA287CB107">XMUINT2</a> to the current instance of <code>XMUINT2</code>.
+This operator assigns the vector component data from one instance of <a href="/windows/win32/api/directxmath/ns-directxmath-xmuint2">XMUINT2</a> to the current instance of <code>XMUINT2</code>.
 
 <div class="alert"><b>Note</b>  This operator is only available under C++.</div>
 
@@ -67,7 +67,6 @@ The current instance of <code>XMUINT2</code> whose vector component data has bee
 
 ## -see-also
 
-<a href="https://msdn.microsoft.com/33240440-20A8-4320-AF2F-40BA287CB107">XMUINT2</a>
+<a href="/windows/win32/api/directxmath/ns-directxmath-xmuint2">XMUINT2</a>
 
-<a href="https://msdn.microsoft.com/2d3596f0-9c01-4b81-b1b1-95c43f0749e1">XMUINT2 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmuint2-operators">XMUINT2 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmuint3-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmuint3-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMUINT3.operator = (const XMUINT3)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMUINT3.operator =, Use DirectX::::XMUINT3::operator =, XMUINT3 structure [DirectX Math Support APIs],operator = method, XMUINT3.operator =, XMUINT3.operator-assign, XMUINT3.operator=, XMUINT3::operator-assign, XMUINT3::operator=, dxmath.xmuint3_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMUINT3 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMUINT3::operator=
  - directxmath/XMUINT3::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMUINT3</code> whose vector component data has bee
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmuint3">XMUINT3</a>
 
-<a href="https://msdn.microsoft.com/6e732b64-9926-4949-9292-c3ac3a553967">XMUINT3 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmuint3-operators">XMUINT3 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmuint4-operator-assign.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmuint4-operator-assign.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.reference.XMUINT4.operator = (const XMUINT4)
 ms.date: 05/13/2019
 ms.keywords: Use DirectX..XMUINT4.operator =, Use DirectX::::XMUINT4::operator =, XMUINT4 structure [DirectX Math Support APIs],operator = method, XMUINT4.operator =, XMUINT4.operator-assign, XMUINT4.operator=, XMUINT4::operator-assign, XMUINT4::operator=, dxmath.xmuint4_operator_eq, operator = method [DirectX Math Support APIs], operator = method [DirectX Math Support APIs],XMUINT4 structure, operator=
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMUINT4::operator=
  - directxmath/XMUINT4::operator=
@@ -69,5 +69,4 @@ The current instance of <code>XMUINT4</code> whose vector component data has bee
 
 <a href="/windows/win32/api/directxmath/ns-directxmath-xmuint4">XMUINT4</a>
 
-<a href="https://msdn.microsoft.com/2488e70d-01dd-4d98-840e-35eca28ac10b">XMUINT4 Operators</a>
-
+<a href="/windows/win32/dxmath/ovw-xmuint4-operators">XMUINT4 Operators</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp10.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp10.md
@@ -4,7 +4,6 @@ title: XMVectorExp10 function (directxmath.h)
 description: Computes ten raised to the power for each component.
 helpviewer_keywords: ["Use DirectX..XMVectorExp10","XMVectorExp10","XMVectorExp10 method [DirectX Math Support APIs]","dxmath.xmvectorexp10"]
 tech.root: dxmath
-ms.assetid: M:Microsoft.directx_sdk.arithmetic.XMVectorExp10(XMVECTOR)
 ms.date: 06/06/2021
 ms.keywords: Use DirectX..XMVectorExp10, XMVectorExp10, XMVectorExp10 method [DirectX Math Support APIs], dxmath.xmvectorexp10
 req.header: directxmath.h

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp10.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp10.md
@@ -1,0 +1,95 @@
+---
+UID: NF:directxmath.XMVectorExp10
+title: XMVectorExp10 function (directxmath.h)
+description: Computes ten raised to the power for each component.
+helpviewer_keywords: ["Use DirectX..XMVectorExp10","XMVectorExp10","XMVectorExp10 method [DirectX Math Support APIs]","dxmath.xmvectorexp10"]
+tech.root: dxmath
+ms.assetid: M:Microsoft.directx_sdk.arithmetic.XMVectorExp10(XMVECTOR)
+ms.date: 06/06/2021
+ms.keywords: Use DirectX..XMVectorExp10, XMVectorExp10, XMVectorExp10 method [DirectX Math Support APIs], dxmath.xmvectorexp10
+req.header: directxmath.h
+req.include-header: DirectXMath.h
+req.target-type: Windows
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace: Use DirectX.
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+targetos: Windows
+req.typenames:
+req.redist:
+ms.custom: FE
+f1_keywords:
+ - XMVectorExp10
+ - directxmath/XMVectorExp10
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - COM
+api_location:
+ - directxmathvector.inl
+api_name:
+ - XMVectorExp10
+---
+
+# XMVectorExp10 function
+
+
+## -description
+
+Computes ten raised to the power for each component.
+
+## -parameters
+
+### -param V [in]
+
+Vector used for the exponents of base ten.
+
+## -returns
+
+Returns a vector whose components are ten raised to the power of the corresponding component of <i>V</i>.
+
+## -remarks
+
+<h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
+ Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+
+> This function was added in DirectXMath 3.16
+
+
+<b>XMVectorExp10</b> is implemented like this:
+
+<pre class="syntax" xml:space="preserve"><code>
+XMVECTOR Result;
+
+Result.x = powf(10.0f, V.x);
+Result.y = powf(10.0f, V.y);
+Result.z = powf(10.0f, V.z);
+Result.w = powf(10.0f, V.w);
+
+return Result;
+</code></pre>
+
+## -see-also
+
+<a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-vector-transcendental">Transcendental Vector Functions</a>
+
+
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp2">XMVectorExp2</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexpe">XMVectorExpE</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog10">XMVectorLog10</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp2.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexp2.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorExp2, XMVectorExp2, XMVectorExp2 method [Direc
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorExp2
@@ -65,21 +65,21 @@ Returns a vector whose components are two raised to the power of the correspondi
 ## -remarks
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
-Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8.1. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
 
-<b>XMVectorExp2</b> is new for DirectXMath version 3.05, but it's just a renamed version of the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp">XMVectorExp</a> function for Windows 8. 
+<b>XMVectorExp2</b> is new for DirectXMath version 3.05, but it's just a renamed version of the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp">XMVectorExp</a> function for Windows 8.
 
 
 
 <b>XMVectorExp2</b> is implemented like this:
 
 <pre class="syntax" xml:space="preserve"><code>
-XMVECTOR Result; 
+XMVECTOR Result;
 
-Result.x = powf(2.0f, V.x);
-Result.y = powf(2.0f, V.y);
-Result.z = powf(2.0f, V.z);
-Result.w = powf(2.0f, V.w);
+Result.x = exp2f(V.x);
+Result.y = exp2f(V.y);
+Result.z = exp2f(V.z);
+Result.w = exp2f(V.w);
 
 return Result;
 </code></pre>
@@ -92,6 +92,6 @@ return Result;
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexpe">XMVectorExpE</a>
 
-
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp10">XMVectorExp10</a>
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog2">XMVectorLog2</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexpe.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorexpe.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorExpE, XMVectorExpE, XMVectorExpE method [Direc
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorExpE
@@ -65,9 +65,9 @@ Returns a vector whose components are e raised to the power of the corresponding
 ## -remarks
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
-Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8.1. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
 
-<b>XMVectorExpE</b> is new for DirectXMath version 3.05. 
+<b>XMVectorExpE</b> is new for DirectXMath version 3.05.
 
 It's similar to the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp">XMVectorExp</a> function for Windows 8, but computes base e instead of base 2.
 
@@ -75,7 +75,7 @@ It's similar to the existing <a href="/windows/desktop/api/directxmath/nf-direct
 <b>XMVectorExpE</b> is implemented like this:
 
 <pre class="syntax" xml:space="preserve"><code>
-XMVECTOR Result; 
+XMVECTOR Result;
 
 Result.x = expf(V.x);
 Result.y = expf(V.y);
@@ -93,6 +93,6 @@ return Result;
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp2">XMVectorExp2</a>
 
-
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp10">XMVectorExp10</a>
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorloge">XMVectorLogE</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog10.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog10.md
@@ -4,7 +4,6 @@ title: XMVectorLog10 function (directxmath.h)
 description: Computes the base ten logarithm of each component of a vector.
 helpviewer_keywords: ["Use DirectX..XMVectorLog10","XMVectorLog10","XMVectorLog10 method [DirectX Math Support APIs]","dxmath.xmvectorlog10"]
 tech.root: dxmath
-ms.assetid: M:Microsoft.directx_sdk.arithmetic.XMVectorLog10(XMVECTOR)
 ms.date: 06/06/2021
 ms.keywords: Use DirectX..XMVectorLog10, XMVectorLog10, XMVectorLog10 method [DirectX Math Support APIs], dxmath.xmvectorlog10
 req.header: directxmath.h

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog10.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog10.md
@@ -1,0 +1,93 @@
+---
+UID: NF:directxmath.XMVectorLog10
+title: XMVectorLog10 function (directxmath.h)
+description: Computes the base ten logarithm of each component of a vector.
+helpviewer_keywords: ["Use DirectX..XMVectorLog10","XMVectorLog10","XMVectorLog10 method [DirectX Math Support APIs]","dxmath.xmvectorlog10"]
+tech.root: dxmath
+ms.assetid: M:Microsoft.directx_sdk.arithmetic.XMVectorLog10(XMVECTOR)
+ms.date: 06/06/2021
+ms.keywords: Use DirectX..XMVectorLog10, XMVectorLog10, XMVectorLog10 method [DirectX Math Support APIs], dxmath.xmvectorlog10
+req.header: directxmath.h
+req.include-header: DirectXMath.h
+req.target-type: Windows
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace: Use DirectX.
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
+targetos: Windows
+req.typenames:
+req.redist:
+ms.custom: FE
+f1_keywords:
+ - XMVectorLog10
+ - directxmath/XMVectorLog10
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - COM
+api_location:
+ - directxmathvector.inl
+api_name:
+ - XMVectorLog10
+---
+
+# XMVectorLog10 function
+
+
+## -description
+
+Computes the base ten logarithm of each component of a vector.
+
+## -parameters
+
+### -param V [in]
+
+Vector for which to compute the base ten logarithm.
+
+## -returns
+
+Returns a vector whose components are base ten logarithm of the corresponding components of <i>V</i>.
+
+## -remarks
+
+<h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
+Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
+
+> This function was added in DirectXMath 3.16
+
+
+<b>XMVectorLog10</b> is implemented like this:
+
+<pre class="syntax" xml:space="preserve"><code>
+XMVECTOR Result;
+
+Result.x = log10f(V.x);
+Result.y = log10f(V.y);
+Result.z = log10f(V.z);
+Result.w = log10f(V.w);
+
+return Result;
+</code></pre>
+
+## -see-also
+
+<a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-vector-transcendental">Transcendental Vector Functions</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorloge">XMVectorLogE</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog2">XMVectorLog2</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp10">XMVectorExp10</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog2.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorlog2.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorLog2, XMVectorLog2, XMVectorLog2 method [Direc
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorLog2
@@ -67,7 +67,7 @@ Returns a vector whose components are base two logarithm of the corresponding co
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8.1. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
 
-<b>XMVectorLog2</b> is new for DirectXMath version 3.05, but it's just a renamed version of the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog">XMVectorLog</a> function for Windows 8. 
+<b>XMVectorLog2</b> is new for DirectXMath version 3.05, but it's just a renamed version of the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog">XMVectorLog</a> function for Windows 8.
 
 
 
@@ -76,10 +76,10 @@ Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows 
 <pre class="syntax" xml:space="preserve"><code>
 XMVECTOR Result;
 
-Result.x = logf(V.x) / logf(2);
-Result.y = logf(V.y) / logf(2);
-Result.z = logf(V.z) / logf(2);
-Result.w = logf(V.w) / logf(2);
+Result.x = log2f(V.x);
+Result.y = log2f(V.y);
+Result.z = log2f(V.z);
+Result.w = log2f(V.w);
 
 return Result;
 </code></pre>
@@ -88,10 +88,8 @@ return Result;
 
 <a href="/windows/desktop/dxmath/ovw-xnamath-reference-functions-vector-transcendental">Transcendental Vector Functions</a>
 
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorloge">XMVectorLogE</a>
 
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog10">XMVectorLog10</a>
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexp2">XMVectorExp2</a>
-
-
-
-<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorloge">XMVectorLogE</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorloge.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorloge.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorLogE, XMVectorLogE, XMVectorLogE method [Direc
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorLogE
@@ -67,7 +67,7 @@ Returns a vector whose components are base e logarithm of the corresponding comp
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8.1. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.
 
-<b>XMVectorLogE</b> is new for DirectXMath version 3.05. 
+<b>XMVectorLogE</b> is new for DirectXMath version 3.05.
 
 It's similar to the existing <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog">XMVectorLog</a> function for Windows 8, but computes base e instead of base 2.
 
@@ -91,8 +91,9 @@ return Result;
 
 
 
-<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexpe">XMVectorExpE</a>
-
-
 
 <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog2">XMVectorLog2</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorlog10">XMVectorLog10</a>
+
+<a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorexpe">XMVectorExpE</a>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorselect.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorselect.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorSelect, XMVectorSelect, XMVectorSelect method 
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorSelect
@@ -104,7 +104,7 @@ Manual construction of a control vector is not necessary. There are two simple w
 <li>
 Using the <a href="/windows/desktop/api/directxmath/nf-directxmath-xmvectorselectcontrol">XMVectorSelectControl</a>function to construct a control vector.
 
-See <a href="https://msdn.microsoft.com/307660ea-09d4-49ce-b4ed-4a0e5ad1f021">Using XMVectorSelect and
+See <a href="/windows/win32/api/directxmath/nf-directxmath-xmvectorselectcontrol">Using XMVectorSelect and
        XMVectorSelectControl</a> for a demonstration of how this function can be used.
 
 </li>

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmvectorsum.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmvectorsum.md
@@ -11,23 +11,23 @@ ms.keywords: Use DirectX..XMVectorSum, XMVectorSum, XMVectorSum method [DirectX 
 req.header: directxmath.h
 req.include-header: DirectXMath.h
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMVectorSum
@@ -61,6 +61,12 @@ Vector for which to compute the horizontal sum.
 ## -returns
 
 Returns a vector whose components are the horizontal sum of the components of <i>V</i>.
+
+## -remarks
+
+Note that for SSE/SSE2, horizonal sums require a number of math and shuffle operations. If you enable SSE3 (via defining ``_XM_SSE3_INTRINSICS_``, ``/arch:AVX``, or ``/arch:AVX2``) -or- if using Windows on ARM/ARM64, this function can make use of horizonal sum intrinsics.
+
+> This is new to DirectXMath 3.10
 
 ## -see-also
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat2a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat2a.md
@@ -9,20 +9,20 @@ ms.date: 05/20/2019
 ms.keywords: XMFLOAT2A
 targetos: Windows
 req.construct-type: structure
-req.ddi-compliance: 
-req.dll: 
+req.ddi-compliance:
+req.dll:
 req.header: directxmath.h
-req.include-header: 
-req.kmdf-ver: 
-req.lib: 
-req.max-support: 
-req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.target-type: 
-req.typenames: 
-req.umdf-ver: 
-req.unicode-ansi: 
+req.include-header:
+req.kmdf-ver:
+req.lib:
+req.max-support:
+req.redist:
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.target-type:
+req.typenames:
+req.umdf-ver:
+req.unicode-ansi:
 f1_keywords:
  - XMFLOAT2A
  - directxmath/XMFLOAT2A
@@ -45,7 +45,8 @@ api_name:
 
 Describes an <a href="/windows/desktop/api/directxmath/ns-directxmath-xmfloat2">XMFLOAT2</a> structure aligned on a 16-byte boundary.
 
-<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and <a href="https://msdn.microsoft.com/dce61bc4-4ed5-4e64-84e8-6db88025e5c2">DXGI_FORMAT</a> objects.</div>
+<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+<a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
 
 ## -struct-fields
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3a.md
@@ -9,20 +9,20 @@ ms.date: 05/20/2019
 ms.keywords: XMFLOAT3A
 targetos: Windows
 req.construct-type: structure
-req.ddi-compliance: 
-req.dll: 
+req.ddi-compliance:
+req.dll:
 req.header: directxmath.h
-req.include-header: 
-req.kmdf-ver: 
-req.lib: 
-req.max-support: 
-req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.target-type: 
-req.typenames: 
-req.umdf-ver: 
-req.unicode-ansi: 
+req.include-header:
+req.kmdf-ver:
+req.lib:
+req.max-support:
+req.redist:
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.target-type:
+req.typenames:
+req.umdf-ver:
+req.unicode-ansi:
 f1_keywords:
  - XMFLOAT3A
  - directxmath/XMFLOAT3A
@@ -46,8 +46,8 @@ api_name:
 Describes an <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat3">XMFLOAT3</a> structure aligned on a 16-byte boundary.
 
 <div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information
-  about equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and
-  <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
+  about equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+  <a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
 
 ## -struct-fields
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3x4.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3x4.md
@@ -7,25 +7,25 @@ helpviewer_keywords: ["XMFLOAT3X4","XMFLOAT3X4 structure [DirectX Math Support A
 tech.root: dxmath
 req.construct-type: structure
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT3X4
  - directxmath/XMFLOAT3X4
@@ -116,6 +116,8 @@ The member *m* is a 2-dimensional 3x4 array. It provides 0-based indexing of the
 You can load an [XMMATRIX](./ns-directxmath-xmmatrix.md) from an **XMFLOAT3X4** by using [XMLoadFloat3x4](./nf-directxmath-xmloadfloat3x4.md).
 
 You can store an [XMMATRIX](./ns-directxmath-xmmatrix.md) into an **XMFLOAT3X4** by using [XMStoreFloat3x4](./nf-directxmath-xmstorefloat3x4.md).
+
+> This type and the associated functions were added in DirectXMath 3.13
 
 ## -see-also
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3x4a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat3x4a.md
@@ -7,25 +7,25 @@ helpviewer_keywords: ["XMFLOAT3X4A","XMFLOAT3X4A structure [DirectX Math Support
 tech.root: dxmath
 req.construct-type: structure
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 f1_keywords:
  - XMFLOAT3X4A
  - directxmath/XMFLOAT3X4A
@@ -53,6 +53,8 @@ A 3x4 column-major matrix containing 32-bit floating-point components aligned on
 You can load an [XMMATRIX](./ns-directxmath-xmmatrix.md) from an **XMFLOAT3X4A** by using [XMLoadFloat3x4A](./nf-directxmath-xmloadfloat3x4a.md).
 
 You can store an [XMMATRIX](./ns-directxmath-xmmatrix.md) into an **XMFLOAT3X4A** by using [XMStoreFloat3x4A](./nf-directxmath-xmstorefloat3x4a.md).
+
+> This type and the associated functions were added in DirectXMath 3.13
 
 ## -see-also
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4a.md
@@ -9,20 +9,20 @@ ms.date: 05/20/2019
 ms.keywords: XMFLOAT4A
 targetos: Windows
 req.construct-type: structure
-req.ddi-compliance: 
-req.dll: 
+req.ddi-compliance:
+req.dll:
 req.header: directxmath.h
-req.include-header: 
-req.kmdf-ver: 
-req.lib: 
-req.max-support: 
-req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.target-type: 
-req.typenames: 
-req.umdf-ver: 
-req.unicode-ansi: 
+req.include-header:
+req.kmdf-ver:
+req.lib:
+req.max-support:
+req.redist:
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.target-type:
+req.typenames:
+req.umdf-ver:
+req.unicode-ansi:
 f1_keywords:
  - XMFLOAT4A
  - directxmath/XMFLOAT4A
@@ -45,7 +45,8 @@ api_name:
 
 Describes an <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4">XMFLOAT4</a> structure aligned on a 16-byte boundary.
 
-<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and <a href="https://msdn.microsoft.com/dce61bc4-4ed5-4e64-84e8-6db88025e5c2">DXGI_FORMAT</a> objects.</div>
+<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+<a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
 
 ## -struct-fields
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x3.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x3.md
@@ -9,25 +9,25 @@ ms.assetid: T:Microsoft.directx_sdk.reference.XMFLOAT4X3
 ms.date: 12/05/2018
 ms.keywords: XMFLOAT4X3, XMFLOAT4X3 structure [DirectX Math Support APIs], directxmath/XMFLOAT4X3, dxmath.xmfloat4x3
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMFLOAT4X3
@@ -55,10 +55,10 @@ A 4*3 floating point matrix.
 
 
 For a list of additional functionality such as constructors and operators that are available using <code>XMFLOAT4X3</code> when you
-  are programming in C++, see <a href="https://msdn.microsoft.com/6745ae3e-a0b5-4b3d-99d3-b6b024e1bea4">XMFLOAT4X3 Extensions</a>.
+  are programming in C++, see <a href="/windows/win32/dxmath/ovw-xmfloat4x3-extensions">XMFLOAT4X3 Extensions</a>.
 <div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about
-  equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and
-  <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div><div> </div>
+  equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+  <a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div><div> </div>
 
 ## -struct-fields
 
@@ -154,4 +154,4 @@ Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows 
 
 
 
-<a href="https://msdn.microsoft.com/6745ae3e-a0b5-4b3d-99d3-b6b024e1bea4">XMFLOAT4X3 Extensions</a>
+<a href="/windows/win32/dxmath/ovw-xmfloat4x3-extensions">XMFLOAT4X3 Extensions</a>

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x3a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x3a.md
@@ -9,20 +9,20 @@ ms.date: 05/20/2019
 ms.keywords: XMFLOAT4X3A
 targetos: Windows
 req.construct-type: structure
-req.ddi-compliance: 
-req.dll: 
+req.ddi-compliance:
+req.dll:
 req.header: directxmath.h
-req.include-header: 
-req.kmdf-ver: 
-req.lib: 
-req.max-support: 
-req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.target-type: 
-req.typenames: 
-req.umdf-ver: 
-req.unicode-ansi: 
+req.include-header:
+req.kmdf-ver:
+req.lib:
+req.max-support:
+req.redist:
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.target-type:
+req.typenames:
+req.umdf-ver:
+req.unicode-ansi:
 f1_keywords:
  - XMFLOAT4X3A
  - directxmath/XMFLOAT4X3A
@@ -45,7 +45,8 @@ api_name:
 
 Describes an <a href="/windows/win32/api/directxmath/ns-directxmath-xmfloat4x3">XMFLOAT4X3</a> structure aligned on a 16-byte boundary.
 
-<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and <a href="https://msdn.microsoft.com/dce61bc4-4ed5-4e64-84e8-6db88025e5c2">DXGI_FORMAT</a> objects.</div>
+<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+<a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
 
 ## -struct-fields
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x4.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x4.md
@@ -9,25 +9,25 @@ ms.assetid: T:Microsoft.directx_sdk.reference.XMFLOAT4X4
 ms.date: 12/05/2018
 ms.keywords: XMFLOAT4X4, XMFLOAT4X4 structure [DirectX Math Support APIs], directxmath/XMFLOAT4X4, dxmath.xmfloat4x4
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMFLOAT4X4
@@ -55,10 +55,10 @@ A 4*4 floating point matrix.
 
 
 For a list of additional functionality such as constructors and operators that are available using <code>XMFLOAT4X4</code> when you
-  are programming in C++, see <a href="https://msdn.microsoft.com/ae6a5159-4a77-488c-a836-da3a16e7fcaf">XMFLOAT4X4 Extensions</a>.
+  are programming in C++, see <a href="/windows/win32/dxmath/ovw-xmfloat4x4-extensions">XMFLOAT4X4 Extensions</a>.
 <div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about
-  equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and
-  <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div><div> </div>
+  equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+  <a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects. objects.</div>
 
 ## -struct-fields
 
@@ -168,7 +168,7 @@ Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows 
 
 
 
-<a href="https://msdn.microsoft.com/ae6a5159-4a77-488c-a836-da3a16e7fcaf">XMFLOAT4X4 Extensions</a>
+<a href="/windows/win32/dxmath/ovw-xmfloat4x4-extensions">XMFLOAT4X4 Extensions</a>
 
 
 

--- a/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x4a.md
+++ b/sdk-api-src/content/directxmath/ns-directxmath-xmfloat4x4a.md
@@ -9,20 +9,20 @@ ms.date: 05/20/2019
 ms.keywords: XMFLOAT4X4A
 targetos: Windows
 req.construct-type: structure
-req.ddi-compliance: 
-req.dll: 
+req.ddi-compliance:
+req.dll:
 req.header: directxmath.h
-req.include-header: 
-req.kmdf-ver: 
-req.lib: 
-req.max-support: 
-req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.target-type: 
-req.typenames: 
-req.umdf-ver: 
-req.unicode-ansi: 
+req.include-header:
+req.kmdf-ver:
+req.lib:
+req.max-support:
+req.redist:
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.target-type:
+req.typenames:
+req.umdf-ver:
+req.unicode-ansi:
 f1_keywords:
  - XMFLOAT4X4A
  - directxmath/XMFLOAT4X4A
@@ -45,7 +45,8 @@ api_name:
 
 Describes an <a href="/windows/desktop/api/directxmath/ns-directxmath-xmfloat4x4">XMFLOAT4X4</a> structure aligned on a 16-byte boundary.
 
-<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="https://msdn.microsoft.com/993fc7e4-4752-4bce-82d0-0a034fdc69c0">D3DDECLTYPE</a>, <a href="https://msdn.microsoft.com/a222e3bb-310c-4019-93ee-6a2da2a46ded">D3DFORMAT</a>, and <a href="https://msdn.microsoft.com/dce61bc4-4ed5-4e64-84e8-6db88025e5c2">DXGI_FORMAT</a> objects.</div>
+<div class="alert"><b>Note</b>  See <a href="/windows/desktop/dxmath/pg-xnamath-internals">DirectXMath Library Type Equivalences</a> for information about equivalent <a href="/windows/desktop/direct3d9/d3ddecltype">D3DDECLTYPE</a>, <a href="/windows/desktop/direct3d9/d3dformat">D3DFORMAT</a>, and
+<a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI_FORMAT</a> objects.</div>
 
 ## -struct-fields
 


### PR DESCRIPTION
* Added topics for new functions: ``XMMatrixVectorTensorProduct`` , ``XMColorRGBToYUV_UHD``, ``XMColorYUVToRGB_UHD``, ``XMVectorLog10``, and ``XMVectorExp10``.

* Added new directive ``_XM_SVML_INTRINSICS_`` to table

* Cleaned up remaining 'dead' references to msdn URLs

* Updated library internals for recent changes, and a few cases of updating the remarks based on C++11 math functions.