### PR TITLE
Update nf-synchapi-waitonaddress.md

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-waitonaddress.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitonaddress.md
@@ -107,7 +107,7 @@ ULONG UndesiredValue;
 UndesiredValue = 0;
 CapturedValue = g_TargetValue;
 while (CapturedValue == UndesiredValue) {
-      WaitOnAddress(&amp;g_TargetValue, &amp;UndesiredValue, sizeof(ULONG), INFINITE);
+      WaitOnAddress(&g_TargetValue, &UndesiredValue, sizeof(ULONG), INFINITE);
       CapturedValue = g_TargetValue;
 }
 


### PR DESCRIPTION
Example corrected. HTML &amp was shown instead of the C++ &-operator when opening the page on docs.microsoft.com.