### PR TITLE
fix parameter name in RegisterHotKey documentation

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-registerhotkey.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerhotkey.md
@@ -145,7 +145,7 @@ Either WINDOWS key was held down. These keys are labeled with the Windows logo. 
 </tr>
 </table>
 
-### -param vk [in]
+### -param uVirtKey [in]
 
 Type: <b>UINT</b>
 


### PR DESCRIPTION
Another parameter mentions "uVirtKey", but the parameter was defined
as "vk" here.