### PR TITLE
ADD1 did not support INT32/UINT32

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_add1_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_add1_operator_desc.md
@@ -88,16 +88,16 @@ This operator was introduced in `DML_FEATURE_LEVEL_2_0`.
 ### DML_FEATURE_LEVEL_3_0 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |
 | ------ | ---- | -------------------------- | -------------------- |
-| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
-| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
-| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16, INT32, UINT32 |
+| ATensor | Input | 1 to 8 | FLOAT32, FLOAT16 |
+| BTensor | Input | 1 to 8 | FLOAT32, FLOAT16 |
+| OutputTensor | Output | 1 to 8 | FLOAT32, FLOAT16 |
 
 ### DML_FEATURE_LEVEL_2_1 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |
 | ------ | ---- | -------------------------- | -------------------- |
-| ATensor | Input | 4 to 5 | FLOAT32, FLOAT16, INT32, UINT32 |
-| BTensor | Input | 4 to 5 | FLOAT32, FLOAT16, INT32, UINT32 |
-| OutputTensor | Output | 4 to 5 | FLOAT32, FLOAT16, INT32, UINT32 |
+| ATensor | Input | 4 to 5 | FLOAT32, FLOAT16 |
+| BTensor | Input | 4 to 5 | FLOAT32, FLOAT16 |
+| OutputTensor | Output | 4 to 5 | FLOAT32, FLOAT16 |
 
 ### DML_FEATURE_LEVEL_2_0 and above
 | Tensor | Kind | Supported dimension counts | Supported data types |


### PR DESCRIPTION
This was copy pasta :/. We can see in the actual codebase that the HLSL shaders only support float16/float32. (if we add these data types in the future, then a future feature level >=4.1 will support them) OS Bug 33358314