### PR TITLE
Document CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID

### DIFF
--- a/sdk-api-src/content/namespaceapi/nf-namespaceapi-createboundarydescriptorw.md
+++ b/sdk-api-src/content/namespaceapi/nf-namespaceapi-createboundarydescriptorw.md
@@ -58,7 +58,11 @@ The name of the boundary descriptor.
 
 ### -param Flags [in]
 
-This parameter is reserved for future use.
+A combination of the following flags that are combined by using a bitwise **OR** operation.
+
+| Flag                                                            | Description |
+| --------------------------------------------------------------- | ----------- |
+| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported before Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
 
 ## -returns
 

--- a/sdk-api-src/content/namespaceapi/nf-namespaceapi-createboundarydescriptorw.md
+++ b/sdk-api-src/content/namespaceapi/nf-namespaceapi-createboundarydescriptorw.md
@@ -62,7 +62,7 @@ A combination of the following flags that are combined by using a bitwise **OR**
 
 | Flag                                                            | Description |
 | --------------------------------------------------------------- | ----------- |
-| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported before Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
+| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported prior to Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
 
 ## -returns
 

--- a/sdk-api-src/content/winbase/nf-winbase-createboundarydescriptora.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createboundarydescriptora.md
@@ -67,7 +67,11 @@ The name of the boundary descriptor.
 
 ### -param Flags [in]
 
-This parameter is reserved for future use.
+A combination of the following flags that are combined by using a bitwise **OR** operation.
+
+| Flag                                                            | Description |
+| --------------------------------------------------------------- | ----------- |
+| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported before Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
 
 ## -returns
 

--- a/sdk-api-src/content/winbase/nf-winbase-createboundarydescriptora.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createboundarydescriptora.md
@@ -71,7 +71,7 @@ A combination of the following flags that are combined by using a bitwise **OR**
 
 | Flag                                                            | Description |
 | --------------------------------------------------------------- | ----------- |
-| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported before Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
+| **CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID** (0x01)<br>**Note:** This value is not supported prior to Windows 8.     | Required for creating a boundary descriptor in an appcontainer process, regardless of producer or consumer.       |
 
 ## -returns
 


### PR DESCRIPTION
It's used by Microsoft.NET [here](https://github.com/intj-t/Microsoft.NET/blob/f46cf8a239e94dbf298e04c1c164f9f13c05753c/coreclr/src/ipcman/ipcsharedsrc.cpp#L146-L149), defined [here](https://github.com/intj-t/Microsoft.NET/blob/f46cf8a239e94dbf298e04c1c164f9f13c05753c/coreclr/src/ipcman/ipcshared.h#L45-L50).

You can see that it's also defined in Microsoft docs for Rust:
https://github.com/microsoft/windows-docs-rs/search?q=CREATE_BOUNDARY_DESCRIPTOR_ADD_APPCONTAINER_SID