### PR TITLE
Update nf-winuser-getrawinputbuffer.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getrawinputbuffer.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getrawinputbuffer.md
@@ -57,7 +57,9 @@ Performs a buffered read of the raw input messages data found in the calling thr
 
 Type: **PRAWINPUT**
 
-A pointer to a buffer of [RAWINPUT](ns-winuser-rawinput.md) structures that contain the raw input data. If **NULL**, size of the first raw input message data (minimum required buffer), in bytes, is returned in \**pcbSize*.
+A pointer to a buffer of [RAWINPUT](ns-winuser-rawinput.md) structures that contain the raw input data. Buffer should be aligned on a pointer boundary, which is a **DWORD** on 32-bit architectures and a **QWORD** on 64-bit architectures.
+
+If **NULL**, size of the first raw input message data (minimum required buffer), in bytes, is returned in \**pcbSize*.
 
 ### -param pcbSize [in, out]
 


### PR DESCRIPTION
NEXTRAWINPUTBLOCK is not working if pData isn't aligned on DWORD/QWORD boundary.