### PR TITLE
Fix missing description of DWRITE_SHAPING_TEXT_PROPERTIES::canBreakShapingAfter

### DIFF
--- a/sdk-api-src/content/dwrite/ns-dwrite-dwrite_shaping_text_properties.md
+++ b/sdk-api-src/content/dwrite/ns-dwrite-dwrite_shaping_text_properties.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Shaping output properties for an output glyph.
+Shaping output properties per input character.
 
 ## -struct-fields
 
@@ -58,13 +58,19 @@ Shaping output properties for an output glyph.
 
 Type: <b>UINT16</b>
 
-Indicates that the glyph is shaped alone.
+Indicates that the character is shaped independently from the others (usually set for the space character).
 
 ### -field reserved1
 
+Reserved for use by shaping engine.
+
 ### -field canBreakShapingAfter
 
+Glyph shaping can be safely cut after this point without affecting shaping before or after it. Otherwise, splitting a call to GetGlyphs would cause a reflow of glyph advances and shapes.
+
 ### -field reserved
+
+Reserved for use by shaping engine.
 
 Type: <b>UINT16</b>
 

--- a/sdk-api-src/content/dwrite/ns-dwrite-dwrite_shaping_text_properties.md
+++ b/sdk-api-src/content/dwrite/ns-dwrite-dwrite_shaping_text_properties.md
@@ -45,9 +45,6 @@ api_name:
  - DWRITE_SHAPING_TEXT_PROPERTIES
 ---
 
-# DWRITE_SHAPING_TEXT_PROPERTIES structure
-
-
 ## -description
 
 Shaping output properties per input character.
@@ -66,13 +63,12 @@ Reserved for use by shaping engine.
 
 ### -field canBreakShapingAfter
 
-Glyph shaping can be safely cut after this point without affecting shaping before or after it. Otherwise, splitting a call to GetGlyphs would cause a reflow of glyph advances and shapes.
+Glyph shaping can be safely cut after this point without affecting shaping before or after it. Otherwise, splitting a call to [GetGlyphs](/windows/win32/api/dwrite/nf-dwrite-idwritetextanalyzer-getglyphs) would cause a reflow of glyph advances and shapes.
 
 ### -field reserved
 
-Reserved for use by shaping engine.
+Reserved for use by the shaping engine.
 
 Type: <b>UINT16</b>
 
 Reserved for future use.
-


### PR DESCRIPTION
- Use the header comments from DWrite.h to fill in the missing descriptions.
- These properties are not for the output glyphs but for the input characters. This may have been copy pasta from DWRITE_SHAPING_GLYPH_PROPERTIES.
- The previous description also said the "glyph is shaped", but the TEXT_PROPERTIES struct is per-character.