### PR TITLE
Fix link to CONTEXT structure documentation

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-exception_pointers.md
+++ b/sdk-api-src/content/winnt/ns-winnt-exception_pointers.md
@@ -66,7 +66,7 @@ A pointer to an
 ### -field ContextRecord
 
 A pointer to a 
-<a href="/windows/desktop/api/winnt/ns-winnt-arm64_nt_context">CONTEXT</a> structure that contains a processor-specific description of the state of the processor at the time of the exception.
+<a href="/windows/desktop/api/winnt/ns-winnt-context">CONTEXT</a> structure that contains a processor-specific description of the state of the processor at the time of the exception.
 
 ## -see-also
 


### PR DESCRIPTION
Current page links to ARM64_NT_CONTEXT page instead of regular CONTEXT page.