### PR TITLE
Fix typo in ID3D12Device CreateCommandList docs

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-createcommandlist.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-createcommandlist.md
@@ -73,7 +73,7 @@ A pointer to the command allocator object from which the device creates command 
 
 Type: **[ID3D12PipelineState](./nn-d3d12-id3d12pipelinestate.md)\***
 
-An optional pointer to the pipeline state object that contains the initial pipeline state for the command list. If it is `nulltpr`, then the runtime sets a dummy initial pipeline state, so that drivers don't have to deal with undefined state. The overhead for this is low, particularly for a command list, for which the overall cost of recording the command list likely dwarfs the cost of a single initial state setting. So there's little cost in not setting the initial pipeline state parameter, if doing so is inconvenient.
+An optional pointer to the pipeline state object that contains the initial pipeline state for the command list. If it is `nullptr`, then the runtime sets a dummy initial pipeline state, so that drivers don't have to deal with undefined state. The overhead for this is low, particularly for a command list, for which the overall cost of recording the command list likely dwarfs the cost of a single initial state setting. So there's little cost in not setting the initial pipeline state parameter, if doing so is inconvenient.
 
 For bundles, on the other hand, it might make more sense to try to set the initial state parameter (since bundles are likely smaller overall, and can be reused frequently).
 


### PR DESCRIPTION
- nulltpr (null-t-p-r) to nullptr (null-p-t-r)