### PR TITLE
Update nf-winuser-getdisplayautorotationpreferences.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getdisplayautorotationpreferences.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getdisplayautorotationpreferences.md
@@ -11,8 +11,8 @@ ms.keywords: GetDisplayAutoRotationPreferences, GetDisplayAutoRotationPreference
 req.header: winuser.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
This method is not available in Windows 7. 

See https://abi-laboratory.pro/compatibility/Windows_7.0_to_Windows_8.1/x86_64/compat_reports/user32.dll/abi_compat_report.html