### PR TITLE
Update ne-minidumpapiset-minidump_type.md

### DIFF
--- a/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
+++ b/sdk-api-src/content/minidumpapiset/ne-minidumpapiset-minidump_type.md
@@ -68,41 +68,41 @@ Identifies the type of information that will be written to the minidump file by 
 
 ### -field MiniDumpNormal
 
-Include just the information necessary to capture stack traces for all existing threads in a process.
+`0x00000000`. Include just the information necessary to capture stack traces for all existing threads in a process.
 
 ### -field MiniDumpWithDataSegs
 
-Include the data sections from all loaded modules. This results in the inclusion of global variables, which 
+`0x00000001`. Include the data sections from all loaded modules. This results in the inclusion of global variables, which 
       can make the minidump file significantly larger. For per-module control, use the 
       <b>ModuleWriteDataSeg</b> enumeration value from 
       <a href="/windows/desktop/api/minidumpapiset/ne-minidumpapiset-module_write_flags">MODULE_WRITE_FLAGS</a>.
 
 ### -field MiniDumpWithFullMemory
 
-Include all accessible memory in the process. The raw memory data is included at the end, so that the 
+`0x00000002`. Include all accessible memory in the process. The raw memory data is included at the end, so that the 
       initial structures can be mapped directly without the raw memory information. This option can result in a very 
       large file.
 
 ### -field MiniDumpWithHandleData
 
-Include high-level information about the operating system handles that are active when the minidump is 
+`0x00000004`. Include high-level information about the operating system handles that are active when the minidump is 
       made.
 
 ### -field MiniDumpFilterMemory
 
-Stack and backing store memory written to the minidump file should be filtered to remove all but the 
+`0x00000008`. Stack and backing store memory written to the minidump file should be filtered to remove all but the 
       pointer values necessary to reconstruct a stack trace.
 
 ### -field MiniDumpScanMemory
 
-Stack and backing store memory should be scanned for pointer references to modules in the module list. If a 
+`0x00000010`. Stack and backing store memory should be scanned for pointer references to modules in the module list. If a 
       module is referenced by stack or backing store memory, the <b>ModuleWriteFlags</b> member of 
       the <a href="/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_callback_output">MINIDUMP_CALLBACK_OUTPUT</a> structure is 
       set to <b>ModuleReferencedByMemory</b>.
 
 ### -field MiniDumpWithUnloadedModules
 
-Include information from the list of modules that were recently unloaded, if this information is maintained 
+`0x00000020`. Include information from the list of modules that were recently unloaded, if this information is maintained 
       by the operating system.
       
 
@@ -113,7 +113,7 @@ Include information from the list of modules that were recently unloaded, if thi
 
 ### -field MiniDumpWithIndirectlyReferencedMemory
 
-Include pages with data referenced by locals or other stack memory. This option can increase the size of 
+`0x00000040`. Include pages with data referenced by locals or other stack memory. This option can increase the size of 
       the minidump file significantly.
       
 
@@ -121,7 +121,7 @@ Include pages with data referenced by locals or other stack memory. This option 
 
 ### -field MiniDumpFilterModulePaths
 
-Filter module paths for information such as user names or important directories. This option may prevent 
+`0x00000080`. Filter module paths for information such as user names or important directories. This option may prevent 
       the system from locating the image file and should be used only in special situations.
       
 
@@ -129,21 +129,21 @@ Filter module paths for information such as user names or important directories.
 
 ### -field MiniDumpWithProcessThreadData
 
-Include complete per-process and per-thread information from the operating system.
+`0x00000100`. Include complete per-process and per-thread information from the operating system.
       
 
 <b>DbgHelp 5.1:  </b>This value is not supported.
 
 ### -field MiniDumpWithPrivateReadWriteMemory
 
-Scan the virtual address space for <b>PAGE_READWRITE</b> memory to be included.
+`0x00000200`. Scan the virtual address space for <b>PAGE_READWRITE</b> memory to be included.
       
 
 <b>DbgHelp 5.1:  </b>This value is not supported.
 
 ### -field MiniDumpWithoutOptionalData
 
-Reduce the data that is dumped by eliminating memory regions that are not essential to meet criteria  
+`0x00000400`. Reduce the data that is dumped by eliminating memory regions that are not essential to meet criteria  
       specified for the dump. This can avoid dumping  memory that may contain data that is private to the user. 
       However, it is not a guarantee that no private information will be present.
       
@@ -152,7 +152,7 @@ Reduce the data that is dumped by eliminating memory regions that are not essent
 
 ### -field MiniDumpWithFullMemoryInfo
 
-Include memory region information. For more information, see 
+`0x00000800`. Include memory region information. For more information, see 
       <a href="/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_info_list">MINIDUMP_MEMORY_INFO_LIST</a>.
       
 
@@ -160,7 +160,7 @@ Include memory region information. For more information, see
 
 ### -field MiniDumpWithThreadInfo
 
-Include thread state information. For more information, see 
+`0x00001000`. Include thread state information. For more information, see 
       <a href="/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread_info_list">MINIDUMP_THREAD_INFO_LIST</a>.
       
 
@@ -168,7 +168,7 @@ Include thread state information. For more information, see
 
 ### -field MiniDumpWithCodeSegs
 
-Include all code and code-related sections from loaded modules to capture executable content. For 
+`0x00002000`. Include all code and code-related sections from loaded modules to capture executable content. For 
       per-module control, use the <b>ModuleWriteCodeSegs</b> enumeration value from 
       <a href="/windows/desktop/api/minidumpapiset/ne-minidumpapiset-module_write_flags">MODULE_WRITE_FLAGS</a>.
       
@@ -177,23 +177,23 @@ Include all code and code-related sections from loaded modules to capture execut
 
 ### -field MiniDumpWithoutAuxiliaryState
 
-Turns off secondary auxiliary-supported memory gathering.
+`0x00004000`. Turns off secondary auxiliary-supported memory gathering.
 
 ### -field MiniDumpWithFullAuxiliaryState
 
-Requests that auxiliary data providers include their state in the dump image; the state data that is 
+`0x00008000`. Requests that auxiliary data providers include their state in the dump image; the state data that is 
       included is provider dependent. This option can result in a large dump image.
 
 ### -field MiniDumpWithPrivateWriteCopyMemory
 
-Scans the virtual address space for <b>PAGE_WRITECOPY</b> memory to be included.
+`0x00010000`. Scans the virtual address space for <b>PAGE_WRITECOPY</b> memory to be included.
       
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpIgnoreInaccessibleMemory
 
-If you specify <b>MiniDumpWithFullMemory</b>, the 
+`0x00020000`. If you specify <b>MiniDumpWithFullMemory</b>, the 
        <a href="/windows/desktop/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump">MiniDumpWriteDump</a> function will fail if the 
        function cannot read the memory regions; however, if you include 
        <b>MiniDumpIgnoreInaccessibleMemory</b>, the 
@@ -205,7 +205,7 @@ If you specify <b>MiniDumpWithFullMemory</b>, the
 
 ### -field MiniDumpWithTokenInformation
 
-Adds security token related data. This will make the "!token" extension work when 
+`0x00040000`. Adds security token related data. This will make the "!token" extension work when 
       processing a user-mode dump.
       
 
@@ -213,39 +213,39 @@ Adds security token related data. This will make the "!token" extension work whe
 
 ### -field MiniDumpWithModuleHeaders
 
-Adds module header related data.
+`0x00080000`. Adds module header related data.
       
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpFilterTriage
 
-Adds filter triage related data.
+`0x00100000`. Adds filter triage related data.
       
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpWithAvxXStateContext
 
-Adds AVX crash state context registers.
+`0x00200000`. Adds AVX crash state context registers.
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpWithIptTrace
 
-Adds Intel Processor Trace related data. 
+`0x00400000`. Adds Intel Processor Trace related data. 
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpScanInaccessiblePartialPages
 
-Scans inaccessible partial memory pages.
+`0x00800000`. Scans inaccessible partial memory pages.
 
 <b>Prior to DbgHelp 6.1:  </b>This value is not supported.
 
 ### -field MiniDumpValidTypeFlags
 
-Indicates which flags are valid.
+`0x00ffffff`. Indicates which flags are valid.
 
 ## -see-also
 


### PR DESCRIPTION
As the enumeration has specified values, it is helpful to include them here, particularly as this enum set is used in registry settings such as HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\CustomDumpFlags (https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps)