### PR TITLE
Update nf-virtdisk-setvirtualdiskmetadata.md

### DIFF
--- a/sdk-api-src/content/virtdisk/nf-virtdisk-setvirtualdiskmetadata.md
+++ b/sdk-api-src/content/virtdisk/nf-virtdisk-setvirtualdiskmetadata.md
@@ -60,12 +60,13 @@ Handle to an open virtual disk.
 
 ### -param Item [in]
 
-Address of a <b>GUID</b> identifying the metadata to retrieve.
+Address of a <b>GUID</b> identifying the metadata to set. This cannot be the NULL GUID (a GUID of all zeroes).
 
 ### -param MetaDataSize [in]
 
 Address of a <b>ULONG</b> containing the size, in bytes, of 
       the buffer pointed to by the <i>MetaData</i> parameter.
+      Specific VHD file types have a maximum size per metadata element. Specific VHD files also have a maximum number of total metadata entries and total metadata size.
 
 ### -param MetaData [in]
 


### PR DESCRIPTION
Fix typo (retrieve -> set).
Add a remark that there are max sizes. For example, the Windows VHDMP implementation currently enforces:
* 1MB per metadata entry
* 1024 metadata entries or 40MB of total metadata space (and holes in this space may lead to less actual capacity than advertised).

These sizes are implementation details and can change over time.

.vhd files don't support this sort of metadata.