### PR TITLE
Improve parameter names for IDirectDraw7::CreateClipper

### DIFF
--- a/sdk-api-src/content/ddraw/nf-ddraw-idirectdraw7-createclipper.md
+++ b/sdk-api-src/content/ddraw/nf-ddraw-idirectdraw7-createclipper.md
@@ -54,15 +54,15 @@ Creates a DirectDrawClipper object.
 
 ## -parameters
 
-### -param unnamedParam1 [in]
+### -param dwFlags [in]
 
 Currently not used and must be set to 0.
 
-### -param unnamedParam2 [out]
+### -param lplpDDClipper [out]
 
 Address of a variable to be set to a valid <a href="/windows/desktop/api/ddraw/nn-ddraw-idirectdrawclipper">IDirectDrawClipper</a> interface pointer if the call succeeds.
 
-### -param unnamedParam3 [in]
+### -param pUnkOuter [in]
 
 Allows for future compatibility with COM aggregation features. Currently this method returns an error if this parameter is not NULL.
 


### PR DESCRIPTION
For this page:
https://docs.microsoft.com/en-us/windows/win32/api/ddraw/nf-ddraw-idirectdraw7-createclipper

Something systemic took these parameters out, see here where we used to have them
https://docs.microsoft.com/en-us/previous-versions/ms785026(v=vs.85)

I don't know how to fix the systemic issue, this fixes the issue on this one page.