### PR TITLE
DML_CONVOLUTION_MODE_CONVOLUTION clarity

### DIFF
--- a/sdk-api-src/content/directml/ne-directml-dml_convolution_mode.md
+++ b/sdk-api-src/content/directml/ne-directml-dml_convolution_mode.md
@@ -53,11 +53,11 @@ Defines constants that specify a mode for the DirectML convolution operator (as 
 
 ### -field DML_CONVOLUTION_MODE_CONVOLUTION
 
-Specifies the convolution mode.
+Specifies the convolution mode. When used along with [DML_CONVOLUTION_DIRECTION_FORWARD](/windows/win32/api/directml/ne-directml-dml_convolution_direction), this flips the filter along the height and width axes.
 
 ### -field DML_CONVOLUTION_MODE_CROSS_CORRELATION
 
-Specifies the cross-correlation mode. If in doubt, use this mode—it is appropriate for the vast majority of machine learning (ML) models.
+Specifies the cross-correlation mode. If in doubt, use this mode — it is appropriate for the vast majority of machine learning (ML) model inference. When used along with [DML_CONVOLUTION_DIRECTION_BACKWARD](/windows/win32/api/directml/ne-directml-dml_convolution_direction), this flips the filter along the height and width axes.
 
 ## -see-also
 

--- a/sdk-api-src/content/directml/ne-directml-dml_convolution_mode.md
+++ b/sdk-api-src/content/directml/ne-directml-dml_convolution_mode.md
@@ -57,7 +57,7 @@ Specifies the convolution mode. When used along with [DML_CONVOLUTION_DIRECTION_
 
 ### -field DML_CONVOLUTION_MODE_CROSS_CORRELATION
 
-Specifies the cross-correlation mode. If in doubt, use this mode — it is appropriate for the vast majority of machine learning (ML) model inference. When used along with [DML_CONVOLUTION_DIRECTION_BACKWARD](/windows/win32/api/directml/ne-directml-dml_convolution_direction), this flips the filter along the height and width axes.
+Specifies the cross-correlation mode. If in doubt, use this mode&mdash;it is appropriate for the vast majority of machine learning (ML) model inference. When used along with [DML_CONVOLUTION_DIRECTION_BACKWARD](/windows/win32/api/directml/ne-directml-dml_convolution_direction), this flips the filter along the height and width axes.
 
 ## -see-also
 

--- a/sdk-api-src/content/directml/ns-directml-dml_convolution_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_convolution_operator_desc.md
@@ -139,6 +139,15 @@ Type: \_Maybenull\_ **const [DML_OPERATOR_DESC](/windows/win32/api/directml/ns-d
 
 An optional fused activation layer to apply after the convolution.
 
+## Mode interactions
+
+Convolution mode                       | Convolution direction              | Filter orientation
+---------------------------------------|------------------------------------|------------------------------------
+DML_CONVOLUTION_MODE_CROSS_CORRELATION | DML_CONVOLUTION_DIRECTION_FORWARD  | filter has identity orientation
+DML_CONVOLUTION_MODE_CROSS_CORRELATION | DML_CONVOLUTION_DIRECTION_BACKWARD | filter is transposed along x,y axes
+DML_CONVOLUTION_MODE_CONVOLUTION       | DML_CONVOLUTION_DIRECTION_FORWARD  | filter is transposed along x,y axes
+DML_CONVOLUTION_MODE_CONVOLUTION       | DML_CONVOLUTION_DIRECTION_BACKWARD | filter has identity orientation
+
 ## Availability
 This operator was introduced in `DML_FEATURE_LEVEL_1_0`.
 


### PR DESCRIPTION
Clarify the interaction of `DML_CONVOLUTION_MODE` and `DML_CONVOLUTION_DIRECTION` regarding the filter orientation on `DML_CONVOLUTION_OPERATOR_DESC`.