### PR TITLE
Fix lock release omission error in nf-synchapi-sleepconditionvariablesrw.md

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablesrw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablesrw.md
@@ -88,7 +88,7 @@ If the timeout expires the function returns FALSE and <a href="/windows/desktop/
 
 If the lock is unlocked when this function is called, the function behavior is undefined.
 
-The thread can be woken using the <a href="/windows/desktop/api/synchapi/nf-synchapi-wakeconditionvariable">WakeConditionVariable</a> or <a href="/windows/desktop/api/synchapi/nf-synchapi-wakeallconditionvariable">WakeAllConditionVariable</a> function.
+The thread can be woken using the <a href="/windows/desktop/api/synchapi/nf-synchapi-wakeconditionvariable">WakeConditionVariable</a> or <a href="/windows/desktop/api/synchapi/nf-synchapi-wakeallconditionvariable">WakeAllConditionVariable</a> function. After the thread is woken, it re-acquires the lock it released when the thread entered the sleeping state.
 
 Condition variables are subject to spurious wakeups (those not associated with an explicit wake) and stolen wakeups (another thread manages to run before the woken thread). Therefore, you should recheck a predicate (typically in a <b>while</b> loop) after a sleep operation returns.
 


### PR DESCRIPTION
Omission error of lock release. Statement adapted verbatim from the nf-synchapi-sleepconditionvariablecs.md page.