### PR TITLE
Clarify alignment requirements for MapViewOfFile3

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-mapviewoffile3.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-mapviewoffile3.md
@@ -122,6 +122,7 @@ After you replace a placeholder with a mapped view, to free that mapped view bac
 
 A placeholder is a type of reserved memory region.
 
+The 64k alignment requirements on <i>Offset</i> and <i>BaseAddress</i> do not apply when this flag is specified.
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
It has been observed that when using the MEM_REPLACE_PLACEHOLDER flag the input alignment isn't forced to 64k, you can use VirtualFreeEx with the MEM_PRESERVE_PLACEHOLDER to create an unaligned placeholder then pass that to MapViewOfFile3 to map a non-64k aligned region.