### PR TITLE
Fixed D2D1_LAYER_PARAMETERS contentBounds description

### DIFF
--- a/sdk-api-src/content/d2d1/ns-d2d1-d2d1_layer_parameters.md
+++ b/sdk-api-src/content/d2d1/ns-d2d1-d2d1_layer_parameters.md
@@ -58,7 +58,7 @@ Contains the content bounds, mask information, opacity settings, and other optio
 
 Type: <b><a href="/windows/win32/Direct2D/d2d1-rect-f">D2D1_RECT_F</a></b>
 
-The content bounds of the layer. Content outside these bounds is not guaranteed to render.
+The content bounds of the layer. Content outside these bounds is guaranteed not to render.
 
 ### -field geometricMask
 

--- a/sdk-api-src/content/d2d1/ns-d2d1-d2d1_layer_parameters.md
+++ b/sdk-api-src/content/d2d1/ns-d2d1-d2d1_layer_parameters.md
@@ -58,7 +58,7 @@ Contains the content bounds, mask information, opacity settings, and other optio
 
 Type: <b><a href="/windows/win32/Direct2D/d2d1-rect-f">D2D1_RECT_F</a></b>
 
-The content bounds of the layer. Content outside these bounds is guaranteed not to render.
+The content bounds of the layer. Content won't render outside these bounds.
 
 ### -field geometricMask
 


### PR DESCRIPTION
I'm assuming that the description at the following URL is the correct description (that content outside of the content bounds is guaranteed not to render).

https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-layers-overview#creating-layers

> The content bounds of the layer. Content outside these bounds is guaranteed not to render.

As such, I'm proposing to change the current page to match.