### PR TITLE
Fixed mistakes in constant names and ordering

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_depth_stencil_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_depth_stencil_desc.md
@@ -108,7 +108,7 @@ This table shows the default values of depth-stencil states.
 </tr>
 <tr>
 <td>DepthFunc</td>
-<td>D3D12_COMPARISON_LESS</td>
+<td>D3D12_COMPARISON_FUNC_LESS</td>
 </tr>
 <tr>
 <td>StencilEnable</td>
@@ -124,14 +124,14 @@ This table shows the default values of depth-stencil states.
 </tr>
 <tr>
 <td>
-FrontFace.StencilFunc
+FrontFace.StencilFailOp
 
 and
 
-BackFace.StencilFunc
+BackFace.StencilFailOp
 
 </td>
-<td>D3D12_COMPARISON_ALWAYS</td>
+<td>D3D12_STENCIL_OP_KEEP</td>
 </tr>
 <tr>
 <td>
@@ -157,14 +157,14 @@ BackFace.StencilPassOp
 </tr>
 <tr>
 <td>
-FrontFace.StencilFailOp
+FrontFace.StencilFunc
 
 and
 
-BackFace.StencilFailOp
+BackFace.StencilFunc
 
 </td>
-<td>D3D12_STENCIL_OP_KEEP</td>
+<td>D3D12_COMPARISON_FUNC_ALWAYS</td>
 </tr>
 </table>
  


### PR DESCRIPTION
- Fixed wrong constant names in default values. The document referred to D3D12_COMPARISON_* values while the actual constant values in d3d12.h are called D3D12_COMPARISON_FUNC_*
- Fixed ordering of default values. The default values for D3D12_DEPTH_STENCILOP_DESC where "StencilFunc > StencilDepthFailOp > StencilPassOp > StencilFailOp" while the struct is ordered like this "StencilFailOp > StencilDepthFailOp > StencilPassOp > StencilFunc"