### PR TITLE
Add behavior for non-shader-visible descriptor heaps

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12descriptorheap-getgpudescriptorhandleforheapstart.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12descriptorheap-getgpudescriptorhandleforheapstart.md
@@ -58,7 +58,7 @@ Gets the GPU descriptor handle that represents the start of the heap.
 
 Type: <b><a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_gpu_descriptor_handle">D3D12_GPU_DESCRIPTOR_HANDLE</a></b>
 
-Returns the GPU descriptor handle that represents the start of the heap.
+Returns the GPU descriptor handle that represents the start of the heap. If the descriptor heap is not shader-visible, a null handle is returned.
 
 ## -see-also
 


### PR DESCRIPTION
The D3D12 programming guide documents this behavior, but the API documentation does not mention it, see also [this link](https://docs.microsoft.com/en-us/windows/win32/direct3d12/creating-descriptor-heaps#descriptor-heap-methods).