### PR TITLE
Remove [out] on SyncStatus

### DIFF
--- a/sdk-api-src/content/cfapi/nf-cfapi-cfreportsyncstatus.md
+++ b/sdk-api-src/content/cfapi/nf-cfapi-cfreportsyncstatus.md
@@ -58,7 +58,7 @@ Allows a sync provider to notify the platform of its status on a specified sync 
 
 Path to the sync root.
 
-### -param SyncStatus [in, out]
+### -param SyncStatus [in]
 
 The sync status to report; if <b>null</b>, clears the previously-saved sync status. For more information, see the Remarks section, below.
 


### PR DESCRIPTION
cfapi.h describes this API as such:
```cpp
STDAPI
CfReportSyncStatus(
    _In_ LPCWSTR SyncRootPath,
    _In_opt_ CF_SYNC_STATUS *SyncStatus
    );
```

Have not verified this isn't an SDK bug.