### PR TITLE
Clarify out parameters of TryCreatePackageDependency and AddPackageDependency

### DIFF
--- a/sdk-api-src/content/appmodel/nf-appmodel-addpackagedependency.md
+++ b/sdk-api-src/content/appmodel/nf-appmodel-addpackagedependency.md
@@ -74,7 +74,7 @@ The handle of the added package dependency. This handle is valid until it is pas
 
 Type: <b>PCWSTR*</b>
 
-The full name of the package to which the dependency has been resolved. Use the [HeapAlloc](/windows/win32/api/heapapi/nf-heapapi-heapalloc) function to allocate memory for this parameter, and use [HeapFree](/windows/win32/api/heapapi/nf-heapapi-heapfree) to deallocate the memory.
+When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the full name of the package to which the dependency has been resolved. The caller is responsible for freeing this resource once it is no longer needed by calling [HeapFree](/windows/win32/api/heapapi/nf-heapapi-heapfree).
 
 ## -returns
 

--- a/sdk-api-src/content/appmodel/nf-appmodel-trycreatepackagedependency.md
+++ b/sdk-api-src/content/appmodel/nf-appmodel-trycreatepackagedependency.md
@@ -92,7 +92,7 @@ The options to apply when creating the package dependency.
 
 Type: <b>PWSTR*</b>
 
-The ID of the new package dependency. Use the [HeapAlloc](/windows/win32/api/heapapi/nf-heapapi-heapalloc) function to allocate memory for this parameter, and use [HeapFree](/windows/win32/api/heapapi/nf-heapapi-heapfree) to deallocate the memory.
+When this method returns, contains the address of a pointer to a null-terminated Unicode string that specifies the ID of the new package dependency. The caller is responsible for freeing this resource once it is no longer needed by calling [HeapFree](/windows/win32/api/heapapi/nf-heapapi-heapfree).
 
 ## -returns
 


### PR DESCRIPTION
The mention of `HeapAlloc` here is more confusing than anything, it implies that you have to heap allocate the memory passed here, when you don't: you pass a pointer to a variable and the function updates that variable, then you must deallocate the resource when done. Updated their description to make them more in line with similar out parameters in the Windows API, and clearer.