### PR TITLE
Restored lost text with links in ns-winnt-mem_address_requirements.md

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -64,7 +64,7 @@ Specifies the lowest acceptable address. Calling <a href=" and specifying <b>NUL
 
 ### -field HighestEndingAddress
 
-Specifies the highest acceptable address (inclusive). This address must not exceed <b>lpMaximumApplicationAddress</b> returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>. Calling <a href=" and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, and specifying <b>NULL</b> for <i>HighestEndingAddress</i>, gives the same behavior as calling <a href="/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc">VirtualAlloc</a>/<a href="/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile">MapViewOfFile</a>.
+Specifies the highest acceptable address (inclusive). This address must not exceed <b>lpMaximumApplicationAddress</b> returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>. Calling <a href="https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc2">VirtualAlloc2</a> or <a href="https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile3">MapViewOfFile3</a> and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, and specifying <b>NULL</b> for <i>HighestEndingAddress</i>, gives the same behavior as calling <a href="/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc">VirtualAlloc</a>/<a href="/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile">MapViewOfFile</a>.
 
 ### -field Alignment
 

--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -60,7 +60,7 @@ Specifies a lowest and highest base address and alignment as part of an extended
 
 ### -field LowestStartingAddress
 
-Specifies the lowest acceptable address. Calling <a href=" and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, gives the same behavior as calling <a href="/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc">VirtualAlloc</a>/<a href="/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile">MapViewOfFile</a>.
+Specifies the lowest acceptable address. Calling <a href="https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc2">VirtualAlloc2</a> or <a href="https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile3">MapViewOfFile3</a> and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, and specifying <b>NULL</b> for <i>LowestStartingAddress</i>, gives the same behavior as calling <a href="/windows/desktop/api/memoryapi/nf-memoryapi-virtualalloc">VirtualAlloc</a>/<a href="/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile">MapViewOfFile</a>.
 
 ### -field HighestEndingAddress
 


### PR DESCRIPTION
This automated commit breaks text and links:
https://github.com/MicrosoftDocs/sdk-api/commit/1be0a8bca7a97a6c02e54f6b2758ac9de787823f#diff-0cc82e46bfa5e3161fa57c7e24045c0ca8c815356b3ea71cf3555ee1a3368dee