### PR TITLE
fix links to interlockedexchangesubtract

### DIFF
--- a/sdk-api-src/content/winnt/nf-winnt-interlockedexchange.md
+++ b/sdk-api-src/content/winnt/nf-winnt-interlockedexchange.md
@@ -100,7 +100,7 @@ This function  generates a full memory barrier (or fence) to ensure that memory 
 
 
 
-<a href="/windows/win32/api/winbase/nf-winbase-interlockedexchangesubtract">InterlockedExchange</a>
+<a href="/windows/win32/api/winbase/nf-winbase-interlockedexchange">InterlockedExchange</a>
 
 
 


### PR DESCRIPTION
I am not sure how this list was generated, but apparently all of them point to interlockedexchangesubtract