### PR TITLE
Fix formatting of '_*' in the name of flags

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilea.md
@@ -335,12 +335,12 @@ The file or device attributes and flags, <b>FILE_ATTRIBUTE_NORMAL</b> being the 
        common default value for files.
 
 This parameter can include any combination of the available file attributes 
-       (<b>FILE_ATTRIBUTE_*</b>). All other file attributes override 
+       (<b>FILE_ATTRIBUTE_\*</b>). All other file attributes override 
        <b>FILE_ATTRIBUTE_NORMAL</b>.
 
-This parameter can also contain combinations of flags (<b>FILE_FLAG_*</b>) for control of 
+This parameter can also contain combinations of flags (<b>FILE_FLAG_\*</b>) for control of 
        file or device caching behavior, access modes, and other special-purpose flags. These combine with any 
-       <b>FILE_ATTRIBUTE_*</b> values.
+       <b>FILE_ATTRIBUTE_\*</b> values.
 
 This parameter can also contain Security Quality of Service (SQOS) information by specifying the 
        <b>SECURITY_SQOS_PRESENT</b> flag. Additional SQOS-related flags information is presented in 


### PR DESCRIPTION
As motivation for this change &mdash; the un-escaped '\*' in 'FILE_FLAG_\*' causes the text following it to be interpreted as Markdown italics:

---
![image](https://user-images.githubusercontent.com/32688592/149746520-728ad385-cf83-471a-8107-f493d44a039c.png)
---

With this change, the text is now formatted correctly:

---
![image](https://user-images.githubusercontent.com/32688592/149746692-54b709ec-3f88-4a6a-bac8-7c2ef64cf09e.png)
---