### PR TITLE
Add color format to sampler desc BorderColor field

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_sampler_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_sampler_desc.md
@@ -84,7 +84,7 @@ A <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_comparison_func">D3D12_COMP
 
 ### -field BorderColor
 
-Border color to use if <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_texture_address_mode">D3D12_TEXTURE_ADDRESS_MODE_BORDER</a> is specified for <b>AddressU</b>, <b>AddressV</b>, or <b>AddressW</b>. Range must be between 0.0 and 1.0 inclusive.
+RGBA border color to use if <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_texture_address_mode">D3D12_TEXTURE_ADDRESS_MODE_BORDER</a> is specified for <b>AddressU</b>, <b>AddressV</b>, or <b>AddressW</b>. Range must be between 0.0 and 1.0 inclusive.
 
 ### -field MinLOD
 


### PR DESCRIPTION
The BorderColor field doesn't tell you what color format the float array is being interpreted as.