### PR TITLE
Document `TCP_NODELAY` as being a `BOOLEAN`

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-getsockopt.md
+++ b/sdk-api-src/content/winsock/nf-winsock-getsockopt.md
@@ -341,7 +341,7 @@ The following table of value for the <i>optname</i> parameter are valid when the
 </tr>
 <tr>
 <td>TCP_NODELAY</td>
-<td>BOOL</td>
+<td>BOOLEAN</td>
 <td>Disables the Nagle algorithm for send coalescing.</td>
 </tr>
 </table>

--- a/sdk-api-src/content/winsock/nf-winsock-setsockopt.md
+++ b/sdk-api-src/content/winsock/nf-winsock-setsockopt.md
@@ -327,7 +327,7 @@ For more complete and detailed information about socket options for <i>level</i>
 </tr>
 <tr>
 <td>TCP_NODELAY</td>
-<td>BOOL</td>
+<td>BOOLEAN</td>
 <td>Disables the Nagle algorithm for send coalescing.This socket option is included for backward compatibility with Windows Sockets 1.1
 
 </td>

--- a/sdk-api-src/content/winsock2/nf-winsock2-getsockopt.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-getsockopt.md
@@ -341,7 +341,7 @@ The following table of value for the <i>optname</i> parameter are valid when the
 </tr>
 <tr>
 <td>TCP_NODELAY</td>
-<td>BOOL</td>
+<td>BOOLEAN</td>
 <td>Disables the Nagle algorithm for send coalescing.</td>
 </tr>
 </table>

--- a/sdk-api-src/content/winsock2/nf-winsock2-setsockopt.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-setsockopt.md
@@ -327,7 +327,7 @@ For more complete and detailed information about socket options for <i>level</i>
 </tr>
 <tr>
 <td>TCP_NODELAY</td>
-<td>BOOL</td>
+<td>BOOLEAN</td>
 <td>Disables the Nagle algorithm for send coalescing.This socket option is included for backward compatibility with Windows Sockets 1.1
 
 </td>


### PR DESCRIPTION
Currently `TCP_NODELAY` is stated to be a `BOOL` (a 32 bit integer). However, only the first byte is ever read or written to. Therefore it should be documented as being a `BOOLEAN` (an 8 bit integer).

I've tried to minimize my code into a test program:

<details><summary>Test TCP_NODELAY</summary>

```cpp
#include <windows.h>
#include <winsock2.h>
#include <stdio.h>

#pragma comment(lib, "ws2_32.lib")

class Socket {
    WSADATA wsaData;
    SOCKET handle;
public:
    Socket();
    ~Socket();

    int getsockopt(int level, int optname, char* optval, int* optlen);
    int setsockopt(int level, int optname, const char* optval, int optlen);
};

void test_nodelay(Socket &soc, BOOL in_flag) {
    soc.setsockopt(IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&in_flag), sizeof(in_flag));

    int length = sizeof(in_flag);
    BOOL out_flag = 0;
    soc.getsockopt(IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&out_flag), &length);

    printf("0x%08x: flag: %d, length: %d\n", in_flag, out_flag, length);
}

int main()
{
    Socket soc;

    test_nodelay(soc, 1);
    test_nodelay(soc, 0x80);
    test_nodelay(soc, 0x100);
    test_nodelay(soc, 0xffffff00);

    return 0;
}

Socket::Socket() {
    int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
    if (result != 0) {
        ExitProcess(WSAGetLastError());
    }
    handle = socket(AF_INET, SOCK_STREAM, 0);
    if (SOCKET_ERROR == handle)
    {
        printf("Socket error: %d", WSAGetLastError());
        ExitProcess(1);
    }
}
Socket::~Socket() {
    WSACleanup();
}
int Socket::getsockopt(int level, int optname, char* optval, int* optlen) {
    if (SOCKET_ERROR == ::getsockopt(handle, IPPROTO_TCP, TCP_NODELAY, optval, optlen))
    {
        printf("Socket error: %d", WSAGetLastError());
        ExitProcess(1);
    }
    return 0;
}
int Socket::setsockopt(int level, int optname, const char* optval, int optlen) {
    if (SOCKET_ERROR == ::setsockopt(handle, IPPROTO_TCP, TCP_NODELAY, optval, optlen))
    {
        printf("Socket error: %d", WSAGetLastError());
        ExitProcess(1);
    }
    return 0;
}

```

</details>
<details><summary>Output</summary>

```plain
0x00000001: flag: 1, length: 1
0x00000080: flag: 1, length: 1
0x00000100: flag: 0, length: 1
0xffffff00: flag: 0, length: 1
```

</details>