### PR TITLE
Update ns-d3d12video-d3d12_video_process_input_stream.md

### DIFF
--- a/sdk-api-src/content/d3d12video/ns-d3d12video-d3d12_video_process_input_stream.md
+++ b/sdk-api-src/content/d3d12video/ns-d3d12video-d3d12_video_process_input_stream.md
@@ -52,7 +52,7 @@ An [ID3D12Resource](/windows/desktop/api/d3d12/nn-d3d12-id3d12resource) represen
 
 ### -field Subresource
 
-The subresource index to use of the *pInputTexture* argument.
+The subresource index to use of the *pTexture2D* argument.
 
 ### -field ReferenceSet
 


### PR DESCRIPTION
The description for the Subresource argument references a nonexistent pInputTexture argument. This should be the pTexture2D argument.