### PR TITLE
Correct minimum supported Build

### DIFF
--- a/sdk-api-src/content/mfidl/nn-mfidl-imfextendedcameracontroller.md
+++ b/sdk-api-src/content/mfidl/nn-mfidl-imfextendedcameracontroller.md
@@ -14,8 +14,8 @@ req.include-header:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 19041
+req.target-min-winversvr: Windows 10 Build 19041
 req.target-type: 
 req.unicode-ansi: 
 topic_type:


### PR DESCRIPTION
IMFExtendedCameraController - Win32 apps | Microsoft Docs is available in 19041+, while the MSDN doc says it is available only Build 20348 and up.