### PR TITLE
TextOutW: Fix argument name, from "c" to "cchString"

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-textoutw.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-textoutw.md
@@ -77,7 +77,7 @@ The y-coordinate, in logical coordinates, of the reference point that the system
 
 A pointer to the string to be drawn. The string does not need to be zero-terminated, because <i>cchString</i> specifies the length of the string.
 
-### -param c [in]
+### -param cchString [in]
 
 The <a href="/windows/desktop/gdi/specifying-length-of-text-output-string">length of the string</a> pointed to by <i>lpString</i>, in characters.
 


### PR DESCRIPTION
The argument "lpString" refers to "cchString" as the argument of the string length, but did not exist. However, there is an argument matching the explanation, which was just called "c". Therefor, changing "c" to "cchString" should fix the API definition.