### PR TITLE
Update D3D12_RESOURCE_STATE_DEPTH_READ

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_states.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_states.md
@@ -6,8 +6,7 @@ helpviewer_keywords: ["D3D12_RESOURCE_STATES","D3D12_RESOURCE_STATES enumeration
 old-location: direct3d12\d3d12_resource_states.htm
 tech.root: direct3d12
 ms.assetid: AB14DE3E-97EA-47BE-8917-805B9651ED3A
-ms.date: 12/05/2018
-ms.keywords: D3D12_RESOURCE_STATES, D3D12_RESOURCE_STATES enumeration, D3D12_RESOURCE_STATE_COMMON, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_DEPTH_READ, D3D12_RESOURCE_STATE_DEPTH_WRITE, D3D12_RESOURCE_STATE_GENERIC_READ, D3D12_RESOURCE_STATE_INDEX_BUFFER, D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_PREDICATION, D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_RESOLVE_DEST, D3D12_RESOURCE_STATE_RESOLVE_SOURCE, D3D12_RESOURCE_STATE_STREAM_OUT, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, D3D12_RESOURCE_STATE_VIDEO_DECODE_READ, D3D12_RESOURCE_STATE_VIDEO_DECODE_WRITE, D3D12_RESOURCE_STATE_VIDEO_PROCESS_READ, D3D12_RESOURCE_STATE_VIDEO_PROCESS_WRITE, d3d12/D3D12_RESOURCE_STATES, d3d12/D3D12_RESOURCE_STATE_COMMON, d3d12/D3D12_RESOURCE_STATE_COPY_DEST, d3d12/D3D12_RESOURCE_STATE_COPY_SOURCE, d3d12/D3D12_RESOURCE_STATE_DEPTH_READ, d3d12/D3D12_RESOURCE_STATE_DEPTH_WRITE, d3d12/D3D12_RESOURCE_STATE_GENERIC_READ, d3d12/D3D12_RESOURCE_STATE_INDEX_BUFFER, d3d12/D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT, d3d12/D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, d3d12/D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, d3d12/D3D12_RESOURCE_STATE_PREDICATION, d3d12/D3D12_RESOURCE_STATE_PRESENT, d3d12/D3D12_RESOURCE_STATE_RENDER_TARGET, d3d12/D3D12_RESOURCE_STATE_RESOLVE_DEST, d3d12/D3D12_RESOURCE_STATE_RESOLVE_SOURCE, d3d12/D3D12_RESOURCE_STATE_STREAM_OUT, d3d12/D3D12_RESOURCE_STATE_UNORDERED_ACCESS, d3d12/D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER, d3d12/D3D12_RESOURCE_STATE_VIDEO_DECODE_READ, d3d12/D3D12_RESOURCE_STATE_VIDEO_DECODE_WRITE, d3d12/D3D12_RESOURCE_STATE_VIDEO_PROCESS_READ, d3d12/D3D12_RESOURCE_STATE_VIDEO_PROCESS_WRITE, direct3d12.d3d12_resource_states
+ms.date: 11/03/2021
 req.header: d3d12.h
 req.include-header: 
 req.target-type: Windows
@@ -54,9 +53,9 @@ Defines constants that specify the state of a resource regarding how the resourc
 
 Your application should transition to this state only for accessing a resource across different graphics engine types.
 
-Specifically, a resource must be in the COMMON state before being used on a COPY queue (when previous used on DIRECT/COMPUTE), and before being used on DIRECT/COMPUTE (when previously used on COPY). This restriction does not exist when accessing data between DIRECT and COMPUTE queues.
+Specifically, a resource must be in the COMMON state before being used on a COPY queue (when previously used on DIRECT/COMPUTE), and before being used on DIRECT/COMPUTE (when previously used on COPY). This restriction doesn't exist when accessing data between DIRECT and COMPUTE queues.
 
-The COMMON state can be used for all usages on a Copy queue using the implicit state transitions. For more info, in <a href="/windows/win32/direct3d12/user-mode-heap-synchronization">Multi-engine synchronization</a>, find "common".          
+The COMMON state can be used for all usages on a Copy queue using the implicit state transitions. For more info, in <a href="/windows/win32/direct3d12/user-mode-heap-synchronization">Multi-engine synchronization</a>, find "common".
 
 Additionally, textures must be in the COMMON state for CPU access to be legal, assuming the texture was created in a CPU-visible heap in the first place.
 
@@ -70,9 +69,9 @@ A subresource must be in this state when it is accessed by the 3D pipeline as an
 
 ### -field D3D12_RESOURCE_STATE_RENDER_TARGET
 
-The resource is used as a render target. A subresource must be in this state when it is rendered to or when it is cleared with <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearrendertargetview">ID3D12GraphicsCommandList::ClearRenderTargetView</a>.
+The resource is used as a render target. A subresource must be in this state when it is rendered to, or when it is cleared with <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearrendertargetview">ID3D12GraphicsCommandList::ClearRenderTargetView</a>.
 
-This is a write-only state. To read from a render target as a shader resource the resource must be in either  D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE or D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE.
+This is a write-only state. To read from a render target as a shader resource, the resource must be in either **D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE** or **D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE**.
 
 ### -field D3D12_RESOURCE_STATE_UNORDERED_ACCESS
 
@@ -84,11 +83,11 @@ The resource is used for unordered access. A subresource must be in this state w
 
 ### -field D3D12_RESOURCE_STATE_DEPTH_READ
 
-DEPTH_READ is a state which can be combined with other states. It should be used when the subresource is in a read-only depth stencil view, or when depth write of <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_depth_stencil_desc">D3D12_DEPTH_STENCIL_DESC</a> is disabled. It can be combined with other read states (for example, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE), such that the resource can be used for the depth or stencil test, and accessed by a shader within the same draw call. Using it when depth will be written by a draw call or clear command is invalid.
+DEPTH_READ is a state that can be combined with other states. It should be used when the subresource is in a read-only depth stencil view, or when depth write of <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_depth_stencil_desc">D3D12_DEPTH_STENCIL_DESC</a> is disabled. It can be combined with other read states (for example, **D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE**), such that the resource can be used for the depth or stencil test, and accessed by a shader within the same draw call. Using it when depth will be written by a draw call or clear command is invalid.
 
 ### -field D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
 
-The resource is used with a shader other than the pixel shader. A subresource must be in this state before being read by any stage (except for the pixel shader stage) via a shader resource view. You can still use the resource in a pixel shader with this flag as long as it also has the flag D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE set. This is a read-only state.
+The resource is used with a shader other than the pixel shader. A subresource must be in this state before being read by any stage (except for the pixel shader stage) via a shader resource view. You can still use the resource in a pixel shader with this flag as long as it also has the flag **D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE** set. This is a read-only state.
 
 ### -field D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
 
@@ -188,9 +187,6 @@ D3D12_RESOURCE_STATE_GENERIC_READ is a logically OR'd combination of other read-
 
 ## -see-also
 
-<a href="/windows/win32/direct3d12/direct3d-12-enumerations">Core Enumerations</a>
-
-
-
-<a href="/windows/win32/direct3d12/using-resource-barriers-to-synchronize-resource-states-in-direct3d-12">Using Resource Barriers to Synchronize Resource States in Direct3D 12</a>
-
+* <a href="/windows/win32/direct3d12/direct3d-12-enumerations">Core Enumerations</a>
+* <a href="/windows/win32/direct3d12/using-resource-barriers-to-synchronize-resource-states-in-direct3d-12">Using Resource Barriers to Synchronize Resource States in Direct3D 12</a>
+* 

--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_states.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_states.md
@@ -84,7 +84,7 @@ The resource is used for unordered access. A subresource must be in this state w
 
 ### -field D3D12_RESOURCE_STATE_DEPTH_READ
 
-DEPTH_READ is a state which can be combined with other states. It should be used when the subresource is in a read-only depth stencil view, or when the <i>DepthEnable</i> parameter of <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_depth_stencil_desc">D3D12_DEPTH_STENCIL_DESC</a> is false. It can be combined with other read states (for example, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE), such that the resource can be used for the depth or stencil test, and accessed by a shader within the same draw call. Using it when depth will be written by a draw call or clear command is invalid.
+DEPTH_READ is a state which can be combined with other states. It should be used when the subresource is in a read-only depth stencil view, or when depth write of <a href="/windows/win32/api/d3d12/ns-d3d12-d3d12_depth_stencil_desc">D3D12_DEPTH_STENCIL_DESC</a> is disabled. It can be combined with other read states (for example, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE), such that the resource can be used for the depth or stencil test, and accessed by a shader within the same draw call. Using it when depth will be written by a draw call or clear command is invalid.
 
 ### -field D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
 


### PR DESCRIPTION
Depth read resource state only require that depth write is disable, it doesn't require depth test to be disabled.