### PR TITLE
Update nf-winbase-updateresourcea.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-updateresourcea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-updateresourcea.md
@@ -68,7 +68,7 @@ Type: <b>LPCTSTR</b>
 
 The resource type to be updated. Alternatively, rather than a pointer, this parameter can be <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>(ID), where ID is an integer value representing a predefined resource type. If the first character of the string is a pound sign (#), then the remaining characters represent a decimal number that specifies the integer identifier of the resource type. For example, the string "#258" represents the identifier 258.
 
-For a list of predefined resource types, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-types">Resource Types</a>.
+For a list of predefined resource types, see <a href="/windows/win32/menurc/resource-types">Resource Types</a>.
 
 ### -param lpName [in]
 


### PR DESCRIPTION
"Predefined resource types" linked to a Direct3D page instead of the correct "Resource Types" page