### PR TITLE
DML_ELEMENT_WISE_ADD_OPERATOR_DESC / ADD1 / DIVIDE do not support int8/int16

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_add1_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_add1_operator_desc.md
@@ -88,9 +88,9 @@ This operator was introduced in `DML_FEATURE_LEVEL_2_0`.
 ### DML_FEATURE_LEVEL_3_0 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |
 | ------ | ---- | -------------------------- | -------------------- |
-| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
+| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
 
 ### DML_FEATURE_LEVEL_2_1 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |

--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_add_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_add_operator_desc.md
@@ -87,9 +87,9 @@ This operator was introduced in `DML_FEATURE_LEVEL_1_0`.
 ### DML_FEATURE_LEVEL_3_0 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |
 | ------ | ---- | -------------------------- | -------------------- |
-| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
+| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
 
 ### DML_FEATURE_LEVEL_2_1 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |

--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_divide_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_divide_operator_desc.md
@@ -87,9 +87,9 @@ This operator was introduced in `DML_FEATURE_LEVEL_1_0`.
 ### DML_FEATURE_LEVEL_3_0 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |
 | ------ | ---- | -------------------------- | -------------------- |
-| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
-| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, INT16, INT8, UINT32, UINT16, UINT8 |
+| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
 
 ### DML_FEATURE_LEVEL_2_1 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |


### PR DESCRIPTION
This is a typo. Subtract and Multiply are already correct.