### PR TITLE
Update nn-d2d1_1-id2d1properties.md

### DIFF
--- a/sdk-api-src/content/d2d1_1/nn-d2d1_1-id2d1properties.md
+++ b/sdk-api-src/content/d2d1_1/nn-d2d1_1-id2d1properties.md
@@ -184,7 +184,7 @@ The minimum value that the parent property supports being set to.
 </td>
 </tr>
 <tr>
-<td>Max / D2D1_SUBPROPERTY_MIN</td>
+<td>Max / D2D1_SUBPROPERTY_MAX</td>
 <td>Same as parent property.
 				<div class="alert"><b>Note</b>  Applicable only to numeric-type properties.</div>
 <div> </div>


### PR DESCRIPTION
The "Max" property incorrectly refers to `D2D1_SUBPROPERTY_MIN` instead of `D2D1_SUBPROPERTY_MAX`.