### PR TITLE
Correct path for COM CLSID registry entry

### DIFF
--- a/sdk-api-src/content/ccgplugins/nf-ccgplugins-iccgdomainauthcredentials-getpasswordcredentials.md
+++ b/sdk-api-src/content/ccgplugins/nf-ccgplugins-iccgdomainauthcredentials-getpasswordcredentials.md
@@ -70,7 +70,7 @@ The return value is an HRESULT. A value of S_OK indicates the call was successfu
 
 The API may be called concurrently. Therefore, the developer needs to ensure that their implementation is thread safe. Additionally, the COM object will be activated out-of-proc and it must be registered appropriately.
 
-The implementer must add a key under “HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\CCG\COMClasses” for their COM CLSID. Write access to “CCG\COMClasses” is restricted to SYSTEM and Administrator accounts.
+The implementer must add a key under “HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\CCG\COMClasses” for their COM CLSID. Write access to “CCG\COMClasses” is restricted to SYSTEM and Administrator accounts.
 
 The following is an example credential specification file. For information on supplying this file to Docker, see [Run a container with a gMSA](/virtualization/windowscontainers/manage-containers/gmsa-run-container).
 


### PR DESCRIPTION
We noticed that on AKS, where a version of this plugin is implemented and registered successfully, the CLSID appears at the path
`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\CCG\COMClasses`.

When we attempt to use the documented path `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\CCG\COMClasses` we get the following error:
```
TimeCreated  : 1/25/2022 1:19:21 PM
ProviderName : Microsoft-Windows-Containers-CCG
Id           : 4
Message      : Container Credential Guard failed to instantiate the plugin: {...}. Error: Object was not found in registry
```