### PR TITLE
Update ns-d3d12-d3d12_query_data_so_statistics.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_query_data_so_statistics.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_query_data_so_statistics.md
@@ -7,7 +7,6 @@ old-location: direct3d12\d3d12_query_data_so_statistics.htm
 tech.root: direct3d12
 ms.assetid: 7A71F6DA-AAC2-4070-90E9-F91F090AD1A1
 ms.date: 12/05/2018
-ms.keywords: D3D12_QUERY_DATA_SO_STATISTICS, D3D12_QUERY_DATA_SO_STATISTICS structure, d3d12/D3D12_QUERY_DATA_SO_STATISTICS, direct3d12.d3d12_query_data_so_statistics
 req.header: d3d12.h
 req.include-header: 
 req.target-type: Windows
@@ -45,27 +44,28 @@ api_name:
  - D3D12_QUERY_DATA_SO_STATISTICS
 ---
 
-# D3D12_QUERY_DATA_SO_STATISTICS structure
-
-
 ## -description
 
-Describes query data for stream output.
+Describes query data about the amount of data streamed out to the stream-output buffers.
 
 ## -struct-fields
 
 ### -field NumPrimitivesWritten
 
-Specifies the number of primitives actually written to the stream output resource.
+Type: **[UINT64](/windows/win32/winprog/windows-data-types)**
+
+The number of primitives (that is, points, lines, and triangles) that were actually written to the stream output resource.
 
 ### -field PrimitivesStorageNeeded
 
-Specifies the total amount of storage needed by all the primitives that would have been written to the stream output resource if it was big enough to do so.
+Type: **[UINT64](/windows/win32/winprog/windows-data-types)**
+
+If the stream output resource is large enough, then *PrimitivesStorageNeeded* represents the total amount of storage occupied by all of the primitives written to the stream output resource. Otherwise, it represents the total amount of storage that *would* have been written to the stream-output resource had there been enough space for it all.
 
 ## -remarks
 
-Use this structure with <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_query_heap_type">D3D12_QUERY_HEAP_TYPE</a> and <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createqueryheap">CreateQueryHeap</a>.
+Use this structure with [D3D12_QUERY_HEAP_TYPE](/windows/win32/api/d3d12/ne-d3d12-d3d12_query_heap_type) and [CreateQueryHeap](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createqueryheap).
 
 ## -see-also
 
-<a href="/windows/desktop/direct3d12/direct3d-12-structures">Core Structures</a>
+* [Core structures](/windows/win32/direct3d12/direct3d-12-structures)

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_query_data_so_statistics.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_query_data_so_statistics.md
@@ -56,11 +56,11 @@ Describes query data for stream output.
 
 ### -field NumPrimitivesWritten
 
-Specifies the number of primitives written.
+Specifies the number of primitives actually written to the stream output resource.
 
 ### -field PrimitivesStorageNeeded
 
-Specifies the total amount of storage needed by the primitives.
+Specifies the total amount of storage needed by all the primitives that would have been written to the stream output resource if it was big enough to do so.
 
 ## -remarks
 


### PR DESCRIPTION
Changed the language of the NumPrimitivesWritten and PrimitivesStorageNeeded fields to more accurately explain the behavior if the stream output resource is smaller than the size required by the number of primitives that would be written; now more closely matches the D3D11 documentation on this type, which noted this behavior more clearly.