### PR TITLE
Fix `InternetSetStatusCallback` return value

### DIFF
--- a/sdk-api-src/content/wininet/nf-wininet-internetsetstatuscallback.md
+++ b/sdk-api-src/content/wininet/nf-wininet-internetsetstatuscallback.md
@@ -1,3 +1,5 @@
+The `InternetSetStatusCallback` function is marked as returning `void` [in the docs](https://docs.microsoft.com/en-us/windows/win32/api/wininet/nf-wininet-internetsetstatuscallback), but actually it returns `INTERNET_STATUS_CALLBACK`.
+
 ---
 UID: NF:wininet.InternetSetStatusCallback
 title: InternetSetStatusCallback function (wininet.h)


### PR DESCRIPTION
I'm sorry for misusing the pull requests mechanism, but it's an obvious error and I don't know how to fix it.

The `InternetSetStatusCallback` function is marked as returning `void` [in the docs](https://docs.microsoft.com/en-us/windows/win32/api/wininet/nf-wininet-internetsetstatuscallback), but in reality it returns `INTERNET_STATUS_CALLBACK`.