### PR TITLE
Update nf-shellapi-shellexecutea.md and nf-shellapi-shellexecutew.md

### DIFF
--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
@@ -142,7 +142,7 @@ The flags that specify how an application is to be displayed when it is opened. 
 
 Type: <b>HINSTANCE</b>
 
-If the function succeeds, it returns a value greater than 32. If the function fails, it returns an error value that indicates the cause of the failure. The return value is cast as an HINSTANCE for backward compatibility with 16-bit Windows applications. It is not a true HINSTANCE, however. It can be cast only to an <b>int</b> and compared to either 32 or the following error codes below.
+If the function succeeds, it returns a value greater than 32. If the function fails, it returns an error value that indicates the cause of the failure. The return value is cast as an HINSTANCE for backward compatibility with 16-bit Windows applications. It is not a true HINSTANCE, however. It can be cast only to an <b>INT_PTR</b> and compared to either 32 or the following error codes below.
 
 <table>
 <tr>

--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
@@ -142,7 +142,7 @@ The flags that specify how an application is to be displayed when it is opened. 
 
 Type: <b>HINSTANCE</b>
 
-If the function succeeds, it returns a value greater than 32. If the function fails, it returns an error value that indicates the cause of the failure. The return value is cast as an HINSTANCE for backward compatibility with 16-bit Windows applications. It is not a true HINSTANCE, however. It can be cast only to an <b>int</b> and compared to either 32 or the following error codes below.
+If the function succeeds, it returns a value greater than 32. If the function fails, it returns an error value that indicates the cause of the failure. The return value is cast as an HINSTANCE for backward compatibility with 16-bit Windows applications. It is not a true HINSTANCE, however. It can be cast only to an <b>INT_PTR</b> and compared to either 32 or the following error codes below.
 
 <table>
 <tr>


### PR DESCRIPTION
The recommendation to cast `HINSTANCE` to `int` confuses people since it generates a truncation warning, as evidenced e.g. by StackOverflow topics like [this one](https://stackoverflow.com/questions/67098202/avoid-msvc-warning-when-casting-shellexecute-return-hinstance-to-int).

Referring to `INT_PTR` instead should clear up the confusion, remove the need for oddly-looking double casts and/or warning suppression, and [still aligns with Raymond Chen's recommendations](https://devblogs.microsoft.com/oldnewthing/20061108-05/?p=29083):
> Or you could cast the result to an INT_PTR and compare the result against 32. That’s fine, too.