### PR TITLE
Describe long path behaviour of `GetFullPathName`

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
@@ -80,9 +80,8 @@ This parameter can be a short (the 8.3 form) or long file name. This string can 
        name.
 
 In the ANSI version of this function, the name is limited to <b>MAX_PATH</b> characters. 
-       To extend this limit to 32,767 wide characters, call the Unicode version of the function (<b>GetFullPathNameW</b>), and prepend 
-       "\\\\?\\" to the path. For more information, see 
-       <a href="/windows/desktop/FileIO/naming-a-file">Naming a File</a>.
+       To extend this limit to 32,767 wide characters, call the Unicode version of the function (<b>GetFullPathNameW</b>).
+
 
 <div class="alert"><b>Tip</b>  Starting in Windows 10, version 1607, for the unicode version of this function (<b>GetFullPathNameW</b>), you can opt-in to remove the <b>MAX_PATH</b> character limitation without prepending "\\?\". See the "Maximum Path Limitation" section of  <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a> for details. </div>
 <div> </div>

--- a/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
@@ -82,10 +82,6 @@ This parameter can be a short (the 8.3 form) or long file name. This string can 
 In the ANSI version of this function, the name is limited to <b>MAX_PATH</b> characters. 
        To extend this limit to 32,767 wide characters, call the Unicode version of the function (<b>GetFullPathNameW</b>).
 
-
-<div class="alert"><b>Tip</b>  Starting in Windows 10, version 1607, for the unicode version of this function (<b>GetFullPathNameW</b>), you can opt-in to remove the <b>MAX_PATH</b> character limitation without prepending "\\?\". See the "Maximum Path Limitation" section of  <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a> for details. </div>
-<div> </div>
-
 ### -param nBufferLength [in]
 
 The size of the buffer to receive the null-terminated string for the drive and path, in 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamew.md
@@ -80,12 +80,7 @@ This parameter can be a short (the 8.3 form) or long file name. This string can 
        name.
 
 In the ANSI version of this function, the name is limited to <b>MAX_PATH</b> characters. 
-       To extend this limit to 32,767 wide characters, call the Unicode version of the function (<b>GetFullPathNameW</b>), and prepend 
-       "\\\\?\\" to the path. For more information, see 
-       <a href="/windows/desktop/FileIO/naming-a-file">Naming a File</a>.
-
-<div class="alert"><b>Tip</b>  Starting in Windows 10, version 1607, for the unicode version of this function (<b>GetFullPathNameW</b>), you can opt-in to remove the <b>MAX_PATH</b> character limitation without prepending "\\?\". See the "Maximum Path Limitation" section of  <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a> for details. </div>
-<div> </div>
+       To extend this limit to 32,767 wide characters, call the Unicode version of the function (<b>GetFullPathNameW</b>).
 
 ### -param nBufferLength [in]
 


### PR DESCRIPTION
The Unicode version (aka `GetFullPathNameW`) is not limited to `MAX_PATH` even without the `\\?\`. This has been true since at least Windows 7 (I didn't test Vista or XP).

Real code in use today does rely on this being true in order to create long paths from relative ones so they can be used in other functions.