### PR TITLE
Fix minimum OS version for IsWow64Process2

### DIFF
--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process2.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process2.md
@@ -9,25 +9,25 @@ ms.assetid: 77B4E3C8-F9DE-4674-9CEA-9C81AEEB393C
 ms.date: 12/05/2018
 ms.keywords: IsWow64Process2, IsWow64Process2 function, base.iswow64process2, wow64apiset/IsWow64Process2
 req.header: wow64apiset.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
 req.target-min-winverclnt: Windows 10, version 1709 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2016, version1709 [desktop apps \| UWP apps]
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
+req.target-min-winversvr: Windows Server 2016, version 1709 [desktop apps \| UWP apps]
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
 req.lib: Kernel32.lib
 req.dll: Kernel32.dll
-req.irql: 
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - IsWow64Process2
@@ -57,7 +57,7 @@ api_name:
 
 ## -description
 
-Determines whether the specified process is running under 
+Determines whether the specified process is running under
 <a href="/windows/desktop/WinProg64/running-32-bit-applications">WOW64</a>; also returns additional machine process and architecture information.
 
 ## -parameters
@@ -78,7 +78,7 @@ On success, returns a pointer to a possible <a href="/windows/desktop/SysInfo/im
 
 If the function succeeds, the return value is a nonzero value.
 
-If the function fails, the return value is zero. To get extended error information, call 
+If the function fails, the return value is zero. To get extended error information, call
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process2.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process2.md
@@ -11,8 +11,8 @@ ms.keywords: IsWow64Process2, IsWow64Process2 function, base.iswow64process2, wo
 req.header: wow64apiset.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1511 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10, version 1709 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016, version1709 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
The docs have been wrong for years. Win10 v1511 is not the minimum OS, it is Win10 v1709.

See also dotnet/runtime#26612 (comment)

> I think the documentation doesn't correctly reflect the version where this function is available; IsWow64Process2 is actually only available starting with RS3 (Windows 10 Version 1709, Build 16299).