### PR TITLE
Minor wordsmithing

### DIFF
--- a/sdk-api-src/content/ioringapi/nf-ioringapi-closeioring.md
+++ b/sdk-api-src/content/ioringapi/nf-ioringapi-closeioring.md
@@ -56,7 +56,7 @@ Returns S_OK on success.
 
 ## -remarks
 
-Calling this function ensures that resources allocated for the I/O ring are released. The closed handle is no longer valid after the function returns. It is important to note that closing the handle tosses the operations that are queued but not submitted.  However, the operations that are in flight are not cancelled. 
+Calling this function ensures that resources allocated for the I/O ring are released. The closed handle is no longer valid after the function returns. It is important to note that closing the handle abandons the operations that are queued but not submitted.  However, the operations that are in flight are **not** cancelled. 
 
 It is possible that reads from or writes to memory buffers may still occur after **CloseIoRing** returns. If you want to ensure that no pending reads or writes occur, you must wait for the completions to appear in the completion queue for all the operations that are submitted. You may choose to cancel the previously submitted operations before waiting on their completions. As an alternative to submitting multiple cancel requests, you can call [CancelIoEx](/ioapiset/nf-ioapiset-cancelioex.md) with the file handle and NULL for the overlapped pointer to effectively cancel all pending operations on the handle.
 


### PR DESCRIPTION
* Removed use of slang term 'tossed'
* Added emphasis to "not" in reference to not cancelling pending I/O