### PR TITLE
Specify that ITfLangBarItemMgr::AddItem can be ignored

### DIFF
--- a/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritem-getinfo.md
+++ b/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritem-getinfo.md
@@ -56,7 +56,7 @@ Obtains information about the language bar item.
 
 ### -param pInfo [out]
 
-Pointer to a <a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO</a> structure that receives the language bar item information.
+Pointer to a <a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO</a> structure that receives the language bar item information. Since Windows 8, the structure should have GUID_LBI_INPUTMODE or the item will be ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
 
 ## -returns
 

--- a/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritem-getinfo.md
+++ b/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritem-getinfo.md
@@ -56,7 +56,9 @@ Obtains information about the language bar item.
 
 ### -param pInfo [out]
 
-Pointer to a <a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO</a> structure that receives the language bar item information. Since Windows 8, the structure should have GUID_LBI_INPUTMODE or the item will be ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
+Pointer to a <a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO</a> structure that receives the language bar item information.
+
+Starting with Windows 8, the item will be ignored if the structure does not include GUID_LBI_INPUTMODE. For more information, see [Third-party input method editors](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation) in the Compatibility cookbook for Windows.
 
 ## -returns
 
@@ -95,7 +97,4 @@ The method was successful.
 
 <a href="/windows/desktop/api/ctfutb/nn-ctfutb-itflangbaritem">ITfLangBarItem</a>
 
-
-
-<a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO
-      </a>
+<a href="/windows/desktop/api/ctfutb/ns-ctfutb-tf_langbariteminfo">TF_LANGBARITEMINFO</a>

--- a/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
+++ b/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
@@ -56,7 +56,7 @@ Adds an item to the language bar.
 
 ### -param punk [in]
 
-Pointer to the <a href="/windows/desktop/api/ctfutb/nn-ctfutb-itflangbaritem">ITfLangBarItem</a> object to add to the language bar.
+Pointer to the <a href="/windows/desktop/api/ctfutb/nn-ctfutb-itflangbaritem">ITfLangBarItem</a> object to add to the language bar. Since Windows 8, only one item that gives GUID_LBI_INPUTMODE from <a href="/windows/desktop/api/ctfutb/nf-ctfutb-itflangbaritem-getinfo">GetInfo</a> method will be shown and others will be silently ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
 
 ## -returns
 
@@ -74,7 +74,7 @@ This method can return one of these values.
 </dl>
 </td>
 <td width="60%">
-The method was successful.
+The method was successful. Silently ignored calls will also return this status.
 
 </td>
 </tr>

--- a/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
+++ b/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
@@ -56,7 +56,9 @@ Adds an item to the language bar.
 
 ### -param punk [in]
 
-Pointer to the <a href="/windows/desktop/api/ctfutb/nn-ctfutb-itflangbaritem">ITfLangBarItem</a> object to add to the language bar. Since Windows 8, only one item that gives GUID_LBI_INPUTMODE from <a href="/windows/desktop/api/ctfutb/nf-ctfutb-itflangbaritem-getinfo">GetInfo</a> method will be shown and others will be silently ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
+Pointer to the <a href="/windows/desktop/api/ctfutb/nn-ctfutb-itflangbaritem">ITfLangBarItem</a> object to add to the language bar. 
+
+Starting with Windows 8, only the first item that returns GUID_LBI_INPUTMODE (from [GetInfo](/windows/desktop/api/ctfutb/nf-ctfutb-itflangbaritem-getinf)) is shown. For more information, see [Third-party input method editors](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation) in the Compatibility cookbook for Windows.
 
 ## -returns
 

--- a/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
+++ b/sdk-api-src/content/ctfutb/nf-ctfutb-itflangbaritemmgr-additem.md
@@ -76,7 +76,7 @@ This method can return one of these values.
 </dl>
 </td>
 <td width="60%">
-The method was successful. Silently ignored calls will also return this status.
+The method was successful (silently ignored calls also return this status).
 
 </td>
 </tr>

--- a/sdk-api-src/content/ctfutb/ns-ctfutb-tf_langbariteminfo.md
+++ b/sdk-api-src/content/ctfutb/ns-ctfutb-tf_langbariteminfo.md
@@ -60,7 +60,7 @@ Contains the <b>CLSID</b> of the text service that owns the language bar item. T
 
 ### -field guidItem
 
-Contains a <b>GUID</b> value that identifies the language bar item.
+Contains a <b>GUID</b> value that identifies the language bar item. Since Windows 8, this value should be GUID_LBI_INPUTMODE or the language bar item will be ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
 
 ### -field dwStyle
 

--- a/sdk-api-src/content/ctfutb/ns-ctfutb-tf_langbariteminfo.md
+++ b/sdk-api-src/content/ctfutb/ns-ctfutb-tf_langbariteminfo.md
@@ -60,7 +60,9 @@ Contains the <b>CLSID</b> of the text service that owns the language bar item. T
 
 ### -field guidItem
 
-Contains a <b>GUID</b> value that identifies the language bar item. Since Windows 8, this value should be GUID_LBI_INPUTMODE or the language bar item will be ignored. Read more [here](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation).
+Contains a <b>GUID</b> value that identifies the language bar item.
+
+Starting with Windows 8, this value should be GUID_LBI_INPUTMODE (or the language bar item will be ignored). For more information, see [Third-party input method editors](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation) in the Compatibility cookbook for Windows.
 
 ### -field dwStyle
 


### PR DESCRIPTION
Windows 8+ forces IMEs to show only one additional language bar button per [Windows 8 Cookbook](https://docs.microsoft.com/en-us/windows/win32/w8cookbook/third-party-input-method-editors#manifestation), which also is true in Windows 10 and 11.