### PR TITLE
Update nf-d3d12-id3d12graphicscommandlist-copyresource.md

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
@@ -69,30 +69,49 @@ A pointer to the <a href="/windows/win32/api/d3d12/nn-d3d12-id3d12resource">ID3D
 
 <b>CopyResource</b> can be used to initialize resources that alias the same heap memory. See <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource">CreatePlacedResource</a> for more details.
 
-###Debug layer
+### Debug layer
 
 The debug layer issues an error if the source subresource is not in the <a href="/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_SOURCE</a> state.
 
 The debug layer issues an error if the destination subresource is not in the <a href="/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_COPY_DEST </a> state.
+
+### Restrictions
 
 This method has a few restrictions designed for improving performance. For instance, the source and destination resources:
 
 <ul>
 <li>Must be different resources.</li>
 <li>Must be the same type.</li>
-<li>Must have identical dimensions (including width, height, depth, and size as appropriate).</li>
-<li>Must have compatible <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types. For more info, see <a href="/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
+<li>Must be the same total size (bytes).</li>
+<li>Must have identical dimensions (width, height, depth) or be a compatible <a href="#reinterpret-copy">Reinterpret Copy</a>.</li>
+<li>Must have compatible <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types (see <a href="#reinterpret-copy">Reinterpret Copy</a>). 
 </li>
 <li>Can't be currently mapped.</li>
 </ul>
 
-**CopyResource** supports only copy; it doesn't support any stretch, color key, or blend. To reinterpret the resource data between a few format types (see [Format Conversion using Direct3D 10.1](/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression)) use **CopyTextureRegion** instead.
+<b>CopyResource</b> only supports copy; it doesn't support any stretch, color key, or blend.
+
+<b>CopyResource</b> can reinterpret the resource data between a few format types, see <a href="#reinterpret-copy">Reinterpret Copy</a> below for details.
 
 You can use a <a href="/windows/win32/api/d3d11/ne-d3d11-d3d11_bind_flag">depth-stencil</a> resource as either a source or a destination. Resources created with multi-sampling capability (see <a href="/windows/win32/api/dxgicommon/ns-dxgicommon-dxgi_sample_desc">DXGI_SAMPLE_DESC</a>) can be used as source and destination only if both source and destination have identical multi-sampled count and quality. If source and destination differ in multi-sampled count and quality or if one is multi-sampled and the other is not multi-sampled, the call to <b>CopyResource</b> fails. Use <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-resolvesubresource">ResolveSubresource</a> to resolve a multi-sampled resource to a resource that is not multi-sampled.
 
 The method is an asynchronous call, which may be added to the command-buffer queue. This attempts to remove pipeline stalls that may occur when copying data. For more info, see <a href="/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-mapping">performance considerations</a>.
 
 Consider using <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> or <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copybufferregion">CopyBufferRegion</a> if you only need to copy a portion of the data in a resource.
+
+### Reinterpret Copy
+
+The following table lists the allowable source and destination formats that you can use in the reinterpretation type of format conversion. The underlying data values are not converted or compressed/decompressed and must be encoded properly for the reinterpretation to work as expected. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
+
+For DXGI\_FORMAT\_R9G9B9E5\_SHAREDEXP the width and height must be equal (1 texel per block).
+
+Block-compressed resource width and height must be 4 times the uncompressed resource width and height (16 texels per block).  For example, a uncompressed 256x256 DXGI\_FORMAT\_R32G32B32A32\_UINT texture will map to a 1024x1024 DXGI\_FORMAT\_BC5\_UNORM compressed texture.
+
+| Bit Width | Uncompressed Resource                                                                                                                                               | Block-Compressed Resource                                                                                                                                           | Width / Height Difference    |
+|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| 32        | DXGI\_FORMAT\_R32\_UINT<br/> DXGI\_FORMAT\_R32\_SINT<br/>                                                                                               | DXGI\_FORMAT\_R9G9B9E5\_SHAREDEXP                                                                                                                                   | 1:1 |
+| 64        | DXGI\_FORMAT\_R16G16B16A16\_UINT<br/> DXGI\_FORMAT\_R16G16B16A16\_SINT<br/> DXGI\_FORMAT\_R32G32\_UINT<br/> DXGI\_FORMAT\_R32G32\_SINT<br/> | DXGI\_FORMAT\_BC1\_UNORM\[\_SRGB\]<br/> DXGI\_FORMAT\_BC4\_UNORM<br/> DXGI\_FORMAT\_BC4\_SNORM<br/>                                               | 1:4 |
+| 128       | DXGI\_FORMAT\_R32G32B32A32\_UINT<br/> DXGI\_FORMAT\_R32G32B32A32\_SINT<br/>                                                                             | DXGI\_FORMAT\_BC2\_UNORM\[\_SRGB\]<br/> DXGI\_FORMAT\_BC3\_UNORM\[\_SRGB\]<br/> DXGI\_FORMAT\_BC5\_UNORM<br/> DXGI\_FORMAT\_BC5\_SNORM<br/> | 1:4 |
 
 ## Examples
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-copyresource.md
@@ -84,7 +84,7 @@ This method has a few restrictions designed for improving performance. For insta
 <li>Must be the same type.</li>
 <li>Must be the same total size (bytes).</li>
 <li>Must have identical dimensions (width, height, depth) or be a compatible <a href="#reinterpret-copy">Reinterpret Copy</a>.</li>
-<li>Must have compatible <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types (see <a href="#reinterpret-copy">Reinterpret Copy</a>). 
+<li>Must have compatible <a href="/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format">DXGI formats</a>, which means the formats must be identical or at least from the same type group. For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopyResource</b> can copy between a few format types (see <a href="#reinterpret-copy">Reinterpret copy</a>). 
 </li>
 <li>Can't be currently mapped.</li>
 </ul>
@@ -99,7 +99,7 @@ The method is an asynchronous call, which may be added to the command-buffer que
 
 Consider using <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copytextureregion">CopyTextureRegion</a> or <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-copybufferregion">CopyBufferRegion</a> if you only need to copy a portion of the data in a resource.
 
-### Reinterpret Copy
+### Reinterpret copy
 
 The following table lists the allowable source and destination formats that you can use in the reinterpretation type of format conversion. The underlying data values are not converted or compressed/decompressed and must be encoded properly for the reinterpretation to work as expected. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.
 
@@ -107,7 +107,7 @@ For DXGI\_FORMAT\_R9G9B9E5\_SHAREDEXP the width and height must be equal (1 texe
 
 Block-compressed resource width and height must be 4 times the uncompressed resource width and height (16 texels per block).  For example, a uncompressed 256x256 DXGI\_FORMAT\_R32G32B32A32\_UINT texture will map to a 1024x1024 DXGI\_FORMAT\_BC5\_UNORM compressed texture.
 
-| Bit Width | Uncompressed Resource                                                                                                                                               | Block-Compressed Resource                                                                                                                                           | Width / Height Difference    |
+| Bit width | Uncompressed resource                                                                                                                                               | Block-compressed resource                                                                                                                                           | Width / height difference    |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
 | 32        | DXGI\_FORMAT\_R32\_UINT<br/> DXGI\_FORMAT\_R32\_SINT<br/>                                                                                               | DXGI\_FORMAT\_R9G9B9E5\_SHAREDEXP                                                                                                                                   | 1:1 |
 | 64        | DXGI\_FORMAT\_R16G16B16A16\_UINT<br/> DXGI\_FORMAT\_R16G16B16A16\_SINT<br/> DXGI\_FORMAT\_R32G32\_UINT<br/> DXGI\_FORMAT\_R32G32\_SINT<br/> | DXGI\_FORMAT\_BC1\_UNORM\[\_SRGB\]<br/> DXGI\_FORMAT\_BC4\_UNORM<br/> DXGI\_FORMAT\_BC4\_SNORM<br/>                                               | 1:4 |


### PR DESCRIPTION
After further internal discussion, the previous PR was incorrect. CopyResource can be used for format reinterpretation. We have reverted and expanded the language here to clarify handling of copies to and from Block-compressed resources.