### PR TITLE
Add info about array delimiter for D3D compilation

### DIFF
--- a/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
+++ b/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile.md
@@ -76,7 +76,7 @@ Type: <b><a href="/windows/desktop/WinProg/windows-data-types">LPCSTR</a></b>
 
 Type: <b>const <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a>*</b>
 
- An array of NULL-terminated macro definitions (see <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a>).
+An optional array of <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a> structures that define shader macros. Each macro definition contains a name and a null-terminated definition. If not used, set to <b>NULL</b>. The last structure in the array serves as a terminator and must have all members set to <b>NULL</b>.
 
 ### -param pInclude [in, optional]
 

--- a/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile2.md
+++ b/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompile2.md
@@ -76,7 +76,7 @@ An optional pointer to a constant null-terminated string containing the name tha
 
 Type: <b>const <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a>*</b>
 
-An optional array of <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a> structures that define shader macros. Each macro definition contains a name and a NULL-terminated definition. If not used, set to <b>NULL</b>.
+An optional array of <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a> structures that define shader macros. Each macro definition contains a name and a null-terminated definition. If not used, set to <b>NULL</b>. The last structure in the array serves as a terminator and must have all members set to <b>NULL</b>.
 
 ### -param pInclude [in, optional]
 

--- a/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompilefromfile.md
+++ b/sdk-api-src/content/d3dcompiler/nf-d3dcompiler-d3dcompilefromfile.md
@@ -60,7 +60,7 @@ A pointer to a constant null-terminated string that contains  the name of the fi
 
 ### -param pDefines [in, optional]
 
-An optional array of <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a> structures that define shader macros. Each macro definition contains a name and a NULL-terminated definition. If not used, set to <b>NULL</b>.
+An optional array of <a href="/windows/desktop/api/d3dcommon/ns-d3dcommon-d3d_shader_macro">D3D_SHADER_MACRO</a> structures that define shader macros. Each macro definition contains a name and a null-terminated definition. If not used, set to <b>NULL</b>. The last structure in the array serves as a terminator and must have all members set to <b>NULL</b>.
 
 ### -param pInclude [in, optional]
 


### PR DESCRIPTION
Before, there was no indication of how an array parameter was delimited for these functions, potentially leading to confusing access violations. Added a sentence each to indicate how this parameter must be used.