### PR TITLE
Fixing mention of incorrect ID3D12Device interface version

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_pipeline_state_stream_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_pipeline_state_stream_desc.md
@@ -101,7 +101,7 @@ The runtime will determine the type of a pipeline stream (valid types being **CO
 Subobject types irrelevant to the pipeline (e.g a compute shader subobject in a graphics stream) will be ignored.
 If a subobject is not provided (excluding the above required subobjects), the runtime will provide a default value for it.
 
-Consider using the `d3dx12.h` extensions for C++, which provide a set of helper structs for all pipeline subobjects (for example, the above struct is very similar to `CD3DX12_PIPELINE_STATE_STREAM_RASTERIZER`). This header can be found under the **[DirectX-Graphics-Samples]**(https://github.com/microsoft/DirectX-Graphics-Samples/blob/master/Libraries/D3DX12/d3dx12.h) repo on github.
+Consider using the `d3dx12.h` extensions for C++, which provide a set of helper structs for all pipeline subobjects (for example, the above struct is very similar to `CD3DX12_PIPELINE_STATE_STREAM_RASTERIZER`). This header can be found under the **[DirectX-Headers](https://github.com/microsoft/DirectX-Headers/blob/main/include/directx/d3dx12.h)** repo on github.
 
 ### -runtime-validation
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_pipeline_state_stream_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_pipeline_state_stream_desc.md
@@ -76,7 +76,7 @@ Specifies the address of a data structure that describes as a bytestream an arbi
 
 
 
-Use this structure with the **[ID3D12Device1::CreatePipelineState](/windows/win32/api/d3d12/nf-d3d12-id3d12device2-createpipelinestate)** method to create pipeline state objects. 
+Use this structure with the **[ID3D12Device2::CreatePipelineState](/windows/win32/api/d3d12/nf-d3d12-id3d12device2-createpipelinestate)** method to create pipeline state objects. 
 
 The format of the provided stream should consist of an alternating set of **[D3D12_PIPELINE_STATE_SUBOBJECT_TYPE](/windows/win32/api/d3d12/ne-d3d12-d3d12_pipeline_state_subobject_type)**, and the corresponding subobject types for them (for example, **D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER** pairs with **[D3D12_RASTERIZER_DESC](/windows/win32/api/d3d12/ns-d3d12-d3d12_rasterizer_desc)**. In terms of alignment, the D3D12 runtime expects subobjects to be individual struct pairs of enum-struct, rather than a continuous set of fields. It also expects them to be aligned to the natural word alignment of the system. This can be achieved either using `alignas(void*)`, or making a `union` of the enum + subobject and a `void*`. 
 
@@ -97,7 +97,7 @@ public:
 }
 ```
 
-The runtime will determine the type of a pipeline stream (valid types being **COMPUTE**, **GRAPHICS**, and **MESH**), by which subobject type, out of **VS** (vertex shader), **CS** (compute shader), and **MS** (mesh shader), is found. If the runtime finds none of these shaders, it will fail pipeline creation. If it finds multiple of these shaders which are not null, it will also fail. This means it is legal to have both, for example, a **CS** and **VS** in your stream object, provided only one has a non-null pointer for the shader bytecode for any given call to **[ID3D12Device1::CreatePipelineState](/windows/win32/api/d3d12/nf-d3d12-id3d12device2-createpipelinestate)**.
+The runtime will determine the type of a pipeline stream (valid types being **COMPUTE**, **GRAPHICS**, and **MESH**), by which subobject type, out of **VS** (vertex shader), **CS** (compute shader), and **MS** (mesh shader), is found. If the runtime finds none of these shaders, it will fail pipeline creation. If it finds multiple of these shaders which are not null, it will also fail. This means it is legal to have both, for example, a **CS** and **VS** in your stream object, provided only one has a non-null pointer for the shader bytecode for any given call to **[ID3D12Device2::CreatePipelineState](/windows/win32/api/d3d12/nf-d3d12-id3d12device2-createpipelinestate)**.
 Subobject types irrelevant to the pipeline (e.g a compute shader subobject in a graphics stream) will be ignored.
 If a subobject is not provided (excluding the above required subobjects), the runtime will provide a default value for it.
 


### PR DESCRIPTION
The remarks specify that a method belonging to ID3D12Device1 should be used, but that method only exists starting with ID3D12Device2.