### PR TITLE
Update ne-winnt-token_type.md

### DIFF
--- a/sdk-api-src/content/winnt/ne-winnt-token_type.md
+++ b/sdk-api-src/content/winnt/ne-winnt-token_type.md
@@ -56,7 +56,7 @@ The <b>TOKEN_TYPE</b> enumeration contains values that differentiate between a <
 
 ## -enum-fields
 
-### -field TokenPrimary
+### -field TokenPrimary = 1
 
 Indicates a primary token.
 


### PR DESCRIPTION
Adding = 1 to the definition of  TokenPrimary helps understand that the first value is __not__ 0 (default) but 1.
As is, the definition does not represent the reality of this enum in winnt.h:
```cpp
typedef enum _TOKEN_TYPE {
    TokenPrimary = 1,
    TokenImpersonation
    } TOKEN_TYPE;
typedef TOKEN_TYPE *PTOKEN_TYPE;
```