### PR TITLE
[CreateFileMappingW] combining flProtect SEC_ flags

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-createfilemappingw.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-createfilemappingw.md
@@ -244,7 +244,7 @@ This attribute has no effect for file mapping objects that are backed by executa
 
 <b>SEC_COMMIT</b> cannot be combined with <b>SEC_RESERVE</b>.
 
-If no attribute is specified, <b>SEC_COMMIT</b> is assumed.
+If no attribute is specified, <b>SEC_COMMIT</b> is assumed. However, <b>SEC_COMMIT</b> must be explicitly specified when combining it with another <b>SEC_</b> attribute that requires it.
 
 </td>
 </tr>


### PR DESCRIPTION

https://github.com/MicrosoftDocs/sdk-api/blob/f6ac37c61312f6cc56f7ff921f8a0bdcf6ec4455/sdk-api-src/content/memoryapi/nf-memoryapi-createfilemappingw.md#L247

Proposed revision:
>`... However, <b>SEC_COMMIT</b> must be explicitly specified when combining it with another <b>SEC_</b> attribute that requires it.`

It's only true that `SEC_COMMIT` is implied if there are not other `SEC_` flags **or'd** into the `pageProtection` parameter value. 

For example, in a situation where `PAGE_READONLY` by itself works fine (yes, in this case implying `SEC_COMMIT` as currently noted), and where `PAGE_READONLY | SEC_COMMIT | SEC_NOCACHE` also works, given these same conditions `PAGE_READONLY | SEC_NOCACHE` will fail with 0x80004005 "The parameter is incorrect".
 
An alternate wording for the end of my revision might be *"...when combining it with another &lt;b&gt;SEC_&lt;/b&gt; attribute where it is required."*  The "requirements" this alludes to are clearly stated as such in the current documentation, throughout the remainder of the section on the `flProtect` parameter.