### PR TITLE
DirectXMath matrix view function updates

### DIFF
--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographiclh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographiclh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixOrthographicLH(float,float,fl
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixOrthographicLH, XMMatrixOrthographicLH, XMMatrixOrthographicLH method [DirectX Math Support APIs], dxmath.xmmatrixorthographiclh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixOrthographicLH
@@ -75,6 +75,10 @@ Distance to the far clipping plane.
 Returns the orthogonal projection matrix.
 
 ## -remarks
+
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 All the parameters of
    <b>XMMatrixOrthographicLH</b> are distances

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicoffcenterlh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicoffcenterlh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixOrthographicOffCenterLH(float
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixOrthographicOffCenterLH, XMMatrixOrthographicOffCenterLH, XMMatrixOrthographicOffCenterLH method [DirectX Math Support APIs], dxmath.xmmatrixorthographicoffcenterlh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixOrthographicOffCenterLH
@@ -83,6 +83,10 @@ Distance to the far clipping plane.
 Returns the custom orthogonal projection matrix.
 
 ## -remarks
+
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 All the parameters of
   <b>XMMatrixOrthographicOffCenterLH</b> are distances in camera space.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicoffcenterrh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicoffcenterrh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixOrthographicOffCenterRH(float
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixOrthographicOffCenterRH, XMMatrixOrthographicOffCenterRH, XMMatrixOrthographicOffCenterRH method [DirectX Math Support APIs], dxmath.xmmatrixorthographicoffcenterrh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixOrthographicOffCenterRH
@@ -83,6 +83,10 @@ Distance to the far clipping plane.
 Returns the custom orthogonal projection matrix.
 
 ## -remarks
+
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 All the parameters of <b>XMMatrixOrthographicOffCenterRH</b> are
    distances in camera space.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicrh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixorthographicrh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixOrthographicRH(float,float,fl
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixOrthographicRH, XMMatrixOrthographicRH, XMMatrixOrthographicRH method [DirectX Math Support APIs], dxmath.xmmatrixorthographicrh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixOrthographicRH
@@ -75,6 +75,10 @@ Distance to the far clipping plane.
 Returns the orthogonal projection matrix.
 
 ## -remarks
+
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 All the parameters of
    <b>XMMatrixOrthographicRH</b> are distances

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivefovlh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivefovlh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveFovLH(float,float,
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveFovLH, XMMatrixPerspectiveFovLH, XMMatrixPerspectiveFovLH method [DirectX Math Support APIs], dxmath.xmmatrixperspectivefovlh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveFovLH
@@ -76,7 +76,11 @@ Returns the perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value. The default <i>AspectRatio</i> axis is horizontal, but recalculating <i>FovAngleY</i> with <i>AspectRatio</i> controls the view scale direction: 2.0 * atan(tan(FovAngleY * 0.5) / AspectRatio).
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
+
+The default <i>AspectRatio</i> axis is horizontal, but recalculating <i>FovAngleY</i> with <i>AspectRatio</i> controls the view scale direction: 2.0 * atan(tan(FovAngleY * 0.5) / AspectRatio).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivefovrh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivefovrh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveFovRH(float,float,
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveFovRH, XMMatrixPerspectiveFovRH, XMMatrixPerspectiveFovRH method [DirectX Math Support APIs], dxmath.xmmatrixperspectivefovrh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveFovRH
@@ -76,7 +76,11 @@ Returns the perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value. The default <i>AspectRatio</i> axis is horizontal, but recalculating <i>FovAngleY</i> with <i>AspectRatio</i> controls the view scale direction: 2.0 * atan(tan(FovAngleY * 0.5) / AspectRatio).
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
+
+The default <i>AspectRatio</i> axis is horizontal, but recalculating <i>FovAngleY</i> with <i>AspectRatio</i> controls the view scale direction: 2.0 * atan(tan(FovAngleY * 0.5) / AspectRatio).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivelh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectivelh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveLH(float,float,flo
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveLH, XMMatrixPerspectiveLH, XMMatrixPerspectiveLH method [DirectX Math Support APIs], dxmath.xmmatrixperspectivelh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveLH
@@ -76,7 +76,9 @@ Returns the perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value.
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiveoffcenterlh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiveoffcenterlh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveOffCenterLH(float,
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveOffCenterLH, XMMatrixPerspectiveOffCenterLH, XMMatrixPerspectiveOffCenterLH method [DirectX Math Support APIs], dxmath.xmmatrixperspectiveoffcenterlh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveOffCenterLH
@@ -84,7 +84,9 @@ Returns the custom perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value.
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiveoffcenterrh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiveoffcenterrh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveOffCenterRH(float,
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveOffCenterRH, XMMatrixPerspectiveOffCenterRH, XMMatrixPerspectiveOffCenterRH method [DirectX Math Support APIs], dxmath.xmmatrixperspectiveoffcenterrh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveOffCenterRH
@@ -84,7 +84,9 @@ Returns the custom perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value.
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiverh.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixperspectiverh.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixPerspectiveRH(float,float,flo
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixPerspectiveRH, XMMatrixPerspectiveRH, XMMatrixPerspectiveRH method [DirectX Math Support APIs], dxmath.xmmatrixperspectiverh
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixPerspectiveRH
@@ -76,7 +76,9 @@ Returns the perspective projection matrix.
 
 ## -remarks
 
-For typical usage, <i>NearZ</i> is less than  <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than  <i>NearZ</i>, the result is an inverted z buffer which can provide increased floating-point precision.  <i>NearZ</i> and <i>FarZ</i> cannot be the same value.
+For typical usage, <i>NearZ</i> is less than <i>FarZ</i>. However, if you flip these values so <i>FarZ</i> is less than <i>NearZ</i>, the result is an inverted z buffer (also known as a "reverse z buffer") which can provide increased floating-point precision.
+
+<i>NearZ</i> and <i>FarZ</i> cannot be the same value and must be greater than 0.
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.


### PR DESCRIPTION
The 'nearZ' and 'farZ' values can be reversed for "reverse z buffer" rendering setups.