### PR TITLE
Fix wsprintf character types

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-wsprintfa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wsprintfa.md
@@ -145,14 +145,14 @@ Output the corresponding argument as a character, a string, or a number. This fi
 
 
 <dl>
-<dt><a id="c"></a><a id="C"></a><code>c</code></dt>
+<dt><a id="c"></a><code>c</code></dt>
 <dd>
-Single character. This value is interpreted as type <b>WCHAR</b> if the calling application defines Unicode and as type <b>__wchar_t</b> otherwise.
+Single character. This value is interpreted as type <b>CHAR</b>.
 
 </dd>
-<dt><a id="C"></a><a id="c"></a><code>C</code></dt>
+<dt><a id="C"></a></a><code>C</code></dt>
 <dd>
-Single character. This value is interpreted as type <b>__wchar_t</b> if the calling application defines Unicode and as type <b>WCHAR</b> otherwise.
+Single character. This value is interpreted as type <b>WCHAR</b>.
 
 </dd>
 <dt><a id="d"></a><a id="D"></a><code>d</code></dt>
@@ -162,7 +162,7 @@ Signed decimal integer. This value is equivalent to <code>i</code>.
 </dd>
 <dt><a id="hc__hC"></a><a id="hc__hc"></a><a id="HC__HC"></a><code>hc</code>, <code>hC</code></dt>
 <dd>
-Single character. The <b>wsprintf</b> function ignores character arguments with a numeric value of zero. This value is always interpreted as type <b>__wchar_t</b>, even when the calling application defines Unicode.
+Single character. The <b>wsprintf</b> function ignores character arguments with a numeric value of zero. This value is always interpreted as type <b>CHAR</b>, even when the calling application defines Unicode.
 
 </dd>
 <dt><a id="hd"></a><a id="HD"></a><code>hd</code></dt>

--- a/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
@@ -145,14 +145,14 @@ Output the corresponding argument as a character, a string, or a number. This fi
 
 
 <dl>
-<dt><a id="c"></a><a id="C"></a><code>c</code></dt>
+<dt><a id="c"></a></a><code>c</code></dt>
 <dd>
-Single character. This value is interpreted as type <b>WCHAR</b> if the calling application defines Unicode and as type <b>__wchar_t</b> otherwise.
+Single character. This value is interpreted as type <b>WCHAR</b>.
 
 </dd>
-<dt><a id="C"></a><a id="c"></a><code>C</code></dt>
+<dt><a id="C"></a></a><code>C</code></dt>
 <dd>
-Single character. This value is interpreted as type <b>__wchar_t</b> if the calling application defines Unicode and as type <b>WCHAR</b> otherwise.
+Single character. This value is interpreted as type <b>CHAR</b>.
 
 </dd>
 <dt><a id="d"></a><a id="D"></a><code>d</code></dt>
@@ -162,7 +162,7 @@ Signed decimal integer. This value is equivalent to <code>i</code>.
 </dd>
 <dt><a id="hc__hC"></a><a id="hc__hc"></a><a id="HC__HC"></a><code>hc</code>, <code>hC</code></dt>
 <dd>
-Single character. The <b>wsprintf</b> function ignores character arguments with a numeric value of zero. This value is always interpreted as type <b>__wchar_t</b>, even when the calling application defines Unicode.
+Single character. The <b>wsprintf</b> function ignores character arguments with a numeric value of zero. This value is always interpreted as type <b>CHAR</b>, even when the calling application defines Unicode.
 
 </dd>
 <dt><a id="hd"></a><a id="HD"></a><code>hd</code></dt>


### PR DESCRIPTION
After the split to A and W documentation the types for characters are wrong. This fixes it in terms of A vs W and what those specific functions do and not what the old T based documentation used to say. This means any talk about Unicode defines is irrelevant but I left some of the other references to it intact.


Code used to verify:
```C++
char nb[42];
wsprintfA(nb, "%hc|%d|%lC", 0x1152, 42, 0x1152),MessageBoxA(0,nb,0,0);
WCHAR wb[42];
wsprintfW(wb, L"%hc|%d|%lC", 0x1152, 42, 0x1152),MessageBoxW(0,wb,0,0);
```