### PR TITLE
Fix params naming in GetObject

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-getobject.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-getobject.md
@@ -60,15 +60,15 @@ The <b>GetObject</b> function retrieves information for the specified graphics o
 
 ## -parameters
 
-### -param h [in]
+### -param hgdiobj [in]
 
 A handle to the graphics object of interest. This can be a handle to one of the following: a logical bitmap, a brush, a font, a palette, a pen, or a device independent bitmap created by calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-createdibsection">CreateDIBSection</a> function.
 
-### -param c [in]
+### -param cbBuffer [in]
 
 The number of bytes of information to be written to the buffer.
 
-### -param pv [out]
+### -param lpvObject [out]
 
 A pointer to a buffer that receives the information about the specified graphics object.
 


### PR DESCRIPTION
[Gdi]
- Fix params naming so they fit the description.


Brought to you by the ReactOS Team


