### PR TITLE
Update nf-winbase-movefileexa.md and nf-winbase-movefileexw.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-movefileexa.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefileexa.md
@@ -198,7 +198,7 @@ If a file named <i>lpNewFileName</i> exists, the function replaces its contents 
          regarding access control lists (ACLs) are met. For more information, see the Remarks section of this 
          topic.
 
-If <i>lpNewFileName</i> or <i>lpExistingFileName</i> name a directory and <i>lpExistingFileName</i> exists, an error is reported.
+If <i>lpNewFileName</i> names an existing directory, an error is reported.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winbase/nf-winbase-movefileexw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-movefileexw.md
@@ -198,8 +198,7 @@ If a file named <i>lpNewFileName</i> exists, the function replaces its contents 
          regarding access control lists (ACLs) are met. For more information, see the Remarks section of this 
          topic.
 
-This value cannot be used if <i>lpNewFileName</i> or 
-         <i>lpExistingFileName</i> names a directory.
+If <i>lpNewFileName</i> names an existing directory, an error is reported.
 
 </td>
 </tr>


### PR DESCRIPTION
**Short description**
Corrected the described behavior of the `MOVEFILE_REPLACE_EXISTING` flag.

**Details**
Functions `MoveFileExA` and `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` flag do only fail if the `lpNewFileName` parameter names an existing directory.
If `lpNewFileName` names an existing file, the function succeeds, no matter if `lpExistingFileName` names a file or directory.

Proof:
Test with "Existing" and "New" as both file or directory.
``` cpp
#include <iostream>
#include <Windows.h>

int main()
{
    LPCSTR lpExistingFileName = "C:\\temp\\MoveFileTest\\Existing";
    LPCSTR lpNewFileName      = "C:\\temp\\MoveFileTest\\New";
    DWORD dwFlags = MOVEFILE_REPLACE_EXISTING;

    BOOL success = MoveFileExA(lpExistingFileName, lpNewFileName, dwFlags);
    DWORD lastError = GetLastError();

    std::cout << "Success: " << success << "\n";
    std::cout << "GetLastError: " << lastError;
}
```

I have tested on Windows 10 (v. 20H2) and Windows XP (v. 5.1) SP3 and got the same results.

Results:
| lpExistingFileName | lpNewFileName | Return | GetLastError |
| --- | --- | --- | --- |
| file | file | `true` | `0` |
| file | directory | `false` | `5` |
| directory | file | `true` | `0` |
| directory | directory | `false` | `5` |
