### PR TITLE
Improving a link in D3D12 documentation

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_writebufferimmediate_parameter.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_writebufferimmediate_parameter.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Specifies the immediate value and destination address written using <a href="/windows/desktop/api/d3d12/nn-d3d12-id3d12graphicscommandlist2">ID3D12CommandList2::WriteBufferImmediate</a>.
+Specifies the immediate value and destination address written using <a href="/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist2-writebufferimmediate">ID3D12GraphicsCommandList2::WriteBufferImmediate</a>.
 
 ## -struct-fields
 


### PR DESCRIPTION
The struct that this doc page is describing is used only for a specific function on a specific COM interface, but the existing link doesn't lead to that function's documentation (despite the text implying that) and also spells the interface's name wrong.