### PR TITLE
Update nf-jobapi2-setinformationjobobject.md

### DIFF
--- a/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
+++ b/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
@@ -127,7 +127,7 @@ The <i>lpJobObjectInfo</i> parameter is a pointer to a
 
 <b>Windows 7, Windows Server 2008 R2, Windows Server 2008, Windows Vista, Windows Server 2003 and Windows XP:  </b>This flag is not supported.
 
-If Dynamic Fair Share Scheduling (DFSS) is enabled, you will not be able to set the CPU rate, SetInformationJobObject will fail with error code 50 or "The request is not supported".
+If Dynamic Fair Share Scheduling (DFSS) is enabled, the CPU rate cannot be set and SetInformationJobObject will fail with error code 50 ("The request is not supported").
 </td>
 </tr>
 <tr>

--- a/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
+++ b/sdk-api-src/content/jobapi2/nf-jobapi2-setinformationjobobject.md
@@ -127,6 +127,7 @@ The <i>lpJobObjectInfo</i> parameter is a pointer to a
 
 <b>Windows 7, Windows Server 2008 R2, Windows Server 2008, Windows Vista, Windows Server 2003 and Windows XP:  </b>This flag is not supported.
 
+If Dynamic Fair Share Scheduling (DFSS) is enabled, you will not be able to set the CPU rate, SetInformationJobObject will fail with error code 50 or "The request is not supported".
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Specifying JobObjectCpuRateControlInformation will fail if DFSS is enabled.