### PR TITLE
`SERVICE_TABLE_ENTRYA`: `lpServiceName` should be of type `LPCSTR`

### DIFF
--- a/sdk-api-src/content/winsvc/ns-winsvc-service_table_entrya.md
+++ b/sdk-api-src/content/winsvc/ns-winsvc-service_table_entrya.md
@@ -1,3 +1,5 @@
+`lpServiceName` should be of type `LPCSTR` according to [the code example](https://docs.microsoft.com/en-us/windows/win32/services/svc-cpp) which sets it to a string literal from readonly data section.
+
 ---
 UID: NS:winsvc._SERVICE_TABLE_ENTRYA
 title: SERVICE_TABLE_ENTRYA (winsvc.h)


### PR DESCRIPTION
A bug report. The docs are in sync with the headers, but the headers are incorrect. I don't know where to report it, so reporting it here. Hopefully one of the Microsoft guys here can forward it to the right location. Thanks.