### PR TITLE
Update ns-winuser-rawinputheader.md - Precision touchpad remark (confusing hDevice == 0)

### DIFF
--- a/sdk-api-src/content/winuser/ns-winuser-rawinputheader.md
+++ b/sdk-api-src/content/winuser/ns-winuser-rawinputheader.md
@@ -90,7 +90,7 @@ The value passed in the <i>wParam</i> parameter of the [WM_INPUT](/windows/win32
 
 ## -remarks
 
-To get more information on the device, use <b>hDevice</b> in a call to [GetRawInputDeviceInfo](nf-winuser-getrawinputdeviceinfoa.md).
+To get more information on the device, use <b>hDevice</b> in a call to [GetRawInputDeviceInfo](nf-winuser-getrawinputdeviceinfoa.md). <b>hDevice</b> can be zero if an input is received from a precision touchpad.
 
 ## -see-also
 


### PR DESCRIPTION
The problem and the answer are described here:
https://stackoverflow.com/questions/57552844/rawinputheader-hdevice-null-on-wm-input-for-laptop-trackpad

Just encountered the same problem with my new notebook. If someone has more knowledge on topic please write more elaborate remark.