### PR TITLE
Improve accuracy of wording

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-peekmessagea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-peekmessagea.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:winuser.PeekMessageA
 title: PeekMessageA function (winuser.h)
-description: Dispatches incoming sent messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
+description: Dispatches incoming nonqueued messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
 helpviewer_keywords: ["PM_NOREMOVE","PM_NOYIELD","PM_QS_INPUT","PM_QS_PAINT","PM_QS_POSTMESSAGE","PM_QS_SENDMESSAGE","PM_REMOVE","PeekMessage","PeekMessage function [Windows and Messages]","PeekMessageA","PeekMessageW","_win32_PeekMessage","_win32_peekmessage_cpp","winmsg.peekmessage","winui._win32_peekmessage","winuser/PeekMessage","winuser/PeekMessageA","winuser/PeekMessageW"]
 old-location: winmsg\peekmessage.htm
 tech.root: winmsg
@@ -62,7 +62,7 @@ req.apiset: ext-ms-win-ntuser-message-l1-1-0 (introduced in Windows 8)
 
 ## -description
 
-Dispatches incoming sent messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
+Dispatches incoming nonqueued messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
 
 ## -parameters
 
@@ -219,7 +219,7 @@ If no messages are available, the return value is zero.
 
 Note that <b>PeekMessage</b> always retrieves <a href="/windows/desktop/winmsg/wm-quit">WM_QUIT</a> messages, no matter which values you specify for <i>wMsgFilterMin</i> and <i>wMsgFilterMax</i>.
 
-During this call, the system delivers pending,  nonqueued messages, that is, messages sent to windows owned by the calling thread using the <a href="/windows/desktop/api/winuser/nf-winuser-sendmessage">SendMessage</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagecallbacka">SendMessageCallback</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagetimeouta">SendMessageTimeout</a>, or <a href="/windows/desktop/api/winuser/nf-winuser-sendnotifymessagea">SendNotifyMessage</a> function. Then the first queued message that matches the specified filter is retrieved. The system may also process internal events. If no filter is specified, messages are processed in the following order:
+During this call, the system dispatches (<a href="windows/desktop/api/winuser/nf-winuser-dispatchmessage">DispatchMessage</a>) pending,  nonqueued messages, that is, messages sent to windows owned by the calling thread using the <a href="/windows/desktop/api/winuser/nf-winuser-sendmessage">SendMessage</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagecallbacka">SendMessageCallback</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagetimeouta">SendMessageTimeout</a>, or <a href="/windows/desktop/api/winuser/nf-winuser-sendnotifymessagea">SendNotifyMessage</a> function. Then the first queued message that matches the specified filter is retrieved. The system may also process internal events. If no filter is specified, messages are processed in the following order:
 
 <ul>
 <li>Sent messages </li>

--- a/sdk-api-src/content/winuser/nf-winuser-peekmessagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-peekmessagew.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:winuser.PeekMessageW
 title: PeekMessageW function (winuser.h)
-description: Dispatches incoming sent messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
+description: Dispatches incoming nonqueued messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
 helpviewer_keywords: ["PM_NOREMOVE","PM_NOYIELD","PM_QS_INPUT","PM_QS_PAINT","PM_QS_POSTMESSAGE","PM_QS_SENDMESSAGE","PM_REMOVE","PeekMessage","PeekMessage function [Windows and Messages]","PeekMessageA","PeekMessageW","_win32_PeekMessage","_win32_peekmessage_cpp","winmsg.peekmessage","winui._win32_peekmessage","winuser/PeekMessage","winuser/PeekMessageA","winuser/PeekMessageW"]
 old-location: winmsg\peekmessage.htm
 tech.root: winmsg
@@ -62,7 +62,7 @@ req.apiset: ext-ms-win-ntuser-message-l1-1-0 (introduced in Windows 8)
 
 ## -description
 
-Dispatches incoming sent messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
+Dispatches incoming nonqueued messages, checks the thread message queue for a posted message, and retrieves the message (if any exist).
 
 ## -parameters
 
@@ -219,7 +219,7 @@ If no messages are available, the return value is zero.
 
 Note that <b>PeekMessage</b> always retrieves <a href="/windows/desktop/winmsg/wm-quit">WM_QUIT</a> messages, no matter which values you specify for <i>wMsgFilterMin</i> and <i>wMsgFilterMax</i>.
 
-During this call, the system delivers pending,  nonqueued messages, that is, messages sent to windows owned by the calling thread using the <a href="/windows/desktop/api/winuser/nf-winuser-sendmessage">SendMessage</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagecallbacka">SendMessageCallback</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagetimeouta">SendMessageTimeout</a>, or <a href="/windows/desktop/api/winuser/nf-winuser-sendnotifymessagea">SendNotifyMessage</a> function. Then the first queued message that matches the specified filter is retrieved. The system may also process internal events. If no filter is specified, messages are processed in the following order:
+During this call, the system dispatches (<a href="windows/desktop/api/winuser/nf-winuser-dispatchmessage">DispatchMessage</a>) pending,  nonqueued messages, that is, messages sent to windows owned by the calling thread using the <a href="/windows/desktop/api/winuser/nf-winuser-sendmessage">SendMessage</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagecallbacka">SendMessageCallback</a>, <a href="/windows/desktop/api/winuser/nf-winuser-sendmessagetimeouta">SendMessageTimeout</a>, or <a href="/windows/desktop/api/winuser/nf-winuser-sendnotifymessagea">SendNotifyMessage</a> function. Then the first queued message that matches the specified filter is retrieved. The system may also process internal events. If no filter is specified, messages are processed in the following order:
 
 <ul>
 <li>Sent messages </li>


### PR DESCRIPTION
The phrase "sent message" was used in place of "nonqueued message" which is not at all obvious to mean the same thing.

The word "delivers" was used to say "dispatches" the message. But the term "deliver a message" is confusing - it wasn't obvious whether the window procedure gets called.