### PR TITLE
Update nf-d3d11_3-id3d11query1-getdesc1.md

### DIFF
--- a/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11query1-getdesc1.md
+++ b/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11query1-getdesc1.md
@@ -57,9 +57,9 @@ Gets a query description.
 
 ### -param pDesc1 [out]
 
-Type: <b><a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-cd3d11_query_desc1">D3D11_QUERY_DESC1</a>*</b>
+Type: <b><a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-d3d11_query_desc1">D3D11_QUERY_DESC1</a>*</b>
 
-A pointer to a <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-cd3d11_query_desc1">D3D11_QUERY_DESC1</a> structure that receives a description of the query.
+A pointer to a <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-d3d11_query_desc1">D3D11_QUERY_DESC1</a> structure that receives a description of the query.
 
 ## -see-also
 


### PR DESCRIPTION
Point to the base C desc type, not the C++ wrapper/helper.

It's nice to know about the wrapper, but the docs for the wrappers don't have links to the member types. This is the first struct link I've followed in the d3d11 docs that goes to the C++ wrapper, so I guessed it was an accident.