### PR TITLE
Update nf-netfw-networkisolationenumappcontainers.md

### DIFF
--- a/sdk-api-src/content/netfw/nf-netfw-networkisolationenumappcontainers.md
+++ b/sdk-api-src/content/netfw/nf-netfw-networkisolationenumappcontainers.md
@@ -88,7 +88,7 @@ ERROR_OUTOFMEMORY will be returned if memory is unavailable.
 
 ## -remarks
 
-If no app containers are installed on the system, ERROR_SUCCESS will still be returned (and <i>ppPublicAppCs</i> will be empty).
+If no app containers are installed on the system, ERROR_SUCCESS will still be returned (and <i>ppPublicAppCs</i> will be empty).  If ppPublicAppCs is not empty, <a href="https://docs.microsoft.com/en-us/windows/win32/api/netfw/nf-netfw-networkisolationfreeappcontainers">NetworkIsolationFreeAppContainers</a> should be used to free the memory when you are done using it.
 
 ## -see-also
 


### PR DESCRIPTION
We had a software vendor ask about this, and it isn't clear to me from the current doc description what to do.  Looking at our current implementation, it appears that NetworkIsolationFreeAppContainers would be the correct call for freeing the memory.  Not freeing it in any way results in a memory leak.