### PR TITLE
Fix documentation of WinHTTP Ex API return codes

### DIFF
--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpaddrequestheadersex.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpaddrequestheadersex.md
@@ -152,8 +152,7 @@ An array of **WINHTTP_EXTENDED_HEADER** structures.
 
 ## -returns
 
-Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise. For extended error information, call 
-<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following.
+A status code indicating the result of the operation. Among the error codes returned are the following.
 
 <table>
 <tr>

--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpqueryheadersex.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpqueryheadersex.md
@@ -120,8 +120,7 @@ The number of headers returned. You shouldn't try to access beyond `ppHeaders[cH
 
 ## -returns
 
-Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise. To get extended error information, call 
-<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. Among the error codes returned are the following.
+A status code indicating the result of the operation. Among the error codes returned are the following.
 
 <table>
 <tr>

--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpreaddataex.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpreaddataex.md
@@ -93,8 +93,7 @@ Reserved. Pass NULL.
 
 ## -returns
 
-Returns <b>TRUE</b> if successful, or <b>FALSE</b> otherwise. For extended error information, call 
-<a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. The following table identifies the error codes that are returned.
+A status code indicating the result of the operation. Among the error codes returned are the following.
 
 <table>
 <tr>


### PR DESCRIPTION
The new WinHTTP Ex APIs return a DWORD containing a Win32 error code, not a BOOLEAN success value.