### PR TITLE
Fix param name references

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-gettextextentexpointi.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-gettextextentexpointi.md
@@ -67,7 +67,7 @@ A pointer to an array of glyph indices for which extents are to be retrieved.
 
 ### -param cwchString [in]
 
-The number of glyphs in the array pointed to by the <i>pgiIn</i> parameter.
+The number of glyphs in the array pointed to by the <i>lpwszString</i> parameter.
 
 ### -param nMaxExtent [in]
 
@@ -79,7 +79,7 @@ A pointer to an integer that receives a count of the maximum number of character
 
 ### -param lpnDx [out]
 
-A pointer to an array of integers that receives partial glyph extents. Each element in the array gives the distance, in logical units, between the beginning of the glyph indices array and one of the glyphs that fits in the space specified by the <i>nMaxExtent</i> parameter. Although this array should have at least as many elements as glyph indices specified by the <i>cgi</i> parameter, the function fills the array with extents only for as many glyph indices as are specified by the <i>lpnFit</i> parameter. If <i>lpnFit</i> is <b>NULL</b>, the function does not compute partial string widths.
+A pointer to an array of integers that receives partial glyph extents. Each element in the array gives the distance, in logical units, between the beginning of the glyph indices array and one of the glyphs that fits in the space specified by the <i>nMaxExtent</i> parameter. Although this array should have at least as many elements as glyph indices specified by the <i>cwchString</i> parameter, the function fills the array with extents only for as many glyph indices as are specified by the <i>lpnFit</i> parameter. If <i>lpnFit</i> is <b>NULL</b>, the function does not compute partial string widths.
 
 ### -param lpSize [out]
 
@@ -93,7 +93,7 @@ If the function fails, the return value is zero.
 
 ## -remarks
 
-If both the <i>lpnFit</i> and <i>alpDx</i> parameters are <b>NULL</b>, calling the <b>GetTextExtentExPointI</b> function is equivalent to calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentpointi">GetTextExtentPointI</a> function.
+If both the <i>lpnFit</i> and <i>lpnDx</i> parameters are <b>NULL</b>, calling the <b>GetTextExtentExPointI</b> function is equivalent to calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentpointi">GetTextExtentPointI</a> function.
 
 When this function returns the text extent, it assumes that the text is horizontal, that is, that the escapement is always 0. This is true for both the horizontal and vertical measurements of the text. Even if you use a font that specifies a nonzero escapement, this function doesn't use the angle while it computes the text extent. The app must convert it explicitly. However, when the graphics mode is set to <a href="/windows/desktop/api/wingdi/nf-wingdi-setgraphicsmode">GM_ADVANCED</a> and the character orientation is 90 degrees from the print orientation, the values that this function return do not follow this rule. When the character orientation and the print orientation match for a given string, this function returns the dimensions of the string in the <a href="/previous-versions/dd145106(v=vs.85)">SIZE</a> structure as { cx : 116, cy : 18 }.  When the character orientation and the print orientation are 90 degrees apart for the same string, this function returns the dimensions of the string in the <b>SIZE</b> structure as { cx : 18, cy : 116 }.
 


### PR DESCRIPTION
The descriptions referred to several parameters that didn't exist. Replaced with 'best guess' to what they are referring to.
History of the file does not show when the inconsistency was introduced.

Note the following parameters referred to by descriptions do not exist:
- `pgiIn`
- `cgi`
- `alpDx`