### PR TITLE
Remove obsolete _MAC fields

### DIFF
--- a/sdk-api-src/content/minwinbase/ns-minwinbase-win32_find_dataa.md
+++ b/sdk-api-src/content/minwinbase/ns-minwinbase-win32_find_dataa.md
@@ -187,12 +187,6 @@ An alternative name for the file.
 
 This name is in the classic 8.3 file name format.
 
-### -field dwFileType
-
-### -field dwCreatorType
-
-### -field wFinderFlags
-
 ## -remarks
 
 If a file has a long file name, the complete name appears in the <b>cFileName</b> member, 

--- a/sdk-api-src/content/minwinbase/ns-minwinbase-win32_find_dataw.md
+++ b/sdk-api-src/content/minwinbase/ns-minwinbase-win32_find_dataw.md
@@ -187,48 +187,6 @@ An alternative name for the file.
 
 This name is in the classic 8.3 file name format.
 
-### -field dwFileType
-
-### -field dwCreatorType
-
-### -field wFinderFlags
-
- 
-
-
-
-
-##### - dwReserved0.IO_REPARSE_TAG_CSV (0x80000009)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_DEDUP (0x80000013)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_DFS (0x8000000A)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_DFSR (0x80000012)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_HSM (0xC0000004)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_HSM2 (0x80000006)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_MOUNT_POINT (0xA0000003)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_NFS (0x80000014)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_SIS (0x80000007)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_SYMLINK (0xA000000C)
-
-
-##### - dwReserved0.IO_REPARSE_TAG_WIM (0x80000008)
 
 ## -remarks
 


### PR DESCRIPTION
The three fields at the end of `WIN32_FIND_DATA` are under an `#ifdef _MAC`.  This was used 25 years ago to support Visual C++ Cross Development Edition For Macintosh, which was not carried forward into OS X so has been obsolete for at least 20 years.  Anyone targeting Windows will not have these fields present in the structure, and suggesting they do is misleading.

This also removes the second definition of reparse tags from `WIN32_FIND_DATAW`.  Note the reparse tags are still included in the text above, and this second definition is not present in `WIN32_FIND_DATAA`, so it looks to be mistakenly included.