### PR TITLE
Update nf-d3d12-id3d12graphicscommandlist-copyresource.md

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
@@ -90,7 +90,7 @@ This method has a few restrictions designed for improving performance. For insta
           </li>
 <li>Can't be currently mapped.</li>
 </ul>
-<b>CopyResource</b> only supports copy; it doesn't support any stretch, color key, or blend. <b>CopyResource</b> can reinterpret the resource data between a few format types. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
+<b>CopyResource</b> only supports copy; it doesn't support any stretch, color key, or blend. To reinterpret the resource data between a few format types (see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>) use <b>CopyTextureRegion</b> instead.
         
 
 You can use a   <a href="/windows/desktop/api/d3d11/ne-d3d11-d3d11_bind_flag">depth-stencil</a> resource as either a source or a destination. Resources created with multi-sampling capability (see <a href="/windows/desktop/api/dxgicommon/ns-dxgicommon-dxgi_sample_desc">DXGI_SAMPLE_DESC</a>) can be used as source and destination only if both source and destination have identical multi-sampled count and quality. If source and destination differ in multi-sampled count and quality or if one is multi-sampled and the other is not multi-sampled, the call to <b>CopyResource</b> fails. Use <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resolvesubresource">ResolveSubresource</a> to resolve a multi-sampled resource to a resource that is not multi-sampled.

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
@@ -45,9 +45,6 @@ api_name:
  - ID3D12GraphicsCommandList.CopyResource
 ---
 
-# ID3D12GraphicsCommandList::CopyResource
-
-
 ## -description
 
 Copies the entire contents of the source resource to the destination resource.
@@ -58,27 +55,25 @@ Copies the entire contents of the source resource to the destination resource.
 
 Type: <b>ID3D12Resource*</b>
 
-A pointer to the <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the destination resource.
+A pointer to the <a href="/windows/win32/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the destination resource.
 
 ### -param pSrcResource [in]
 
 Type: <b>ID3D12Resource*</b>
 
-A pointer to the <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the source resource.
+A pointer to the <a href="/windows/win32/api/d3d12/nn-d3d12-id3d12resource">ID3D12Resource</a> interface that represents the source resource.
 
 ## -remarks
 
-<b>CopyResource</b> operations are performed on the GPU and do not incur a significant CPU workload linearly dependent on the size of the data to copy.
-        
+<b>CopyResource</b> operations are performed on the GPU, and do not incur a significant CPU workload linearly dependent on the size of the data to copy.
 
-<b>CopyResource</b> may be used to initialize resources which alias the same heap memory. See <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createplacedresource">CreatePlacedResource</a> for more details.
+<b>CopyResource</b> can be used to initialize resources that alias the same heap memory. See <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource">CreatePlacedResource</a> for more details.
 
-<h3><a id="Debug_layer"></a><a id="debug_layer"></a><a id="DEBUG_LAYER"></a>Debug layer</h3>
-The debug layer will issue an error if the source subresource is not in the  <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_SOURCE</a> state.
-          
+###Debug layer
 
-The debug layer will issue an error if the destination subresource is not in the  <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_DEST </a> state.
-          
+The debug layer issues an error if the source subresource is not in the <a href="/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_SOURCE</a> state.
+
+The debug layer issues an error if the destination subresource is not in the <a href="/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_DEST </a> state.
 
 This method has a few restrictions designed for improving performance. For instance, the source and destination resources:
 
@@ -86,26 +81,22 @@ This method has a few restrictions designed for improving performance. For insta
 <li>Must be different resources.</li>
 <li>Must be the same type.</li>
 <li>Must have identical dimensions (including width, height, depth, and size as appropriate).</li>
-<li>Must have compatible <a href="/windows/desktop/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
-          </li>
+<li>Must have compatible <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types. For more info, see <a href="/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
+</li>
 <li>Can't be currently mapped.</li>
 </ul>
-<b>CopyResource</b> only supports copy; it doesn't support any stretch, color key, or blend. To reinterpret the resource data between a few format types (see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>) use <b>CopyTextureRegion</b> instead.
-        
 
-You can use a   <a href="/windows/desktop/api/d3d11/ne-d3d11-d3d11_bind_flag">depth-stencil</a> resource as either a source or a destination. Resources created with multi-sampling capability (see <a href="/windows/desktop/api/dxgicommon/ns-dxgicommon-dxgi_sample_desc">DXGI_SAMPLE_DESC</a>) can be used as source and destination only if both source and destination have identical multi-sampled count and quality. If source and destination differ in multi-sampled count and quality or if one is multi-sampled and the other is not multi-sampled, the call to <b>CopyResource</b> fails. Use <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resolvesubresource">ResolveSubresource</a> to resolve a multi-sampled resource to a resource that is not multi-sampled.
-        
+**CopyResource** supports only copy; it doesn't support any stretch, color key, or blend. To reinterpret the resource data between a few format types (see [Format Conversion using Direct3D 10.1](/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression)) use **CopyTextureRegion** instead.
 
-The method is an asynchronous call, which may be added to the command-buffer queue. This attempts to remove pipeline stalls that may occur when copying data. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-mapping">performance considerations</a>.
-        
+You can use a <a href="/windows/win32/api/d3d11/ne-d3d11-d3d11_bind_flag">depth-stencil</a> resource as either a source or a destination. Resources created with multi-sampling capability (see <a href="/windows/win32/api/dxgicommon/ns-dxgicommon-dxgi_sample_desc">DXGI_SAMPLE_DESC</a>) can be used as source and destination only if both source and destination have identical multi-sampled count and quality. If source and destination differ in multi-sampled count and quality or if one is multi-sampled and the other is not multi-sampled, the call to <b>CopyResource</b> fails. Use <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resolvesubresource">ResolveSubresource</a> to resolve a multi-sampled resource to a resource that is not multi-sampled.
 
-Consider using <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> or <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copybufferregion">CopyBufferRegion</a> if you only need to copy a portion of the data in a resource.
-        
+The method is an asynchronous call, which may be added to the command-buffer queue. This attempts to remove pipeline stalls that may occur when copying data. For more info, see <a href="/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-mapping">performance considerations</a>.
 
+Consider using <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> or <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copybufferregion">CopyBufferRegion</a> if you only need to copy a portion of the data in a resource.
 
-#### Examples
+## Examples
 
-The <a href="/windows/desktop/direct3d12/working-samples">D3D12HeterogeneousMultiadapter</a> sample uses <b>CopyResource</b> in the following way: 
+The <a href="/windows/win32/direct3d12/working-samples">D3D12HeterogeneousMultiadapter</a> sample uses <b>CopyResource</b> in the following way: 
 
 <pre class="syntax" xml:space="preserve"><code>	// Command list to copy the render target to the shared heap on the primary adapter. 
  	{ 
@@ -157,4 +148,4 @@ The <a href="/windows/desktop/direct3d12/working-samples">D3D12HeterogeneousMult
 
 ## -see-also
 
-<a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12graphicscommandlist">ID3D12GraphicsCommandList</a>
+<a href="/windows/win32/api/d3d12/nn-d3d12-id3d12graphicscommandlist">ID3D12GraphicsCommandList</a>


### PR DESCRIPTION
CopyResource cannot be used to reinterpret a texture on AMD. CopyTextureRegion needs to be used instead for the conversion to work,