### PR TITLE
Update ns-d3d12-d3d12_command_signature_desc.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_command_signature_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_command_signature_desc.md
@@ -56,7 +56,7 @@ Describes the arguments (parameters) of a command signature.
 
 ### -field ByteStride
 
-Specifies the size of each argument of a command signature, in bytes.
+Specifies the size of each command in the drawing buffer, in bytes.
 
 ### -field NumArgumentDescs
 


### PR DESCRIPTION
Fix the description of D3D12_COMMAND_SIGNATURE_DESC.ByteStride, the previous one was incorrect.