### PR TITLE
Child Process Policy can not be DWORD64

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
@@ -198,9 +198,9 @@ The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> value of <b>PROTECTI
 </dl>
 </td>
 <td width="60%">
-The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> or <b>DWORD64</b> value that specifies the child process policy. The policy specifies whether to allow a child process to be created.
+The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> value that specifies the child process policy. The policy specifies whether to allow a child process to be created.
 
-For information on the possible values for the  <b>DWORD</b> or <b>DWORD64</b> to which <i>lpValue</i> points, see Remarks.
+For information on the possible values for the <b>DWORD</b> to which <i>lpValue</i> points, see Remarks.
 
 </td>
 </tr>
@@ -562,7 +562,7 @@ Restricting certain HSP APIs used to specify security properties of dynamic code
 <dd><b>PROCESS_CREATION_MITIGATION_POLICY2_CET_DYNAMIC_APIS_OUT_OF_PROC_ONLY_ALWAYS_ON </b>     (0x00000001ui64 &lt;&lt; 48)</dd>
 <dd><b>PROCESS_CREATION_MITIGATION_POLICY2_CET_DYNAMIC_APIS_OUT_OF_PROC_ONLY_ALWAYS_OFF </b>    (0x00000002ui64 &lt;&lt; 48)</dd>
 
-The  <b>DWORD</b> or <b>DWORD64</b> pointed to by <i>lpValue</i> can be one or more of the following values when you specify <b>PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY</b> for the <i>Attribute</i> parameter:
+The <b>DWORD</b> pointed to by <i>lpValue</i> can be one or more of the following values when you specify <b>PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY</b> for the <i>Attribute</i> parameter:
 
 <b>PROCESS_CREATION_CHILD_PROCESS_RESTRICTED</b>                                         0x01
 


### PR DESCRIPTION
The doc incorrectly specifies that the `PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY` value can be either a `DWORD` or `DWORD64`.

Tested on Windows 10 x64, the following code will only work if `DWORD64 child_process_policy = 0;` is changed to `DWORD child_process_policy = 0;`, otherwise `UpdateProcThreadAttribute` will return `ERROR_BAD_LENGTH`:

```c++
#include <memory>
#include <Windows.h>
 
enum class Result : int {
    Success,
    SizeDeterminationFailed,
    InitializationFailed,
    StatusBadLength,
    StatusUnknown
};
 
int main() {
    SIZE_T attribute_list_size = 0;
 
    // Retrieve the necessary size for 1 attribute.
    if (InitializeProcThreadAttributeList(nullptr, 1, 0, &attribute_list_size) != 0) {
        return (int)Result::SizeDeterminationFailed;
    }
 
    auto buffer = std::make_unique<uint8_t[]>(attribute_list_size);
    auto attribute_list = (LPPROC_THREAD_ATTRIBUTE_LIST)buffer.get();
 
    // Initialize the list.
    if (InitializeProcThreadAttributeList(attribute_list, 1, 0, &attribute_list_size) == 0) {
        return (int)Result::InitializationFailed;
    }
 
    // Add the attribute.
    DWORD64 child_process_policy = 0;
    auto success = UpdateProcThreadAttribute(
        attribute_list,
        0,
        PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY,
        &child_process_policy,
        sizeof(child_process_policy),
        nullptr,
        nullptr
    );
 
    // Delete the list.
    DeleteProcThreadAttributeList(attribute_list);
 
    if (success == 0) {
        auto status = GetLastError();
 
        if (status == ERROR_BAD_LENGTH) {
            return (int)Result::StatusBadLength;
        } else if (status != ERROR_SUCCESS) {
            return (int)Result::StatusUnknown;
        }
    }
 
    return (int)Result::Success;
}
```

As visible in the disassembly of `KernelBase.dll!UpdateProcThreadAttribute`, it explicitly checks for the size to be `4`, instead of for example for `PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY` that is checked to be `4`, `8` or `16`.