### PR TITLE
Document return value of PathUnquoteSpaces

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathunquotespacesa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathunquotespacesa.md
@@ -68,7 +68,7 @@ A pointer to a null-terminated string of length MAX_PATH that contains the path.
 
 ## -returns
 
-No return value.
+TRUE if the string gets unquoted; otherwise, FALSE
 
 ## -remarks
 


### PR DESCRIPTION
The documentation claimed to the function return no value, but during an experiment with a sample code the function return behaves like PathQuoteSpaces.