### PR TITLE
Added information about timeout from WaitForXXXObject

### DIFF
--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
@@ -90,9 +90,9 @@ If <i>dwMilliseconds</i> is nonzero and the operation is still in progress, the 
 
 If <i>dwMilliseconds</i> is <b>INFINITE</b>, the function returns only when the object is signaled or an I/O completion routine or APC is queued.
 
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value includes time spent in low-power states. For example, the timeout continues counting down while the computer is asleep.
 
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not continue counting down while the computer is asleep.
 
 ### -param bAlertable [in]
 

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
@@ -90,6 +90,10 @@ If <i>dwMilliseconds</i> is nonzero and the operation is still in progress, the 
 
 If <i>dwMilliseconds</i> is <b>INFINITE</b>, the function returns only when the object is signaled or an I/O completion routine or APC is queued.
 
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+
 ### -param bAlertable [in]
 
 If this parameter is <b>TRUE</b> and the calling thread is in the waiting state, the function returns when the system queues an I/O completion routine or APC. The calling thread then runs the routine or function. Otherwise, the function does not return, and the completion routine or APC function is not executed.

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatus.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatus.md
@@ -90,9 +90,9 @@ The number of milliseconds that the caller is willing to wait for a completion p
 
 If <i>dwMilliseconds</i> is <b>INFINITE</b>, the function will never time out. If <i>dwMilliseconds</i> is zero and there is no I/O operation to dequeue, the function will time out immediately.
 
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value includes time spent in low-power states. For example, the timeout continues counting down while the computer is asleep.
 
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not continue counting down while the computer is asleep.
 
 ## -returns
 

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatus.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatus.md
@@ -90,6 +90,10 @@ The number of milliseconds that the caller is willing to wait for a completion p
 
 If <i>dwMilliseconds</i> is <b>INFINITE</b>, the function will never time out. If <i>dwMilliseconds</i> is zero and there is no I/O operation to dequeue, the function will time out immediately.
 
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+
 ## -returns
 
 Returns nonzero (<b>TRUE</b>) if successful or zero (<b>FALSE</b>) otherwise.

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatusex.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatusex.md
@@ -98,6 +98,10 @@ The number of milliseconds that the caller is willing to wait for a completion p
 If <i>dwMilliseconds</i> is <b>INFINITE</b> (0xFFFFFFFF), the function 
        will never time out. If <i>dwMilliseconds</i> is zero and there is no I/O operation to 
        dequeue, the function will time out immediately.
+       
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
 
 ### -param fAlertable [in]
 

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatusex.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getqueuedcompletionstatusex.md
@@ -99,9 +99,9 @@ If <i>dwMilliseconds</i> is <b>INFINITE</b> (0xFFFFFFFF), the function
        will never time out. If <i>dwMilliseconds</i> is zero and there is no I/O operation to 
        dequeue, the function will time out immediately.
        
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value includes time spent in low-power states. For example, the timeout continues counting down while the computer is asleep.
 
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not continue counting down while the computer is asleep.
 
 ### -param fAlertable [in]
 


### PR DESCRIPTION
This information was added to WaitForXXXObject sometime in the past but is applicable. It is missing from these APIs causing of confusion for developers who consider the new Windows 8+/2012 behavior has broken/incompatible.