### PR TITLE
Link between ShellExecute and CreateProcess

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -293,6 +293,10 @@ For an example, see
 
 
 
+<a href="/windows/win32/api/shellapi/nf-shellapi-shellexecutea">ShellExecuteA</a>
+
+
+
 <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessasusera">CreateProcessAsUser</a>
 
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
@@ -297,6 +297,10 @@ For an example, see
 
 
 
+<a href="/windows/win32/api/shellapi/nf-shellapi-shellexecutew">ShellExecuteW</a>
+
+
+
 <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessasusera">CreateProcessAsUser</a>
 
 

--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutea.md
@@ -389,6 +389,10 @@ To obtain information about the application that is launched as a result of call
 
 
 
+<a href="/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcessA</a>
+
+
+
 <a href="/windows/desktop/shell/how-to-register-and-implement-a-property-sheet-handler-for-a-control-panel-application">IShellExecuteHook</a>
 
 

--- a/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-shellexecutew.md
@@ -389,6 +389,10 @@ To obtain information about the application that is launched as a result of call
 
 
 
+<a href="/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw">CreateProcessW</a>
+
+
+
 <a href="/windows/desktop/shell/how-to-register-and-implement-a-property-sheet-handler-for-a-control-panel-application">IShellExecuteHook</a>
 
 


### PR DESCRIPTION
If they are interchangeable enough that .NET allows switching between them with a simple property in `ProcessStartInfo` then its worth noting on the actual function pages that the alternatives exist.