### PR TITLE
Fixing a few problematic yaml headers

### DIFF
--- a/sdk-api-src/content/aviriff/ns-aviriff-avistreamheader.md
+++ b/sdk-api-src/content/aviriff/ns-aviriff-avistreamheader.md
@@ -2,7 +2,7 @@
 UID: NS:aviriff._avistreamheader
 title: AVISTREAMHEADER (aviriff.h)
 description: The AVISTREAMHEADER structure contains information about one stream in an AVI file.
-helpviewer_keywords: [""auds","mids","txts","vids","AVISF_DISABLED","AVISF_VIDEO_PALCHANGES","AVISTREAMHEADER","AVISTREAMHEADER structure [DirectShow]","AVISTREAMHEADERStructure","_avistreamheader","avifmt/AVISTREAMHEADER","dshow.avistreamheader""]
+helpviewer_keywords: ["auds","mids","txts","vids","AVISF_DISABLED","AVISF_VIDEO_PALCHANGES","AVISTREAMHEADER","AVISTREAMHEADER structure [DirectShow]","AVISTREAMHEADERStructure","_avistreamheader","avifmt/AVISTREAMHEADER","dshow.avistreamheader"]
 old-location: dshow\avistreamheader.htm
 tech.root: dshow
 ms.assetid: f07c28ac-2dd0-428a-a94a-32aec2bb0854

--- a/sdk-api-src/content/bdaiface/nf-bdaiface-ibda_dridrmservice-getpairingstatus.md
+++ b/sdk-api-src/content/bdaiface/nf-bdaiface-ibda_dridrmservice-getpairingstatus.md
@@ -2,12 +2,12 @@
 UID: NF:bdaiface.IBDA_DRIDRMService.GetPairingStatus
 title: IBDA_DRIDRMService::GetPairingStatus (bdaiface.h)
 description: The GetPairingStatus method gets the Digital Rights Management (DRM) pairing status for a Media Transform Device (MTD) in a graph under the Protected Broadcast Driver Architecture (PBDA).
-helpviewer_keywords: ["""Green"",""Orange"",""Red"","GetPairingStatus","GetPairingStatus method [DirectShow]","GetPairingStatus method [DirectShow]","IBDA_DRIDRMService interface","IBDA_DRIDRMService interface [DirectShow]","GetPairingStatus method","IBDA_DRIDRMService.GetPairingStatus","IBDA_DRIDRMService::GetPairingStatus","bdaiface/IBDA_DRIDRMService::GetPairingStatus","mstv.ibda_dridrmservice_getpairingstatus""]
+helpviewer_keywords: ["Green","Orange","Red","GetPairingStatus","GetPairingStatus method [DirectShow]","GetPairingStatus method [DirectShow]","IBDA_DRIDRMService interface","IBDA_DRIDRMService interface [DirectShow]","GetPairingStatus method","IBDA_DRIDRMService.GetPairingStatus","IBDA_DRIDRMService::GetPairingStatus","bdaiface/IBDA_DRIDRMService::GetPairingStatus","mstv.ibda_dridrmservice_getpairingstatus"]
 old-location: mstv\ibda_dridrmservice_getpairingstatus.htm
 tech.root: mstv
 ms.assetid: 01918e99-17e6-4c24-bb85-ba71cf68cf09
 ms.date: 12/05/2018
-ms.keywords: ""Green", "Orange", "Red", GetPairingStatus, GetPairingStatus method [DirectShow], GetPairingStatus method [DirectShow],IBDA_DRIDRMService interface, IBDA_DRIDRMService interface [DirectShow],GetPairingStatus method, IBDA_DRIDRMService.GetPairingStatus, IBDA_DRIDRMService::GetPairingStatus, bdaiface/IBDA_DRIDRMService::GetPairingStatus, mstv.ibda_dridrmservice_getpairingstatus"
+ms.keywords: Green, Orange, Red, GetPairingStatus, "GetPairingStatus method [DirectShow]", "GetPairingStatus method [DirectShow]", IBDA_DRIDRMService interface, "IBDA_DRIDRMService interface [DirectShow]", GetPairingStatus method, IBDA_DRIDRMService.GetPairingStatus, IBDA_DRIDRMService::GetPairingStatus, bdaiface/IBDA_DRIDRMService::GetPairingStatus, mstv.ibda_dridrmservice_getpairingstatus
 req.header: bdaiface.h
 req.include-header: 
 req.target-type: Windows

--- a/sdk-api-src/content/d3d12video/ns-d3d12video-d3d12_video_encoder_level_tier_constraints_hevc.md
+++ b/sdk-api-src/content/d3d12video/ns-d3d12video-d3d12_video_encoder_level_tier_constraints_hevc.md
@@ -1,6 +1,6 @@
 ---
 UID: NS:d3d12video.D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC
-tech.root:mf
+tech.root: mf
 title: D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC
 ms.date: 06/04/2021
 targetos: Windows

--- a/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
+++ b/sdk-api-src/content/d3dcommon/nn-d3dcommon-id3ddestructionotifier.md
@@ -1,7 +1,7 @@
 ---
 UID: NN:d3dcommon.ID3DDestructionNotifier
 title: ID3DDestructionNotifier (d3dcommon.h)
-description: **ID3DDestructionNotifier** is an interface that you can use to register for callbacks when a Direct3D nano-COM object is destroyed.
+description: "**ID3DDestructionNotifier** is an interface that you can use to register for callbacks when a Direct3D nano-COM object is destroyed."
 helpviewer_keywords: ["ID3DDestructionNotifier","ID3DDestructionNotifier interface [Direct3D]","ID3DDestructionNotifier interface [Direct3D]","described","d3dcommon/ID3DDestructionNotifier","direct3d.id3ddestructionnotifier"]
 tech.root: direct3d11
 ms.date: 10/06/2020

--- a/sdk-api-src/content/diagnosticdataquery/nf-diagnosticdataquery-ddqgetdiagnosticrecordlocaletags.md
+++ b/sdk-api-src/content/diagnosticdataquery/nf-diagnosticdataquery-ddqgetdiagnosticrecordlocaletags.md
@@ -3,7 +3,7 @@ UID: NF:diagnosticdataquery.DdqGetDiagnosticRecordLocaleTags
 title: DdqGetDiagnosticRecordLocaleTags
 ms.date: 8/19/2019
 ms.keywords: DdqGetDiagnosticRecordLocaleTags
-description: Fetches information for all known tags under the specified locale and provides a handle, HDIAGNOSTIC_EVENT_TAG_DESCRIPTION, to the data. An example locale would be “en-US”. An example return value is a DIAGNOSTIC_EVENT_TAG_DESCRIPTION resource that contains the following data: tag: 11, name: “Device Connectivity and Configuration” and description: “Data that describes the connections and configuration of the devices connected to the service and the network, including device identifiers (e.g IP addresses) configuration, setting and performance”.
+description: "Fetches information for all known tags under the specified locale and provides a handle, HDIAGNOSTIC_EVENT_TAG_DESCRIPTION, to the data. An example locale would be “en-US”. An example return value is a DIAGNOSTIC_EVENT_TAG_DESCRIPTION resource that contains the following data: tag: 11, name: “Device Connectivity and Configuration” and description: “Data that describes the connections and configuration of the devices connected to the service and the network, including device identifiers (e.g IP addresses) configuration, setting and performance”."
 ms.localizationpriority: low
 tech.root: security
 targetos: Windows

--- a/sdk-api-src/content/ras/nf-ras-rasvalidateentrynamew.md
+++ b/sdk-api-src/content/ras/nf-ras-rasvalidateentrynamew.md
@@ -2,7 +2,7 @@
 UID: NF:ras.RasValidateEntryNameW
 title: RasValidateEntryNameW function (ras.h)
 description: The RasValidateEntryName function validates the format of a connection entry name. The name must contain at least one non-white-space alphanumeric character.
-helpviewer_keywords: ["RasValidateEntryName","RasValidateEntryName function [RAS]","RasValidateEntryNameA","RasValidateEntryNameW","\","_ras_rasvalidateentryname","ras/RasValidateEntryName","ras/RasValidateEntryNameA","ras/RasValidateEntryNameW","rras.rasvalidateentryname"]
+helpviewer_keywords: ["RasValidateEntryName","RasValidateEntryName function [RAS]","RasValidateEntryNameA","RasValidateEntryNameW","\\","_ras_rasvalidateentryname","ras/RasValidateEntryName","ras/RasValidateEntryNameA","ras/RasValidateEntryNameW","rras.rasvalidateentryname"]
 old-location: rras\rasvalidateentryname.htm
 tech.root: RRAS
 ms.assetid: c70ad0d4-6bc1-4716-9a8e-0fbeb55b7560

--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-idesktopwallpaper-getslideshow.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-idesktopwallpaper-getslideshow.md
@@ -2,7 +2,8 @@
 UID: NF:shobjidl_core.IDesktopWallpaper.GetSlideshow
 title: IDesktopWallpaper::GetSlideshow (shobjidl_core.h)
 description: Gets the path to the directory where the slideshow images are stored.
-helpviewer_keywords: ["GetSlideshow","GetSlideshow method [Windows Shell]","GetSlideshow method [Windows Shell]","IDesktopWallpaper interface","IDesktopWallpaper interface [Windows Shell]","GetSlideshow method","IDesktopWallpaper.GetSlideshow","IDesktopWallpaper::GetSlideshow","shell.IDesktopWallpaper_GetSlideshow","shobjidl_core/IDesktopWallpaper::GetSlideshow"]old-location: shell\IDesktopWallpaper_GetSlideshow.htm
+helpviewer_keywords: ["GetSlideshow","GetSlideshow method [Windows Shell]","GetSlideshow method [Windows Shell]","IDesktopWallpaper interface","IDesktopWallpaper interface [Windows Shell]","GetSlideshow method","IDesktopWallpaper.GetSlideshow","IDesktopWallpaper::GetSlideshow","shell.IDesktopWallpaper_GetSlideshow","shobjidl_core/IDesktopWallpaper::GetSlideshow"]
+old-location: shell\IDesktopWallpaper_GetSlideshow.htm
 tech.root: shell
 ms.assetid: A5660D7F-C42A-4587-B319-B47441CD37AB
 ms.date: 12/05/2018

--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpreaddataex.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpreaddataex.md
@@ -1,4 +1,4 @@
-    ---
+---
 UID: NF:winhttp.WinHttpReadDataEx
 title: WinHttpReadDataEx
 description: Reads data from a handle opened by the [WinHttpOpenRequest](/windows/win32/api/winhttp/nf-winhttp-winhttpopenrequest) function.

--- a/sdk-api-src/content/winternl/nf-winternl-ntwaitforsingleobject.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntwaitforsingleobject.md
@@ -2,7 +2,7 @@
 UID: NF:winternl.NtWaitForSingleObject
 title: NtWaitForSingleObject function (winternl.h)
 description: Deprecated. Waits until the specified object attains a state of signaled. NtWaitForSingleObject is superseded by WaitForSingleObject.
-helpviewer_keywords: [""NtWaitForSingleObject","FALSE","NtWaitForSingleObject","NtWaitForSingleObject function [Windows API]","TRUE","winprog.ntwaitforsingleobject","winternl/NtWaitForSingleObject","winui.ntwaitforsingleobject""]
+helpviewer_keywords: ["NtWaitForSingleObject","FALSE","NtWaitForSingleObject","NtWaitForSingleObject function [Windows API]","TRUE","winprog.ntwaitforsingleobject","winternl/NtWaitForSingleObject","winui.ntwaitforsingleobject"]
 old-location: winprog\ntwaitforsingleobject.htm
 tech.root: winprog
 ms.assetid: VS|winui|~\winui\windowsuserinterface\lowlevelclientsupport\misc\ntwaitforsingleobject.htm


### PR DESCRIPTION
A few of the YAML headers were "invalid" leading to problems when attempting to parse them using tools like YamlDotNet.