### PR TITLE
Added description of NumShader behavior when resource is a structured…

### DIFF
--- a/sdk-api-src/content/d3d12shader/ns-d3d12shader-d3d12_shader_input_bind_desc.md
+++ b/sdk-api-src/content/d3d12shader/ns-d3d12shader-d3d12_shader_input_bind_desc.md
@@ -88,6 +88,7 @@ A <a href="/windows/desktop/api/d3dcommon/ne-d3dcommon-d3d_srv_dimension">D3D_SR
 
 The number of samples for a multisampled texture; when a texture isn't multisampled, the value is set to -1 (0xFFFFFFFF).
             This is zero if the shader resource is not a recognized texture.
+            If the shader resource is a structured buffer, the field contains the stride of the type in bytes.
 
 ### -field Space
 


### PR DESCRIPTION
… buffer.

@jenatali
Had to make another pr since I managed to mess up the branch on the original one. Whoops :)
Following the discussion from the DX12 discord, NumShaders gets repurposed to store the stride of the struct in the structured buffer.