### PR TITLE
Update ExtTextOut and PolyTextOut to clarify international script support and performance

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-exttextouta.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-exttextouta.md
@@ -305,6 +305,13 @@ For the ANSI version of <b>ExtTextOut</b>, the <i>lpDx</i> array has the same nu
 Note, the <i>alpDx</i> values from <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentexpointa">GetTextExtentExPoint</a> are not the same as the <i>lpDx</i> values for <b>ExtTextOut</b>. To use the <i>alpDx</i> values in <i>lpDx</i>, you must first process them.
 
 
+**ExtTextOut** will use [Uniscribe](/windows/win32/intl/uniscribe) when necessary resulting in font fallback. The ETO_IGNORELANGUAGE flag will inhibit this behavior and should not be passed.
+
+Additionally, **ExtTextOut** will perform internal batching of calls before transitioning to kernel mode, mitigating some of the performance concerns when weighing usage of **PolyTextOut** versus **ExtTextOut**.
+
+> [!TIP]
+>  **ExtTextOut** is strongly recommended over **PolyTextOut** for modern development due to its ability to handle display of different languages.
+
 #### Examples
 
 For an example, see "Setting Fonts for Menu-Item Text Strings" in <a href="/windows/desktop/menurc/using-menus">Using Menus</a>.

--- a/sdk-api-src/content/wingdi/nf-wingdi-exttextoutw.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-exttextoutw.md
@@ -304,6 +304,13 @@ For the ANSI version of <b>ExtTextOut</b>, the <i>lpDx</i> array has the same nu
 
 Note, the <i>alpDx</i> values from <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentexpointa">GetTextExtentExPoint</a> are not the same as the <i>lpDx</i> values for <b>ExtTextOut</b>. To use the <i>alpDx</i> values in <i>lpDx</i>, you must first process them.
 
+**ExtTextOut** will use [Uniscribe](/windows/win32/intl/uniscribe) when necessary resulting in font fallback. The ETO_IGNORELANGUAGE flag will inhibit this behavior and should not be passed.
+
+Additionally, **ExtTextOut** will perform internal batching of calls before transitioning to kernel mode, mitigating some of the performance concerns when weighing usage of **PolyTextOut** versus **ExtTextOut**.
+
+> [!TIP]
+>  **ExtTextOut** is strongly recommended over **PolyTextOut** for modern development due to its ability to handle display of different languages.
+
 
 #### Examples
 

--- a/sdk-api-src/content/wingdi/nf-wingdi-polytextouta.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-polytextouta.md
@@ -83,7 +83,10 @@ Each <a href="/windows/desktop/api/wingdi/ns-wingdi-polytexta">POLYTEXT</a> stru
 To draw a single string of text, the application should call the <a href="/windows/desktop/api/wingdi/nf-wingdi-exttextouta">ExtTextOut</a> function.
 
 
+**PolyTextOut** will not handle international scripting support automatically. To get international scripting support, use **ExtTextOut** instead. **ExtTextOut** will use [Uniscribe](/windows/win32/intl/uniscribe) when necessary resulting in font fallback. Additionally, **ExtTextOut** will perform internal batching of calls before transitioning to kernel mode, mitigating some of the performance concerns when weighing usage of **PolyTextOut** versus **ExtTextOut**.
 
+> [!TIP]
+>  **ExtTextOut** is strongly recommended over **PolyTextOut** for modern development due to its ability to handle display of different languages.
 
 
 > [!NOTE]

--- a/sdk-api-src/content/wingdi/nf-wingdi-polytextoutw.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-polytextoutw.md
@@ -82,9 +82,10 @@ Each <a href="/windows/desktop/api/wingdi/ns-wingdi-polytexta">POLYTEXT</a> stru
 
 To draw a single string of text, the application should call the <a href="/windows/desktop/api/wingdi/nf-wingdi-exttextouta">ExtTextOut</a> function.
 
+**PolyTextOut** will not handle international scripting support automatically. To get international scripting support, use **ExtTextOut** instead. **ExtTextOut** will use [Uniscribe](/windows/win32/intl/uniscribe) when necessary resulting in font fallback. Additionally, **ExtTextOut** will perform internal batching of calls before transitioning to kernel mode, mitigating some of the performance concerns when weighing usage of **PolyTextOut** versus **ExtTextOut**.
 
-
-
+> [!TIP]
+>  **ExtTextOut** is strongly recommended over **PolyTextOut** for modern development due to its ability to handle display of different languages.
 
 > [!NOTE]
 > The wingdi.h header defines PolyTextOut as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).


### PR DESCRIPTION
add additional remarks to exttextout and polytextout describing the Uniscribe behavior of each, the performance detail to ExtTextOut batching, and the general recommendation to encourage Ext over Poly for modern development