### PR TITLE
Specify alignment for DrawIndexedInstancedIndirect

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstancedindirect.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstancedindirect.md
@@ -6,8 +6,7 @@ helpviewer_keywords: ["490eea55-c4b9-bcfb-1fd8-021b92e7979d","DrawIndexedInstanc
 old-location: direct3d11\id3d11devicecontext_drawindexedinstancedindirect.htm
 tech.root: direct3d11
 ms.assetid: c6969210-b452-4a49-a3d7-d849b1d2ebb5
-ms.date: 12/05/2018
-ms.keywords: 490eea55-c4b9-bcfb-1fd8-021b92e7979d, DrawIndexedInstancedIndirect, DrawIndexedInstancedIndirect method [Direct3D 11], DrawIndexedInstancedIndirect method [Direct3D 11],ID3D11DeviceContext interface, ID3D11DeviceContext interface [Direct3D 11],DrawIndexedInstancedIndirect method, ID3D11DeviceContext.DrawIndexedInstancedIndirect, ID3D11DeviceContext::DrawIndexedInstancedIndirect, d3d11/ID3D11DeviceContext::DrawIndexedInstancedIndirect, direct3d11.id3d11devicecontext_drawindexedinstancedindirect
+ms.date: 02/02/2022
 req.header: d3d11.h
 req.include-header: 
 req.target-type: Windows
@@ -46,9 +45,6 @@ api_name:
  - ID3D11DeviceContext.DrawIndexedInstancedIndirect
 ---
 
-# ID3D11DeviceContext::DrawIndexedInstancedIndirect
-
-
 ## -description
 
 Draw indexed, instanced, GPU-generated primitives.
@@ -57,24 +53,22 @@ Draw indexed, instanced, GPU-generated primitives.
 
 ### -param pBufferForArgs [in]
 
-Type: <b><a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a>*</b>
+Type: **[ID3D11Buffer](/windows/win32/api/d3d11/nn-d3d11-id3d11buffer)\***
 
-A pointer to an <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a>, which is a buffer containing the GPU generated primitives.
+A pointer to an [ID3D11Buffer](/windows/win32/api/d3d11/nn-d3d11-id3d11buffer), which is a buffer containing the GPU-generated primitives.
 
 ### -param AlignedByteOffsetForArgs [in]
 
-Type: <b><a href="/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: **[UINT](/windows/win32/winprog/windows-data-types)**
 
 A DWORD-aligned byte offset in <i>pBufferForArgs</i> to the start of the GPU generated primitives.
 
 ## -remarks
 
-When an application creates a buffer that is associated with the <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a> interface that  <i>pBufferForArgs</i> points to, the application must set the <a href="/windows/desktop/api/d3d11/ne-d3d11-d3d11_resource_misc_flag">D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS</a> flag in the <b>MiscFlags</b> member of the <a href="/windows/desktop/api/d3d11/ns-d3d11-d3d11_buffer_desc">D3D11_BUFFER_DESC</a> structure that describes the buffer. To create the buffer, the application calls the <a href="/windows/desktop/api/d3d11/nf-d3d11-id3d11device-createbuffer">ID3D11Device::CreateBuffer</a> method and in this call passes a pointer to <b>D3D11_BUFFER_DESC</b> in the <i>pDesc</i> parameter.
-        
+When an application creates a buffer that is associated with the [ID3D11Buffer](/windows/win32/api/d3d11/nn-d3d11-id3d11buffer) interface that *pBufferForArgs* points to, your application must set the [D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS](/windows/win32/api/d3d11/ne-d3d11-d3d11_resource_misc_flag) flag in the *MiscFlags* member of the [D3D11_BUFFER_DESC](/windows/win32/api/d3d11/ns-d3d11-d3d11_buffer_desc) structure that describes the buffer. To create the buffer, your application should call the [ID3D11Device::CreateBuffer](/windows/win32/api/d3d11/nf-d3d11-id3d11device-createbuffer) method, and pass a pointer to a **D3D11_BUFFER_DESC** in the *pDesc* parameter.
 
-<b>Windows Phone 8:
-        </b> This API is supported.
+**Windows Phone 8:** This API is supported.
 
 ## -see-also
 
-<a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11devicecontext">ID3D11DeviceContext</a>
+[ID3D11DeviceContext](/windows/win32/api/d3d11/nn-d3d11-id3d11devicecontext)

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstancedindirect.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-drawindexedinstancedindirect.md
@@ -65,7 +65,7 @@ A pointer to an <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D1
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">UINT</a></b>
 
-Offset in <i>pBufferForArgs</i> to the start of the GPU generated primitives.
+A DWORD-aligned byte offset in <i>pBufferForArgs</i> to the start of the GPU generated primitives.
 
 ## -remarks
 


### PR DESCRIPTION
This updates the description of AlignedByteOffsetForArgs to specify the required alignment (which is DWORD alignment according to the [spec](https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#8.7%20DrawInstancedIndirect%28%29))