### PR TITLE
Task 29854083: SIP implementation documentation should state that it …

### DIFF
--- a/sdk-api-src/content/mssip/nc-mssip-pfnisfilesupportedname.md
+++ b/sdk-api-src/content/mssip/nc-mssip-pfnisfilesupportedname.md
@@ -72,6 +72,8 @@ If the SIP supports the file type passed by <i>hfile</i>, the function returns <
 
 Each SIP implements its own version of the function that determines if the file type is supported. The specific name of the function may vary depending on the implementation of the SIP, but the signature of the function will match that of the [SIP_ADD_NEWPROVIDER](/windows/desktop/api/mssip/ns-mssip-sip_add_newprovider) structure.
 
+SIPs must support a limited set of file types and file extensions. The fileSupportedName function must check that the provided file matches one of the file extensions supported by the SIP.  For instance, the WSH SIP supports only the following list of file extensions and checks that the file under validation is a member of the following list: .js, .jse, .vbe, .vbs, or .wsf ".
+
 ## -see-also
 
 <a href="/windows/desktop/api/mssip/nc-mssip-pfnisfilesupported">pfnIsFileSupported</a>


### PR DESCRIPTION
…MUST support only a limited set of file extensions

Added in the remarks section: "SIPs must support a limited set of file types and file extensions. The fileSupportedName function must check that the provided file matches one of the file extensions supported by the SIP.  For instance, the WSH SIP supports only the following list of file extensions and checks that the file under validation is a member of the following list: .js, .jse, .vbe, .vbs, or .wsf ".