### PR TITLE
Update VertexFormat requirements for DXR Tier 1.1

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_raytracing_geometry_triangles_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_raytracing_geometry_triangles_desc.md
@@ -86,6 +86,17 @@ Format of the vertices in <i>VertexBuffer</i>.  Must be one of the following:
 <li><b>DXGI_FORMAT_R16G16B16A16_SNORM</b>   - A16 component is ignored, other data can be packed there, such as setting vertex stride to 6 bytes.</li>
 </ul>
 
+Tier 1.1 devices support the following additional formats:
+<ul>
+<li><b>DXGI_FORMAT_R16G16B16A16_UNORM</b>   - A16 component is ignored, other data can be packed there, such as setting vertex stride to 6 bytes</li>
+<li><b>DXGI_FORMAT_R16G16_UNORM</b>   - third component assumed 0</li>
+<li><b>DXGI_FORMAT_R10G10B10A2_UNORM</b>   - A2 component is ignored, stride must be 4 bytes</li>
+<li><b>DXGI_FORMAT_R8G8B8A8_UNORM</b>   - A8 component is ignored, other data can be packed there, such as setting vertex stride to 3 bytes</li>
+<li><b>DXGI_FORMAT_R8G8_UNORM</b>   - third component assumed 0</li>
+<li><b>DXGI_FORMAT_R8G8B8A8_SNORM</b>  - A8 component is ignored, other data can be packed there, such as setting vertex stride to 3 bytes</li>
+<li><b>DXGI_FORMAT_R8G8_SNORM</b>   - third component assumed 0</li>
+</ul>
+
 ### -field IndexCount
 
 Number of indices in <i>IndexBuffer</i>.  Must be 0 if <i>IndexBuffer</i> is NULL.


### PR DESCRIPTION
DXR Tier 1.1 extends support for D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC::VertexFormat to more formats. This change updates the documentation to reflect this. All wording was copy-pasted directly from the DXR spec.