### PR TITLE
Add the return value in case of success

### DIFF
--- a/sdk-api-src/content/objidl/nf-objidl-isequentialstream-write.md
+++ b/sdk-api-src/content/objidl/nf-objidl-isequentialstream-write.md
@@ -68,7 +68,8 @@ A pointer to a <b>ULONG</b> variable where this method writes the actual number 
 
 ## -returns
 
-This method can return one of these values.
+This method can return one of these values. 
+S_OK in case of success.
 
 ## -remarks
 


### PR DESCRIPTION
I would like to submit an issue but here at https://github.com/MicrosoftDocs/sdk-api I do not see the "Issues" tab
![image](https://user-images.githubusercontent.com/2438459/121343635-3418a200-c923-11eb-8d37-0c9f6de94af7.png)

The page
https://docs.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-isequentialstream-write has an incomplete *Return value* section. It states

> This method can return one of these values.

and does not list any values.
After a rapid browsing it seems to me that the problem is also at any method of the interface `IStream`, `IStorage`... 
