### PR TITLE
Reference WSAOVERLAPPED rather than _WSAOVERLAPPED

### DIFF
--- a/sdk-api-src/content/winsock2/ns-winsock2-wsaoverlapped.md
+++ b/sdk-api-src/content/winsock2/ns-winsock2-wsaoverlapped.md
@@ -1,5 +1,5 @@
 ---
-UID: NS:winsock2._WSAOVERLAPPED
+UID: NS:winsock2.WSAOVERLAPPED
 title: WSAOVERLAPPED (winsock2.h)
 description: Provides a communication medium between the initiation of an overlapped I/O operation and its subsequent completion.
 helpviewer_keywords: ["*LPWSAOVERLAPPED","LPWSAOVERLAPPED","LPWSAOVERLAPPED structure pointer [Winsock]","WSAOVERLAPPED","WSAOVERLAPPED structure [Winsock]","_win32_wsaoverlapped_2","winsock.wsaoverlapped_2","winsock2/LPWSAOVERLAPPED","winsock2/WSAOVERLAPPED"]


### PR DESCRIPTION
_WSAOVERLAPPED is the WIN16 version of WSAOVERLAPPED.  Internal and InternalHigh are DWORDs rather than ULONG_PTR.  As a result, the documentation page contradicts itself (struct definition vs struc-fields description).
That being said, I have never used this documentation system and do not know what the policy is for conditionally defined structures, nor how to update the documentation to properly reflect the WIN32 WSAOVERLAPPED structure.  Assistance is appreciated.