### PR TITLE
Update time unit for RtwqSetDeadline and RtwqSetDeadline2

### DIFF
--- a/sdk-api-src/content/rtworkq/nf-rtworkq-rtwqsetdeadline.md
+++ b/sdk-api-src/content/rtworkq/nf-rtworkq-rtwqsetdeadline.md
@@ -60,7 +60,7 @@ The identifier for the work queue. The identifier is returned by the <a href="/w
 
 ### -param deadlineInHNS [in]
 
- The deadline for the work in the queue to be completed, in milliseconds.
+ The deadline for the work in the queue to be completed, in hundred-nanosecond units. For example, if `deadlineInHNS` is 9600, that represents 9600 hundred-nanoseconds, which is equal to 960 microseconds, or 0.96 milliseconds.
 
 ### -param pRequest [in, out]
 

--- a/sdk-api-src/content/rtworkq/nf-rtworkq-rtwqsetdeadline2.md
+++ b/sdk-api-src/content/rtworkq/nf-rtworkq-rtwqsetdeadline2.md
@@ -62,11 +62,11 @@ The identifier for the work queue. The identifier is returned by the <a href="/w
 
 ### -param deadlineInHNS [in]
 
- The deadline for the work in the queue to be completed, in milliseconds.
+ The deadline for the work in the queue to be completed, in hundred-nanosecond units. For example, if `deadlineInHNS` is 9600, that represents 9600 hundred-nanoseconds, which is equal to 960 microseconds, or 0.96 milliseconds.
 
 ### -param preDeadlineInHNS [in]
 
- The pre-deadline for the work in the queue to be completed, in milliseconds.
+ The pre-deadline for the work in the queue to be completed, in hundred-nanosecond units. For example, if `preDeadlineInHNS` is 9600, that represents 9600 hundred-nanoseconds, which is equal to 960 microseconds, or 0.96 milliseconds.
 
 ### -param pRequest [in, out]
 


### PR DESCRIPTION
`RtwqSetDeadline` and `RtwqSetDeadline2` both take a time parameter. The documentation incorrectly states that the unit of this time parameter is milliseconds. In fact, the unit is hundreds-of-nanoseconds.