### PR TITLE
Clarify wording on lpValue

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
@@ -245,7 +245,7 @@ This value is not supported until Windows 11 and Windows Server 2022.
 
 ### -param lpValue [in]
 
-A pointer to the attribute value. This value should persist until the attribute is destroyed using the <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-deleteprocthreadattributelist">DeleteProcThreadAttributeList</a> function.
+A pointer to the attribute value. This value must persist until the attribute list is destroyed using the <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-deleteprocthreadattributelist">DeleteProcThreadAttributeList</a> function.
 
 ### -param cbSize [in]
 


### PR DESCRIPTION
The word "must" makes it clear that it is a requirement and not a mere recommendation. Also make it clear that it's the list that is being referred to.