### PR TITLE
[VirtualFree] clarify MEM_COALESCE_PLACEHOLDERS behavior

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-virtualfree.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-virtualfree.md
@@ -151,7 +151,7 @@ When using <b>MEM_RELEASE</b>, this parameter can additionally specify one of th
 </dl>
 </td>
 <td width="60%">
-To coalesce two adjacent placeholders, specify <code>MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS</code>. When you coalesce placeholders, <i>lpAddress</i> and <i>dwSize</i> must exactly match those of the placeholder.
+To coalesce two adjacent placeholders, specify <code>MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS</code>. When you coalesce placeholders, <i>lpAddress</i> and <i>dwSize</i> must exactly match the overall range of the placeholders to be merged.
 
 </td>
 </tr>


### PR DESCRIPTION
Clarify unclear (and/or incorrect) info regarding `MEM_COALESCE_PLACEHOLDERS` behavior.

By carefully examining the results of each step via `VirtualQuery`, I have discerned how it actually works. You have to specify the overall size of the contiguous address range that you want to coalesce, not the size of one (i.e., which one?) of the placeholders.
