### PR TITLE
Asterisks used to represent multiplication, not as markup

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-cssetconstantbuffers.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-cssetconstantbuffers.md
@@ -78,7 +78,7 @@ Array of constant buffers (see <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d
 The method will hold a reference to the interfaces passed in.
       This differs from the device state behavior in Direct3D 10.
 
-The Direct3D 11.1 runtime, which is available starting with Windows 8, can bind a larger number of <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a> resources to the shader than the maximum constant buffer size that is supported by shaders (4096 constants – 4*32-bit components each).  When you bind such a large buffer, the shader can access only the first 4096 4*32-bit component constants in the buffer, as if 4096 constants is the full size of the buffer.  
+The Direct3D 11.1 runtime, which is available starting with Windows 8, can bind a larger number of <a href="/windows/desktop/api/d3d11/nn-d3d11-id3d11buffer">ID3D11Buffer</a> resources to the shader than the maximum constant buffer size that is supported by shaders (4096 constants – 4\*32-bit components each).  When you bind such a large buffer, the shader can access only the first 4096 4\*32-bit component constants in the buffer, as if 4096 constants is the full size of the buffer.  
 
 If the application wants the shader to access other parts of the buffer, it must call the <a href="/windows/desktop/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-cssetconstantbuffers1">CSSetConstantBuffers1</a> method instead.
 


### PR DESCRIPTION
.... so escape them appropriately.