### PR TITLE
Update nc-fwpmu-ipsec_sa_context_callback0.md

### DIFF
--- a/sdk-api-src/content/fwpmu/nc-fwpmu-ipsec_sa_context_callback0.md
+++ b/sdk-api-src/content/fwpmu/nc-fwpmu-ipsec_sa_context_callback0.md
@@ -45,12 +45,9 @@ api_name:
  - IPSEC_SA_CONTEXT_CALLBACK0
 ---
 
-# IPSEC_SA_CONTEXT_CALLBACK0 callback function
-
-
 ## -description
 
-The <b>IPSEC_SA_CONTEXT_CALLBACK0</b> function is used to add custom behavior to the IPsec security association (SA) context  subscription process.
+The <b>IPSEC_SA_CONTEXT_CALLBACK0</b> function is used to add custom behavior to the IPsec security association (SA) context subscription process.
 
 ## -parameters
 
@@ -58,18 +55,18 @@ The <b>IPSEC_SA_CONTEXT_CALLBACK0</b> function is used to add custom behavior to
 
 Type: <b>void*</b>
 
-Optional context pointer. It contains the value of the <i>context</i> parameter of the <a href="/windows/desktop/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a> function.
+Optional context pointer. It contains the value of the <i>context</i> parameter of the <a href="/windows/win32/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a> function.
 
 ### -param change [in]
 
-Type: <b>const <a href="https://docs.microsoft.com/en-us/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_change0">IPSEC_SA_CONTEXT_CHANGE0</a>*</b>
+Type: **const [IPSEC_SA_CONTEXT_CHANGE0](IPSEC_SA_CONTEXT_CHANGE0)\***
 
 The IPsec SA context information.
 
 ## -remarks
 
-Call <a href="/windows/desktop/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a> to register this callback function.
+Call <a href="/windows/win32/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a> to register this callback function.
 
 ## -see-also
 
-<a href="/windows/desktop/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a>
+<a href="/windows/win32/api/fwpmu/nf-fwpmu-ipsecsacontextsubscribe0">IPsecSaContextSubscribe0</a>

--- a/sdk-api-src/content/fwpmu/nc-fwpmu-ipsec_sa_context_callback0.md
+++ b/sdk-api-src/content/fwpmu/nc-fwpmu-ipsec_sa_context_callback0.md
@@ -62,7 +62,7 @@ Optional context pointer. It contains the value of the <i>context</i> parameter 
 
 ### -param change [in]
 
-Type: <b>const <a href="/windows/desktop/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_change0_">IPSEC_SA_CONTEXT_CHANGE0</a>*</b>
+Type: <b>const <a href="https://docs.microsoft.com/en-us/windows/win32/api/ipsectypes/ns-ipsectypes-ipsec_sa_context_change0">IPSEC_SA_CONTEXT_CHANGE0</a>*</b>
 
 The IPsec SA context information.
 


### PR DESCRIPTION
The link pointing to IPSEC_SA_CONTEXT_CHANGE0 was invalid resulting in a 404 error.  This changes the link to the documentation for that structure where it currently exists.