### PR TITLE
Document GetLastError for ShellExecute

### DIFF
--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
@@ -316,6 +316,8 @@ A sharing violation occurred.
 </tr>
 </table>
 
+Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
+
 ## -remarks
 
 Because <b>ShellExecute</b> can delegate execution to Shell extensions (data sources, context menu handlers, verb implementations) that are activated using Component Object Model (COM), COM should be initialized before <b>ShellExecute</b> is called. Some Shell extensions require the COM single-threaded apartment (STA) type. In that case, COM should be initialized as shown here:

--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
@@ -316,6 +316,8 @@ A sharing violation occurred.
 </tr>
 </table>
 
+Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
+
 ## -remarks
 
 Because <b>ShellExecute</b> can delegate execution to Shell extensions (data sources, context menu handlers, verb implementations) that are activated using Component Object Model (COM), COM should be initialized before <b>ShellExecute</b> is called. Some Shell extensions require the COM single-threaded apartment (STA) type. In that case, COM should be initialized as shown here:


### PR DESCRIPTION
It just calls ShellExecuteEx which has this document. e.g. handy for checking for ERROR_CANCELLED for "runas" usage.