### PR TITLE
Clarifying remarks about pitch, yaw, and roll

### DIFF
--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyaw.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyaw.md
@@ -76,7 +76,8 @@ Angles are measured clockwise when looking along the rotation axis toward the or
 
 The order of transformations is roll first, then pitch, and then yaw. The rotations are all applied in the global coordinate frame.
 
-> This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
+> [!NOTE]
+> This function takes x-axis, y-axis, and z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games, since it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (for example, *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyaw.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyaw.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixRotationRollPitchYaw(float,fl
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixRotationRollPitchYaw, XMMatrixRotationRollPitchYaw, XMMatrixRotationRollPitchYaw method [DirectX Math Support APIs], dxmath.xmmatrixrotationrollpitchyaw
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixRotationRollPitchYaw
@@ -75,6 +75,8 @@ Returns the rotation matrix.
 Angles are measured clockwise when looking along the rotation axis toward the origin. This is a left-handed coordinate system. To use right-handed coordinates, negate all three angles.
 
 The order of transformations is roll first, then pitch, and then yaw. The rotations are all applied in the global coordinate frame.
+
+> This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyawfromvector.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyawfromvector.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.matrix.XMMatrixRotationRollPitchYawFromVecto
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMMatrixRotationRollPitchYawFromVector, XMMatrixRotationRollPitchYawFromVector, XMMatrixRotationRollPitchYawFromVector method [DirectX Math Support APIs], dxmath.xmmatrixrotationrollpitchyawfromvector
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMMatrixRotationRollPitchYawFromVector
@@ -56,7 +56,7 @@ Builds a rotation matrix based on a vector containing the Euler angles (pitch, y
 
 ### -param Angles [in]
 
-3D vector containing the Euler angles in the order pitch, then yaw, and then roll.
+3D vector containing the Euler angles in the order x-axis (pitch), then y-axis (yaw), and then z-axis (roll). The W element is ignored.
 
 ## -returns
 
@@ -66,8 +66,9 @@ Returns the rotation matrix.
 
 Angles are measured clockwise when looking along the rotation axis toward the origin. This is a left-handed coordinate system. To use right-handed coordinates, negate all three angles.
 
-The order of transformations is roll first, then pitch, and then yaw. The rotations are all applied in the global
-   coordinate frame.
+The order of transformations is roll first, then pitch, and then yaw. The rotations are all applied in the global coordinate frame.
+
+> This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyawfromvector.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmmatrixrotationrollpitchyawfromvector.md
@@ -68,7 +68,8 @@ Angles are measured clockwise when looking along the rotation axis toward the or
 
 The order of transformations is roll first, then pitch, and then yaw. The rotations are all applied in the global coordinate frame.
 
-> This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
+> [!NOTE]
+> This function takes x-axis, y-axis, and z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games, since it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (for example, *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyaw.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyaw.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.quaternion.XMQuaternionRotationRollPitchYaw(
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMQuaternionRotationRollPitchYaw, XMQuaternionRotationRollPitchYaw, XMQuaternionRotationRollPitchYaw method [DirectX Math Support APIs], dxmath.xmquaternionrotationrollpitchyaw
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMQuaternionRotationRollPitchYaw
@@ -72,13 +72,13 @@ Returns the rotation quaternion.
 
 ## -remarks
 
-The DirectXMath quaternion functions use an XMVECTOR 4-vector to represent quaternions, 
-    where the X, Y, and Z components are the vector part and the W component is the scalar part.
+The DirectXMath quaternion functions use an XMVECTOR 4-vector to represent quaternions, where the X, Y, and Z components are the vector part and the W component is the scalar part.
 
 Angles are measured clockwise when looking along the rotation axis toward the origin. This is a left-handed coordinate system. To use right-handed coordinates, negate all three angles.
 
-The order of transformations is roll first, then pitch, then yaw. The rotations are all applied in the global coordinate
-   frame.
+The order of transformations is roll first, then pitch, then yaw. The rotations are all applied in the global coordinate frame.
+
+> This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyawfromvector.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyawfromvector.md
@@ -70,7 +70,8 @@ Angles are measured clockwise when looking along the rotation axis toward the or
 
 The order of transformations is roll first, then pitch, then yaw. The rotations are all applied in the global coordinate frame.
 
- > This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
+> [!NOTE]
+> This function takes x-axis, y-axis, and z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games, since it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (for example, *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.

--- a/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyawfromvector.md
+++ b/sdk-api-src/content/directxmath/nf-directxmath-xmquaternionrotationrollpitchyawfromvector.md
@@ -9,25 +9,25 @@ ms.assetid: M:Microsoft.directx_sdk.quaternion.XMQuaternionRotationRollPitchYawF
 ms.date: 12/05/2018
 ms.keywords: Use DirectX..XMQuaternionRotationRollPitchYawFromVector, XMQuaternionRotationRollPitchYawFromVector, XMQuaternionRotationRollPitchYawFromVector method [DirectX Math Support APIs], dxmath.xmquaternionrotationrollpitchyawfromvector
 req.header: directxmath.h
-req.include-header: 
+req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
-req.unicode-ansi: 
-req.idl: 
-req.max-support: 
+req.target-min-winverclnt:
+req.target-min-winversvr:
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
+req.unicode-ansi:
+req.idl:
+req.max-support:
 req.namespace: Use DirectX.
-req.assembly: 
-req.type-library: 
-req.lib: 
-req.dll: 
-req.irql: 
+req.assembly:
+req.type-library:
+req.lib:
+req.dll:
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - XMQuaternionRotationRollPitchYawFromVector
@@ -56,7 +56,7 @@ Computes a rotation quaternion based on a vector containing the Euler angles (pi
 
 ### -param Angles [in]
 
-3D vector containing the Euler angles in the order pitch, yaw, roll.
+3D vector containing the Euler angles in the order x-axis (pitch), then y-axis (yaw), and then z-axis (roll). The W element is ignored.
 
 ## -returns
 
@@ -64,13 +64,13 @@ Returns the rotation quaternion.
 
 ## -remarks
 
-The DirectXMath quaternion functions use an XMVECTOR 4-vector to represent quaternions, 
-    where the X, Y, and Z components are the vector part and the W component is the scalar part.
+The DirectXMath quaternion functions use an XMVECTOR 4-vector to represent quaternions, where the X, Y, and Z components are the vector part and the W component is the scalar part.
 
 Angles are measured clockwise when looking along the rotation axis toward the origin. This is a left-handed coordinate system. To use right-handed coordinates, negate all three angles.
 
-The order of transformations is roll first, then pitch, then yaw. The rotations are all applied in the global coordinate
-   frame.
+The order of transformations is roll first, then pitch, then yaw. The rotations are all applied in the global coordinate frame.
+
+ > This function takes x-axis, y-axis, z-axis angles as input parameters. The assignment of the labels *pitch* to the x-axis, *yaw* to the y-axis, and *roll* to the z-axis is a common one for computer graphics and games as it matches typical 'view' coordinate systems. There are of course other ways to assign those labels when using other coordinate systems (i.e. *roll* could be the x-axis, *pitch* the y-axis, and *yaw* the z-axis).
 
 <h3><a id="Platform_Requirements"></a><a id="platform_requirements"></a><a id="PLATFORM_REQUIREMENTS"></a>Platform Requirements</h3>
 Microsoft Visual Studio 2010 or Microsoft Visual Studio 2012 with the Windows SDK for Windows 8. Supported for Win32 desktop apps, Windows Store apps, and Windows Phone 8 apps.


### PR DESCRIPTION
DirectXMath uses pitch for x-axis, yaw for y-axis, and roll for z-axis which is pretty typical for games. That said, these labels are essentially arbitrary and other coordinate systems use those same labels for different axes.

Adds clarifications to the four functions that use roll, pitch, and yaw.