### PR TITLE
Typo "**Windows ～ XP:  **The"→"**Windows ～ XP:** The"

### DIFF
--- a/sdk-api-src/content/psapi/nf-psapi-getprocessmemoryinfo.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getprocessmemoryinfo.md
@@ -63,7 +63,7 @@ Retrieves information about the memory usage of the specified process.
 
 A handle to the process. The handle must have the **PROCESS_QUERY_INFORMATION** or **PROCESS_QUERY_LIMITED_INFORMATION** access right. For more information, see <a href="/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
 
-**Windows Server 2003 and Windows XP:  **The handle must have the **PROCESS_QUERY_INFORMATION** and **PROCESS_VM_READ** access rights.
+**Windows Server 2003 and Windows XP:** The handle must have the **PROCESS_QUERY_INFORMATION** and **PROCESS_VM_READ** access rights.
 
 ### -param ppsmemCounters [out]
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo
https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/psapi/nf-psapi-getprocessmemoryinfo.md
#PingMSFTDocs