### PR TITLE
Fix OnOverwrite pResponse parameter type

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ifiledialogevents-onoverwrite.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ifiledialogevents-onoverwrite.md
@@ -68,7 +68,7 @@ A pointer to the interface that represents the item that will be overwritten.
 
 ### -param pResponse [out]
 
-Type: <b><a href="/windows/desktop/api/shobjidl_core/ne-shobjidl_core-fde_shareviolation_response">FDE_SHAREVIOLATION_RESPONSE</a>*</b>
+Type: <b><a href="/windows/desktop/api/shobjidl_core/ne-shobjidl_core-fde_overwrite_response">FDE_OVERWRITE_RESPONSE</a>*</b>
 
 A pointer to a value from the <a href="/windows/desktop/api/shobjidl_core/ne-shobjidl_core-fde_overwrite_response">FDE_OVERWRITE_RESPONSE</a> enumeration indicating the response to the potential overwrite action.
 


### PR DESCRIPTION
There is a copy paste error in this doc. The correct pResponse parameter type for OnOverwite is FDE_OVERWRITE_RESPONSE, not FDE_SHAREVIOLATION_RESPONSE.

Stumbled upon this while looking into https://github.com/dotnet/winforms/issues/5405.