### PR TITLE
Update ne-shobjidl_core-_fileopendialogoptions.md

### DIFF
--- a/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions.md
+++ b/sdk-api-src/content/shobjidl_core/ne-shobjidl_core-_fileopendialogoptions.md
@@ -128,6 +128,8 @@ Shortcuts should not be treated as their target items. This allows an applicatio
 
 ### -field FOS_OKBUTTONNEEDSINTERACTION
 
+The OK button will be disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.
+
 ### -field FOS_DONTADDTORECENT
 
 Do not add the item being opened or saved to the recent documents list (<a href="/windows/desktop/api/shlobj_core/nf-shlobj_core-shaddtorecentdocs">SHAddToRecentDocs</a>).


### PR DESCRIPTION
Note the behavior of the FOS_OKBUTTONNEEDSINTERACTION flag, which otherwise misleadingly[1] looks like it would be useful for blocking gesture hijacking attacks.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1338637#c23