### PR TITLE
Corrections and clarifications for FILE_RENAME_INFO

### DIFF
--- a/sdk-api-src/content/winbase/ns-winbase-file_rename_info.md
+++ b/sdk-api-src/content/winbase/ns-winbase-file_rename_info.md
@@ -73,8 +73,7 @@ This field is used when **SetFileInformationByHandle**'s *FileInformationClass* 
 
 ### -field RootDirectory
 
-If the file is not being moved to a different directory, or if the *FileName* member contains the full path to the target file, this member is
-**NULL**. Otherwise, it is a handle for the root directory under which the file will reside after it is renamed.
+This field should be set to NULL.
 
 ### -field FileNameLength
 
@@ -82,9 +81,11 @@ The size of **FileName** in bytes, not including the NUL-termination.
 
 ### -field FileName
 
-A NUL-terminated wide-character string containing the new name for the file. If the *RootDirectory* member is **NULL** and the file is being moved
-to a different directory, this member specifies the full pathname to be assigned to the file. Otherwise, it specifies only the file name or a
-relative pathname.
+A NUL-terminated wide-character string containing the new path to the file. The value can be one of the following:
+
+- An absolute path (drive, directory, and filename).
+- A path relative to the process's current directory.
+- The new name of an NTFS file stream, starting with `:`.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/ns-winbase-file_rename_info.md
+++ b/sdk-api-src/content/winbase/ns-winbase-file_rename_info.md
@@ -52,10 +52,9 @@ api_name:
 
 # FILE_RENAME_INFO structure
 
-
 ## -description
 
-Contains the name to which the file should be renamed. Use only when calling 
+Contains the target name to which the source file should be renamed. Use only when calling 
    <a href="/windows/desktop/api/fileapi/nf-fileapi-setfileinformationbyhandle">SetFileInformationByHandle</a>.
 
 ## -struct-fields
@@ -64,30 +63,31 @@ Contains the name to which the file should be renamed. Use only when calling
 
 ### -field DUMMYUNIONNAME.ReplaceIfExists
 
-<b>TRUE</b> to replace the file; otherwise, <b>FALSE</b>.
+This field is used when **SetFileInformationByHandle**'s *FileInformationClass* parameter is set to **FileRenameInfo**. If this field is **TRUE**
+and the target file exists then the target file will be replaced by the source file. If this field is **FALSE** and the target file exists then
+the operation will return an error.
 
 ### -field DUMMYUNIONNAME.Flags
 
-### -field ReplaceIfExists
-
-<b>TRUE</b> to replace the file; otherwise, <b>FALSE</b>.
+This field is used when **SetFileInformationByHandle**'s *FileInformationClass* parameter is set to **FileRenameInfoEx**.
 
 ### -field RootDirectory
 
-A handle to the root directory in which the file to be renamed is located.
+If the file is not being moved to a different directory, or if the *FileName* member contains the full path to the target file, this member is
+**NULL**. Otherwise, it is a handle for the root directory under which the file will reside after it is renamed.
 
 ### -field FileNameLength
 
-The size of <b>FileName</b> in bytes.
+The size of **FileName** in bytes, not including the NUL-termination.
 
 ### -field FileName
 
-The new file name.
+A NUL-terminated wide-character string containing the new name for the file. If the *RootDirectory* member is **NULL** and the file is being moved
+to a different directory, this member specifies the full pathname to be assigned to the file. Otherwise, it specifies only the file name or a
+relative pathname.
 
 ## -see-also
 
 <a href="/windows/desktop/api/minwinbase/ne-minwinbase-file_info_by_handle_class">FILE_INFO_BY_HANDLE_CLASS</a>
-
-
 
 <a href="/windows/desktop/api/fileapi/nf-fileapi-setfileinformationbyhandle">SetFileInformationByHandle</a>


### PR DESCRIPTION
Remove duplicated ReplaceIfExists field.

Since ReplaceIfExists and Flags are in a union, we need to explain when each one is used. ReplaceIfExists is used for FileRenameInfo, and Flags is used for FileRenameInfoEx.

Ideally the accepted values for Flags should be documented (they're listed in https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_rename_information), but I'm not sure which flags should be shown here or the version of windows when each flag becomes valid, so I'm not going to add that.

Clarify the usage of RootDirectory. Most users should set it to NULL. Wording is taken from https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_rename_information.

FileNameLength needs to be clearly documented as the FileName size in bytes without the NUL termination. (Technical note: at present this value is only used in some code paths. In other code paths, FileName needs to be nul-terminated.)

Clarify that FileName MUST be NUL-terminated. Some code paths use the NUL-termination and other code paths use FileNameLength, so both must be set correctly.