### PR TITLE
Update casing for implied extension.

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibrarya.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibrarya.md
@@ -90,7 +90,7 @@ If the function cannot find the  module, the function fails. When specifying a p
 
 If the string specifies a module name without a path and the file name extension is omitted, the function
        appends the default library extension ".DLL" to the module name. To prevent the function from appending
-       .dll to the module name, include a trailing point character (.) in the module name string.
+       ".DLL" to the module name, include a trailing point character (.) in the module name string.
 
 ## -returns
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibrarya.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibrarya.md
@@ -13,21 +13,21 @@ req.include-header: Windows.h
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
 req.unicode-ansi: LoadLibraryW (Unicode) and LoadLibraryA (ANSI)
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
 req.lib: Kernel32.lib
 req.dll: Kernel32.dll
-req.irql: 
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - LoadLibraryA
@@ -64,153 +64,153 @@ api_name:
 
 ## -description
 
-Loads the specified  module into the address space of the calling process. The specified 
+Loads the specified  module into the address space of the calling process. The specified
     module may cause other modules to be loaded.
 
-For additional load options, use the 
+For additional load options, use the
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> function.
 
 ## -parameters
 
 ### -param lpLibFileName [in]
 
-The name of the module. This can be either a library module (a .dll file) or an executable 
-       module (an .exe file). The name specified is the file name of the module and is not related to the 
-       name stored in the library module itself, as specified by the <b>LIBRARY</b> keyword in 
+The name of the module. This can be either a library module (a .dll file) or an executable
+       module (an .exe file). The name specified is the file name of the module and is not related to the
+       name stored in the library module itself, as specified by the <b>LIBRARY</b> keyword in
        the module-definition (.def) file.
 
 If the string specifies a full path, the function searches only that path for the module.
 
-If the string specifies a relative path or a module name without a path, the function uses a standard search 
+If the string specifies a relative path or a module name without a path, the function uses a standard search
        strategy to find the module; for more information, see the Remarks.
 
-If the function cannot find the  module, the function fails. When specifying a path, be sure to use 
-       backslashes (\\), not forward slashes (/). For more information about paths, see 
+If the function cannot find the  module, the function fails. When specifying a path, be sure to use
+       backslashes (\\), not forward slashes (/). For more information about paths, see
        <a href="/windows/desktop/FileIO/naming-a-file">Naming a File or Directory</a>.
 
-If the string specifies a module name without a path and the file name extension is omitted, the function 
-       appends the default library extension .dll to the module name. To prevent the function from appending 
+If the string specifies a module name without a path and the file name extension is omitted, the function
+       appends the default library extension ".DLL" to the module name. To prevent the function from appending
        .dll to the module name, include a trailing point character (.) in the module name string.
 
 ## -returns
 
 If the function succeeds, the return value is a handle to the module.
 
-If the function fails, the return value is NULL. To get extended error information, call 
+If the function fails, the return value is NULL. To get extended error information, call
        <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 
-To enable or disable error messages displayed by the loader during DLL loads, use the 
+To enable or disable error messages displayed by the loader during DLL loads, use the
     <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-seterrormode">SetErrorMode</a> function.
 
-<b>LoadLibrary</b> can be used to load a library module into 
-    the address space of the process and return a handle that can be used in 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of a DLL function. 
-    <b>LoadLibrary</b> can also be used to load other executable 
-    modules. For example, the function can specify an .exe file to get a handle that can be used in 
-    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> or 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>. However, do not use 
-    <b>LoadLibrary</b> to run an .exe file. Instead, use 
+<b>LoadLibrary</b> can be used to load a library module into
+    the address space of the process and return a handle that can be used in
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of a DLL function.
+    <b>LoadLibrary</b> can also be used to load other executable
+    modules. For example, the function can specify an .exe file to get a handle that can be used in
+    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> or
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>. However, do not use
+    <b>LoadLibrary</b> to run an .exe file. Instead, use
     the <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function.
 
-If the specified module is a DLL that is not already loaded for the calling process, the system calls the 
-    DLL's <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function with the 
-    <b>DLL_PROCESS_ATTACH</b> value. If 
-    <b>DllMain</b> returns <b>TRUE</b>, 
-    <b>LoadLibrary</b> returns a handle to the module. If 
-    <b>DllMain</b> returns <b>FALSE</b>, 
-    the system unloads the DLL from the process address space and 
-    <b>LoadLibrary</b> returns <b>NULL</b>. It is 
-    not safe to call <b>LoadLibrary</b> from 
-    <b>DllMain</b>. For more information, see the Remarks section in 
+If the specified module is a DLL that is not already loaded for the calling process, the system calls the
+    DLL's <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function with the
+    <b>DLL_PROCESS_ATTACH</b> value. If
+    <b>DllMain</b> returns <b>TRUE</b>,
+    <b>LoadLibrary</b> returns a handle to the module. If
+    <b>DllMain</b> returns <b>FALSE</b>,
+    the system unloads the DLL from the process address space and
+    <b>LoadLibrary</b> returns <b>NULL</b>. It is
+    not safe to call <b>LoadLibrary</b> from
+    <b>DllMain</b>. For more information, see the Remarks section in
     <b>DllMain</b>.
 
-Module handles are not global or inheritable. A call to 
-    <b>LoadLibrary</b> by one process does not produce a handle that 
-    another process can use — for example, in calling 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>. The other process must make its own 
-    call to <b>LoadLibrary</b> for the module before calling 
+Module handles are not global or inheritable. A call to
+    <b>LoadLibrary</b> by one process does not produce a handle that
+    another process can use — for example, in calling
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>. The other process must make its own
+    call to <b>LoadLibrary</b> for the module before calling
     <b>GetProcAddress</b>.
 
-If <i>lpFileName</i> does not include a path and there is more than one loaded module with 
+If <i>lpFileName</i> does not include a path and there is more than one loaded module with
     the same base name and extension, the function returns a handle to the module that was loaded first.
 
-If no file name extension is specified in the <i>lpFileName</i> parameter, the default 
-    library extension .dll is appended. However, the file name string can include a trailing point character (.) to 
-    indicate that the module name has no extension. When no path is specified, the function searches for loaded 
-    modules whose base name matches the base name of the module to be loaded. If the name matches, the load succeeds. 
+If no file name extension is specified in the <i>lpFileName</i> parameter, the default
+    library extension .dll is appended. However, the file name string can include a trailing point character (.) to
+    indicate that the module name has no extension. When no path is specified, the function searches for loaded
+    modules whose base name matches the base name of the module to be loaded. If the name matches, the load succeeds.
     Otherwise, the function searches for the file.
 
-The first directory searched is the directory containing the image file used to create the calling process 
-    (for more information, see the 
-    <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function). Doing this allows 
-    private dynamic-link library (DLL) files associated with a process to be found without adding the process's 
-    installed directory to the PATH environment variable. If a relative path is 
-    specified, the entire relative path is appended to every token in the DLL search path list. To load a module from 
-    a relative path without searching any other path, use 
-    <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call 
-    <b>LoadLibrary</b> with the nonrelative path. For more 
-    information on the DLL search order, see 
+The first directory searched is the directory containing the image file used to create the calling process
+    (for more information, see the
+    <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function). Doing this allows
+    private dynamic-link library (DLL) files associated with a process to be found without adding the process's
+    installed directory to the PATH environment variable. If a relative path is
+    specified, the entire relative path is appended to every token in the DLL search path list. To load a module from
+    a relative path without searching any other path, use
+    <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call
+    <b>LoadLibrary</b> with the nonrelative path. For more
+    information on the DLL search order, see
     <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-The search path can be altered using the 
-    <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. This solution is recommended 
-    instead of using <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or 
+The search path can be altered using the
+    <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. This solution is recommended
+    instead of using <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or
     hard-coding the full path to the DLL.
 
-If a path is specified and there is a redirection file for the application, the function searches for the 
-    module in the application's directory. If the module exists in the application's directory, 
-    <b>LoadLibrary</b> ignores the specified path and loads the 
-    module from the application's directory. If the module does not exist in the application's directory, 
-    <b>LoadLibrary</b> loads the module from the specified 
-    directory. For more information, see 
+If a path is specified and there is a redirection file for the application, the function searches for the
+    module in the application's directory. If the module exists in the application's directory,
+    <b>LoadLibrary</b> ignores the specified path and loads the
+    module from the application's directory. If the module does not exist in the application's directory,
+    <b>LoadLibrary</b> loads the module from the specified
+    directory. For more information, see
     <a href="/windows/desktop/Dlls/dynamic-link-library-redirection">Dynamic Link Library Redirection</a>.
 
- If you call <b>LoadLibrary</b> with the name of an assembly 
-    without a path specification and the assembly is listed in the system compatible manifest, the call is 
+ If you call <b>LoadLibrary</b> with the name of an assembly
+    without a path specification and the assembly is listed in the system compatible manifest, the call is
     automatically redirected to the side-by-side assembly.
 
-The system maintains a per-process reference 
-    count on all loaded modules. Calling <b>LoadLibrary</b> 
-    increments the reference count. Calling the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> or 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread">FreeLibraryAndExitThread</a> function decrements 
-    the reference count. The system unloads a module when its reference count reaches zero or when the process 
+The system maintains a per-process reference
+    count on all loaded modules. Calling <b>LoadLibrary</b>
+    increments the reference count. Calling the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> or
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread">FreeLibraryAndExitThread</a> function decrements
+    the reference count. The system unloads a module when its reference count reaches zero or when the process
     terminates (regardless of the reference count).
 
-<b>Windows Server 2003 and Windows XP:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables: 
-      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the 
-      DLL explicitly using <b>LoadLibrary</b> on versions of Windows 
-      prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread local 
-      storage functions instead of <b>_declspec(thread)</b>. For an example, see 
-      <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage 
+<b>Windows Server 2003 and Windows XP:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables:
+      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the
+      DLL explicitly using <b>LoadLibrary</b> on versions of Windows
+      prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread local
+      storage functions instead of <b>_declspec(thread)</b>. For an example, see
+      <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage
       in a Dynamic Link Library</a>.
 
 <h3><a id="Security_Remarks"></a><a id="security_remarks"></a><a id="SECURITY_REMARKS"></a>Security Remarks</h3>
-Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to 
-      a DLL for a subsequent <b>LoadLibrary</b> call. The 
-      <b>SearchPath</b> function uses a different search order than 
-      <b>LoadLibrary</b> and it does not use safe process search mode 
-      unless this is explicitly enabled by calling 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with 
-      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore, 
-      <b>SearchPath</b> is likely to first search the user’s current 
-      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the current 
-      working directory, the path retrieved by <b>SearchPath</b> will 
-      point to the malicious DLL, which <b>LoadLibrary</b> will then 
+Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to
+      a DLL for a subsequent <b>LoadLibrary</b> call. The
+      <b>SearchPath</b> function uses a different search order than
+      <b>LoadLibrary</b> and it does not use safe process search mode
+      unless this is explicitly enabled by calling
+      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with
+      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore,
+      <b>SearchPath</b> is likely to first search the user’s current
+      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the current
+      working directory, the path retrieved by <b>SearchPath</b> will
+      point to the malicious DLL, which <b>LoadLibrary</b> will then
       load.
 
-Do not make assumptions about the operating system version based on a 
-      <b>LoadLibrary</b> call that searches for a DLL. If the 
-      application is running in an environment where the DLL is legitimately not present but a malicious version of 
-      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended 
-      techniques described in 
+Do not make assumptions about the operating system version based on a
+      <b>LoadLibrary</b> call that searches for a DLL. If the
+      application is running in an environment where the DLL is legitimately not present but a malicious version of
+      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended
+      techniques described in
       <a href="/windows/desktop/SysInfo/getting-the-system-version">Getting the System Version</a>.
 
 
 #### Examples
 
-For an example, see 
+For an example, see
      <a href="/windows/desktop/Dlls/using-run-time-dynamic-linking">Using Run-Time Dynamic Linking</a>.
 
 <div class="code"></div>

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexa.md
@@ -13,21 +13,21 @@ req.include-header: Windows.h
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
 req.unicode-ansi: LoadLibraryExW (Unicode) and LoadLibraryExA (ANSI)
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
 req.lib: Kernel32.lib
 req.dll: Kernel32.dll
-req.irql: 
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: snippet-project
 f1_keywords:
  - LoadLibraryExA
@@ -60,38 +60,38 @@ api_name:
 
 ## -description
 
-Loads the specified module into the address space of the calling process. The specified 
+Loads the specified module into the address space of the calling process. The specified
     module may cause other modules to be loaded.
 
 ## -parameters
 
 ### -param lpLibFileName [in]
 
-A string that specifies the file name of the module to load. This name is not related to the name stored in a 
-       library module itself, as specified by the <b>LIBRARY</b> keyword in the module-definition 
+A string that specifies the file name of the module to load. This name is not related to the name stored in a
+       library module itself, as specified by the <b>LIBRARY</b> keyword in the module-definition
        (.def) file.
 
-The module can be a library module (a .dll file) or an executable module (an .exe file). If the 
-       specified module is an executable module, static imports are not loaded; instead, the module is loaded as if 
-       <b>DONT_RESOLVE_DLL_REFERENCES</b> was specified. See the <i>dwFlags</i> 
+The module can be a library module (a .dll file) or an executable module (an .exe file). If the
+       specified module is an executable module, static imports are not loaded; instead, the module is loaded as if
+       <b>DONT_RESOLVE_DLL_REFERENCES</b> was specified. See the <i>dwFlags</i>
        parameter for more information.
 
-If the string specifies a module name without a path and the file name extension is omitted, the function 
-       appends the default library extension .dll to the module name. To prevent the function from appending 
+If the string specifies a module name without a path and the file name extension is omitted, the function
+       appends the default library extension ".DLL" to the module name. To prevent the function from appending
        .dll to the module name, include a trailing point character (.) in the module name string.
 
-If the string specifies a fully qualified path, the function searches only that path for the module. When 
-       specifying a path, be sure to use backslashes (\\), not forward slashes (/). For more information about paths, 
+If the string specifies a fully qualified path, the function searches only that path for the module. When
+       specifying a path, be sure to use backslashes (\\), not forward slashes (/). For more information about paths,
        see <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
-If the string specifies a module name without a path and more than one loaded module has the same base name 
+If the string specifies a module name without a path and more than one loaded module has the same base name
        and extension, the function returns a handle to the module that was loaded first.
 
-If the string specifies a module name without a path and a module of the same name is not already loaded, or 
-       if the string specifies a module name with a relative path, the function searches for the specified module. The 
-       function also searches for modules if loading the specified module causes the system to load other associated 
-       modules (that is, if the module has dependencies). The directories that are searched and the order in which 
-       they are searched depend on the specified path and the <i>dwFlags</i> parameter. For more 
+If the string specifies a module name without a path and a module of the same name is not already loaded, or
+       if the string specifies a module name with a relative path, the function searches for the specified module. The
+       function also searches for modules if loading the specified module causes the system to load other associated
+       modules (that is, if the module has dependencies). The directories that are searched and the order in which
+       they are searched depend on the specified path and the <i>dwFlags</i> parameter. For more
        information, see Remarks.
 
 If the function cannot find the  module or one of its dependencies, the function fails.
@@ -102,8 +102,8 @@ This parameter is reserved for future use. It must be <b>NULL</b>.
 
 ### -param dwFlags [in]
 
-The action to be taken when loading the module. If no flags are specified, the behavior of this function is 
-      identical to that of the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. This 
+The action to be taken when loading the module. If no flags are specified, the behavior of this function is
+      identical to that of the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. This
       parameter can be one of the following values.
 
 <table>
@@ -118,15 +118,15 @@ The action to be taken when loading the module. If no flags are specified, the b
 </dl>
 </td>
 <td width="60%">
-If this value is used, and the executable module is a DLL, the system does not call 
-         <a href="/windows/desktop/Dlls/dllmain">DllMain</a> for process and thread initialization and 
-         termination. Also, the system does not load additional executable modules that are referenced by the 
+If this value is used, and the executable module is a DLL, the system does not call
+         <a href="/windows/desktop/Dlls/dllmain">DllMain</a> for process and thread initialization and
+         termination. Also, the system does not load additional executable modules that are referenced by the
          specified module.
 
-<div class="alert"><b>Note</b>  Do not use this value; it is provided only for backward compatibility. If you are planning to access 
-         only data or resources in the DLL, use <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
-         <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> or both. Otherwise, load the library as a DLL or 
-         executable module using the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> 
+<div class="alert"><b>Note</b>  Do not use this value; it is provided only for backward compatibility. If you are planning to access
+         only data or resources in the DLL, use <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
+         <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> or both. Otherwise, load the library as a DLL or
+         executable module using the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a>
          function.</div>
 <div> </div>
 </td>
@@ -138,16 +138,16 @@ If this value is used, and the executable module is a DLL, the system does not c
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system does not check 
-         <a href="/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd723678(v=ws.10)">AppLocker</a> rules or apply 
-         <a href="/previous-versions/windows/it-pro/windows-server-2003/cc779607(v=ws.10)">Software Restriction Policies</a> 
-         for the DLL. This action applies only to the DLL being loaded and not to its dependencies. This value is 
+If this value is used, the system does not check
+         <a href="/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd723678(v=ws.10)">AppLocker</a> rules or apply
+         <a href="/previous-versions/windows/it-pro/windows-server-2003/cc779607(v=ws.10)">Software Restriction Policies</a>
+         for the DLL. This action applies only to the DLL being loaded and not to its dependencies. This value is
          recommended for use in setup programs that must run extracted DLLs during installation.
 
-<b>Windows Server 2008 R2 and Windows 7:  </b>On systems with KB2532445 installed, the caller must be running as "LocalSystem" or 
-          "TrustedInstaller"; otherwise the system ignores this flag. For more information, see 
-          "You can circumvent AppLocker rules by using an Office macro on a computer that is running Windows 7 or Windows Server 2008 R2" 
-          in the Help and Support Knowledge Base at 
+<b>Windows Server 2008 R2 and Windows 7:  </b>On systems with KB2532445 installed, the caller must be running as "LocalSystem" or
+          "TrustedInstaller"; otherwise the system ignores this flag. For more information, see
+          "You can circumvent AppLocker rules by using an Office macro on a computer that is running Windows 7 or Windows Server 2008 R2"
+          in the Help and Support Knowledge Base at
           <a href="https://support.microsoft.com/kb/2532445">https://support.microsoft.com/kb/2532445</a>.
 
 <b>Windows Server 2008, Windows Vista, Windows Server 2003 and Windows XP:  </b>AppLocker was introduced in Windows 7 and Windows Server 2008 R2.
@@ -161,15 +161,15 @@ If this value is used, the system does not check
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system maps the file into the calling process's virtual address space as if it 
-         were a data file. Nothing is done to execute or prepare to execute the mapped file. Therefore, you cannot 
-         call functions like <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamea">GetModuleFileName</a>,  
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> or 
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> with this DLL. Using this value 
-         causes writes to read-only memory to raise an access violation. Use this flag when you want to load a DLL 
+If this value is used, the system maps the file into the calling process's virtual address space as if it
+         were a data file. Nothing is done to execute or prepare to execute the mapped file. Therefore, you cannot
+         call functions like <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamea">GetModuleFileName</a>,
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> or
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> with this DLL. Using this value
+         causes writes to read-only memory to raise an access violation. Use this flag when you want to load a DLL
          only to extract messages or resources from it.
 
-This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information, 
+This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information,
          see Remarks.
 
 </td>
@@ -181,11 +181,11 @@ This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more info
 </dl>
 </td>
 <td width="60%">
-Similar to <b>LOAD_LIBRARY_AS_DATAFILE</b>, except that the DLL file is opened with 
-         exclusive write access for the calling process. Other processes cannot open the DLL file for write access 
+Similar to <b>LOAD_LIBRARY_AS_DATAFILE</b>, except that the DLL file is opened with
+         exclusive write access for the calling process. Other processes cannot open the DLL file for write access
          while it is in use. However, the DLL can still be opened by other processes.
 
-This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information, 
+This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information,
          see Remarks.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported until Windows Vista.
@@ -199,12 +199,12 @@ This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more info
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system maps the file into the process's virtual address space as an image file. 
-         However, the loader does not load the static imports or perform the other usual initialization steps. Use 
+If this value is used, the system maps the file into the process's virtual address space as an image file.
+         However, the loader does not load the static imports or perform the other usual initialization steps. Use
          this flag when you want to load a DLL only to extract messages or resources from it.
 
-Unless the application depends on the file having the in-memory layout of an image, this value should be used with either 
-         <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
+Unless the application depends on the file having the in-memory layout of an image, this value should be used with either
+         <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
          <b>LOAD_LIBRARY_AS_DATAFILE</b>. For more information, see the Remarks section.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported  until Windows Vista.
@@ -218,12 +218,12 @@ Unless the application depends on the file having the in-memory layout of an ima
 </dl>
 </td>
 <td width="60%">
-If this value is used, the application's installation directory is searched for the DLL and its 
-         dependencies. Directories in the standard search path are not searched. This value cannot be combined with 
+If this value is used, the application's installation directory is searched for the DLL and its
+         dependencies. Directories in the standard search path are not searched. This value cannot be combined with
          <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -237,16 +237,16 @@ If this value is used, the application's installation directory is searched for 
 </dl>
 </td>
 <td width="60%">
-This value is a combination of <b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>, 
-         <b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>, and 
-         <b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>. Directories in the standard search path are not 
+This value is a combination of <b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>,
+         <b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>, and
+         <b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>. Directories in the standard search path are not
          searched. This value cannot be combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-This value represents the recommended maximum number of directories an application should include in its 
+This value represents the recommended maximum number of directories an application should include in its
          DLL search path.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -260,20 +260,20 @@ This value represents the recommended maximum number of directories an applicati
 </dl>
 </td>
 <td width="60%">
-If this value is used, the directory that contains the DLL is temporarily added to the beginning of the 
-         list of directories that are searched for the DLL's dependencies.  Directories in the standard search path 
+If this value is used, the directory that contains the DLL is temporarily added to the beginning of the
+         list of directories that are searched for the DLL's dependencies.  Directories in the standard search path
          are not searched.
 
-The <i>lpFileName</i> parameter must specify a fully qualified path. This value cannot 
+The <i>lpFileName</i> parameter must specify a fully qualified path. This value cannot
          be combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading 
-         Lib1.dll  with this value causes the system to search for Lib2.dll only in 
-         C:\Dir1. To search for Lib2.dll in C:\Dir1 and all of the directories 
+For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading
+         Lib1.dll  with this value causes the system to search for Lib2.dll only in
+         C:\Dir1. To search for Lib2.dll in C:\Dir1 and all of the directories
          in the DLL search path, combine this value with <b>LOAD_LIBRARY_SEARCH_DEFAULT_DIRS</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -287,12 +287,12 @@ For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading
 </dl>
 </td>
 <td width="60%">
-If this value is used, %windows%\system32 is searched for the DLL and its dependencies. 
-         Directories in the standard search path are not searched. This value cannot be combined with 
+If this value is used, %windows%\system32 is searched for the DLL and its dependencies.
+         Directories in the standard search path are not searched. This value cannot be combined with
          <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -306,15 +306,15 @@ If this value is used, %windows%\system32 is searched for the DLL and its depend
 </dl>
 </td>
 <td width="60%">
-If this value is used, directories added using the 
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> or the 
-         <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function are searched for the DLL 
-         and its dependencies. If more than one directory has been added, the order in which the directories are 
-         searched is unspecified. Directories in the standard search path are not searched. This value cannot be 
+If this value is used, directories added using the
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> or the
+         <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function are searched for the DLL
+         and its dependencies. If more than one directory has been added, the order in which the directories are
+         searched is unspecified. Directories in the standard search path are not searched. This value cannot be
          combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -328,13 +328,13 @@ If this value is used, directories added using the
 </dl>
 </td>
 <td width="60%">
-If this value is used and <i>lpFileName</i> specifies an absolute path, the system uses 
-         the alternate file search strategy discussed in the Remarks section to find associated executable modules 
-         that the specified module causes to be loaded. If this value is used and <i>lpFileName</i> 
+If this value is used and <i>lpFileName</i> specifies an absolute path, the system uses
+         the alternate file search strategy discussed in the Remarks section to find associated executable modules
+         that the specified module causes to be loaded. If this value is used and <i>lpFileName</i>
          specifies a relative path, the behavior is undefined.
 
-If this value is not used, or if <i>lpFileName</i> does not specify a path, the system 
-         uses the standard search strategy discussed in the Remarks section to find associated executable modules that 
+If this value is not used, or if <i>lpFileName</i> does not specify a path, the system
+         uses the standard search strategy discussed in the Remarks section to find associated executable modules that
          the specified module causes to be loaded.
 
 This value cannot be combined with any <b>LOAD_LIBRARY_SEARCH</b> flag.
@@ -379,85 +379,85 @@ If this value is used, loading a DLL for execution from the current directory is
 
 If the function succeeds, the return value is a handle to the loaded module.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, 
+If the function fails, the return value is <b>NULL</b>. To get extended error information,
        call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 
-The <b>LoadLibraryEx</b> function is very similar to the 
-     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. The differences consist of a set of 
+The <b>LoadLibraryEx</b> function is very similar to the
+     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. The differences consist of a set of
      optional behaviors that <b>LoadLibraryEx</b> provides:
 
 <ul>
-<li><b>LoadLibraryEx</b> can load a DLL module without 
+<li><b>LoadLibraryEx</b> can load a DLL module without
       calling the <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function of the DLL.</li>
-<li><b>LoadLibraryEx</b> can load a module in a way that is 
-      optimized for the case where the module will never be executed, loading the module as if it were a data 
+<li><b>LoadLibraryEx</b> can load a module in a way that is
+      optimized for the case where the module will never be executed, loading the module as if it were a data
       file.</li>
-<li><b>LoadLibraryEx</b> can find modules and their 
-      associated modules by using  either of two search strategies or it can search a process-specific set of 
+<li><b>LoadLibraryEx</b> can find modules and their
+      associated modules by using  either of two search strategies or it can search a process-specific set of
       directories.</li>
 </ul>
-You select these optional behaviors by setting the <i>dwFlags</i> parameter; if 
-     <i>dwFlags</i> is zero, 
-     <b>LoadLibraryEx</b> behaves identically to 
+You select these optional behaviors by setting the <i>dwFlags</i> parameter; if
+     <i>dwFlags</i> is zero,
+     <b>LoadLibraryEx</b> behaves identically to
      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a>.
 
-The calling process can use the handle returned by 
-    <b>LoadLibraryEx</b> to identify the module in calls to the 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>, 
-    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>, and 
+The calling process can use the handle returned by
+    <b>LoadLibraryEx</b> to identify the module in calls to the
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>,
+    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>, and
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
-To enable or disable error messages displayed by the loader during DLL loads, use the 
+To enable or disable error messages displayed by the loader during DLL loads, use the
     <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-seterrormode">SetErrorMode</a> function.
 
-It is not safe to call <b>LoadLibraryEx</b> from 
-    <a href="/windows/desktop/Dlls/dllmain">DllMain</a>. For more information, see the Remarks section in 
+It is not safe to call <b>LoadLibraryEx</b> from
+    <a href="/windows/desktop/Dlls/dllmain">DllMain</a>. For more information, see the Remarks section in
     <b>DllMain</b>.
 
-<b>Visual C++:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables: 
-      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the 
-      DLL explicitly using <b>LoadLibraryEx</b> on versions of 
-      Windows prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread 
-      local storage functions instead of <b>_declspec(thread)</b>. For an example, see 
+<b>Visual C++:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables:
+      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the
+      DLL explicitly using <b>LoadLibraryEx</b> on versions of
+      Windows prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread
+      local storage functions instead of <b>_declspec(thread)</b>. For an example, see
       <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage in a Dynamic Link Library</a>.
 
 <h3><a id="Loading_a_DLL_as_a_Data_File_or_Image_Resource"></a><a id="loading_a_dll_as_a_data_file_or_image_resource"></a><a id="LOADING_A_DLL_AS_A_DATA_FILE_OR_IMAGE_RESOURCE"></a>Loading a DLL as a Data File or Image Resource</h3>
-The <b>LOAD_LIBRARY_AS_DATAFILE</b>, 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, and 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> values affect the per-process reference count and the 
-      loading of the specified module. If any of these values is specified for the <i>dwFlags</i> 
-      parameter, the loader checks whether the module was already loaded by the process as an executable DLL. If so, 
-      this means that the module is already mapped into the virtual address space of the calling process. In this 
-      case, <b>LoadLibraryEx</b> returns a handle to the DLL and 
-      increments the DLL reference count. If the DLL module was not already loaded as a DLL, the system maps the 
-      module as a data or image file and not as an executable DLL. In this case, 
-      <b>LoadLibraryEx</b> returns a handle to the loaded data or 
+The <b>LOAD_LIBRARY_AS_DATAFILE</b>,
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, and
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> values affect the per-process reference count and the
+      loading of the specified module. If any of these values is specified for the <i>dwFlags</i>
+      parameter, the loader checks whether the module was already loaded by the process as an executable DLL. If so,
+      this means that the module is already mapped into the virtual address space of the calling process. In this
+      case, <b>LoadLibraryEx</b> returns a handle to the DLL and
+      increments the DLL reference count. If the DLL module was not already loaded as a DLL, the system maps the
+      module as a data or image file and not as an executable DLL. In this case,
+      <b>LoadLibraryEx</b> returns a handle to the loaded data or
       image file but does not increment the reference count for the module and does not make the module visible to functions such as <a href="/windows/desktop/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot">CreateToolhelp32Snapshot</a> or <a href="/windows/desktop/api/psapi/nf-psapi-enumprocessmodules">EnumProcessModules</a>.
 
-If <b>LoadLibraryEx</b> is called twice for the same file 
-      with <b>LOAD_LIBRARY_AS_DATAFILE</b>, 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, or 
+If <b>LoadLibraryEx</b> is called twice for the same file
+      with <b>LOAD_LIBRARY_AS_DATAFILE</b>,
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, or
       <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>, two separate mappings are created for the file.
 
-When the <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value is used, the module is loaded as an 
-      image using portable executable (PE) section alignment expansion. Relative virtual addresses (RVA) do not have 
-      to be mapped to disk addresses, so resources can be more quickly retrieved from the module. Specifying 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> prevents other processes from modifying the module 
+When the <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value is used, the module is loaded as an
+      image using portable executable (PE) section alignment expansion. Relative virtual addresses (RVA) do not have
+      to be mapped to disk addresses, so resources can be more quickly retrieved from the module. Specifying
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> prevents other processes from modifying the module
       while it is loaded.
 
-Unless an application depends on specific image mapping characteristics, the 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value should be used with either 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
-      <b>LOAD_LIBRARY_AS_DATAFILE</b>. This allows the loader to choose whether to load the module 
-      as an image resource or a data file, selecting whichever option enables the system to share pages more 
-      effectively. Resource  functions such as 
+Unless an application depends on specific image mapping characteristics, the
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value should be used with either
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
+      <b>LOAD_LIBRARY_AS_DATAFILE</b>. This allows the loader to choose whether to load the module
+      as an image resource or a data file, selecting whichever option enables the system to share pages more
+      effectively. Resource  functions such as
       <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> can use either mapping.
 
 
 
-To determine how a module was loaded, use one of the  following macros to test the handle returned by 
+To determine how a module was loaded, use one of the  following macros to test the handle returned by
       <b>LoadLibraryEx</b>.
 
 
@@ -477,18 +477,18 @@ The following table describes these macros.
 </tr>
 <tr>
 <td><b>LDR_IS_DATAFILE</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as a data file 
-         (<b>LOAD_LIBRARY_AS_DATAFILE</b> or 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as a data file
+         (<b>LOAD_LIBRARY_AS_DATAFILE</b> or
          <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>).</td>
 </tr>
 <tr>
 <td><b>LDR_IS_IMAGEMAPPING</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as an image file 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as an image file
          (<b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>).</td>
 </tr>
 <tr>
 <td><b>LDR_IS_RESOURCE</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as either a data file or an 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as either a data file or an
          image file.</td>
 </tr>
 </table>
@@ -496,133 +496,133 @@ The following table describes these macros.
 
 
 
-Use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> function to free a loaded module, 
-      whether or not loading the module caused its reference count to be incremented. If the module was loaded as a 
-      data or image file, the mapping is destroyed but the reference count is not decremented. Otherwise, the DLL 
-      reference count is decremented. Therefore, it is safe to call 
-      <b>FreeLibrary</b> with any handle returned by 
+Use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> function to free a loaded module,
+      whether or not loading the module caused its reference count to be incremented. If the module was loaded as a
+      data or image file, the mapping is destroyed but the reference count is not decremented. Otherwise, the DLL
+      reference count is decremented. Therefore, it is safe to call
+      <b>FreeLibrary</b> with any handle returned by
       <b>LoadLibraryEx</b>.
 
 <h3><a id="Searching_for_DLLs_and_Dependencies"></a><a id="searching_for_dlls_and_dependencies"></a><a id="SEARCHING_FOR_DLLS_AND_DEPENDENCIES"></a>Searching for DLLs and Dependencies</h3>
-The search path is the set of directories that are searched for a DLL. The 
-      <b>LoadLibraryEx</b> function can search for a DLL using a 
-      standard search path or an altered search path, or it can use a process-specific search path established with 
-      the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> and 
-      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> functions. For a list of directories 
-      and the order in which they are searched, see 
+The search path is the set of directories that are searched for a DLL. The
+      <b>LoadLibraryEx</b> function can search for a DLL using a
+      standard search path or an altered search path, or it can use a process-specific search path established with
+      the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> and
+      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> functions. For a list of directories
+      and the order in which they are searched, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-The <b>LoadLibraryEx</b> function uses the standard search 
+The <b>LoadLibraryEx</b> function uses the standard search
       path in the following cases:
       <ul>
-<li>The file name is specified without a path and the base file name does not match the base file name of a 
+<li>The file name is specified without a path and the base file name does not match the base file name of a
         loaded module, and none of the <b>LOAD_LIBRARY_SEARCH</b> flags are used.</li>
 <li>A path is specified but <b>LOAD_WITH_ALTERED_SEARCH_PATH</b> is not used.</li>
-<li>The application has not specified a default DLL search path for the process using 
+<li>The application has not specified a default DLL search path for the process using
         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a>.</li>
 </ul>
 
 
-If <i>lpFileName</i> specifies a relative path, the entire relative path is appended to 
-      every token in the DLL search path. To load a module from a relative path without searching any other path, use 
-      <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call 
-      <b>LoadLibraryEx</b> with the nonrelative path. If the module 
-      is being loaded as a datafile and the relative path starts with  ".\" or 
+If <i>lpFileName</i> specifies a relative path, the entire relative path is appended to
+      every token in the DLL search path. To load a module from a relative path without searching any other path, use
+      <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call
+      <b>LoadLibraryEx</b> with the nonrelative path. If the module
+      is being loaded as a datafile and the relative path starts with  ".\" or
       "..\", the relative path is treated as an absolute path.
 
-If <i>lpFileName</i> specifies an absolute path and <i>dwFlags</i> is 
-      set to <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>, 
-      <b>LoadLibraryEx</b> uses the altered search path. 
+If <i>lpFileName</i> specifies an absolute path and <i>dwFlags</i> is
+      set to <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>,
+      <b>LoadLibraryEx</b> uses the altered search path.
       The behavior is undefined when <b>LOAD_WITH_ALTERED_SEARCH_PATH</b> flag is set, and <i>lpFileName</i> specifies a relative path.
 
-The <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function can be used to modify 
-      the search path. This solution is better than using 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or hard-coding the full path 
-      to the DLL. However, be aware that using 
-      <b>SetDllDirectory</b> effectively disables safe DLL search 
-      mode while the specified directory is in the search path and it is not thread safe. If possible, it is best to 
-      use <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> to modify a default process 
-      search path. For more information, see 
+The <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function can be used to modify
+      the search path. This solution is better than using
+      <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or hard-coding the full path
+      to the DLL. However, be aware that using
+      <b>SetDllDirectory</b> effectively disables safe DLL search
+      mode while the specified directory is in the search path and it is not thread safe. If possible, it is best to
+      use <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> to modify a default process
+      search path. For more information, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-An application can specify the directories to search for a single 
-      <b>LoadLibraryEx</b> call by using the 
-      <b>LOAD_LIBRARY_SEARCH_*</b> flags. If more than one 
-      <b>LOAD_LIBRARY_SEARCH</b> flag is specified, the directories are searched in the following 
+An application can specify the directories to search for a single
+      <b>LoadLibraryEx</b> call by using the
+      <b>LOAD_LIBRARY_SEARCH_*</b> flags. If more than one
+      <b>LOAD_LIBRARY_SEARCH</b> flag is specified, the directories are searched in the following
       order:
       <ul>
-<li>The directory that contains the DLL (<b>LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR</b>). This 
+<li>The directory that contains the DLL (<b>LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR</b>). This
         directory is searched only for dependencies of the DLL to be loaded.</li>
 <li>The application directory (<b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>).</li>
-<li>Paths explicitly added to the application search path with the 
-        <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> function 
-        (<b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>) or the 
-        <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. If more than one path 
+<li>Paths explicitly added to the application search path with the
+        <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> function
+        (<b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>) or the
+        <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. If more than one path
         has been added, the  order in which the paths are searched is unspecified.</li>
 <li>The System32 directory (<b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>).</li>
 </ul>
 
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>The <b>LOAD_LIBRARY_SEARCH_*</b> flags are available on systems that have 
-       <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> 
-       installed. To determine whether the flags are available, use 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of the 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a>, 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-removedlldirectory">RemoveDllDirectory</a>, or 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function. If 
-       <b>GetProcAddress</b> succeeds, the 
-       <b>LOAD_LIBRARY_SEARCH_*</b> flags can be used with 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>The <b>LOAD_LIBRARY_SEARCH_*</b> flags are available on systems that have
+       <a href="https://support.microsoft.com/kb/2533623">KB2533623</a>
+       installed. To determine whether the flags are available, use
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of the
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a>,
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-removedlldirectory">RemoveDllDirectory</a>, or
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function. If
+       <b>GetProcAddress</b> succeeds, the
+       <b>LOAD_LIBRARY_SEARCH_*</b> flags can be used with
        <b>LoadLibraryEx</b>.
 
-If the application has used the 
-      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function to 
-      establish a DLL search path for the process and none of the <b>LOAD_LIBRARY_SEARCH_*</b> 
-      flags are used, the <b>LoadLibraryEx</b> function uses the 
+If the application has used the
+      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function to
+      establish a DLL search path for the process and none of the <b>LOAD_LIBRARY_SEARCH_*</b>
+      flags are used, the <b>LoadLibraryEx</b> function uses the
       process DLL search path instead of the standard search path.
 
-If a path is specified and there is a redirection file associated with the application, the 
-      <b>LoadLibraryEx</b> function searches for the module in the 
-      application directory. If the module exists in the application directory, 
-      <b>LoadLibraryEx</b> ignores the path specification and 
-      loads the module from the application directory. If the module does not exist in the application directory, the 
-      function loads the module from the specified directory. For more information, see 
+If a path is specified and there is a redirection file associated with the application, the
+      <b>LoadLibraryEx</b> function searches for the module in the
+      application directory. If the module exists in the application directory,
+      <b>LoadLibraryEx</b> ignores the path specification and
+      loads the module from the application directory. If the module does not exist in the application directory, the
+      function loads the module from the specified directory. For more information, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-redirection">Dynamic Link Library Redirection</a>.
 
-If you call <b>LoadLibraryEx</b> with the name of an 
-      assembly without a path specification and the assembly is listed in the system compatible manifest, the call is 
+If you call <b>LoadLibraryEx</b> with the name of an
+      assembly without a path specification and the assembly is listed in the system compatible manifest, the call is
       automatically redirected to the side-by-side assembly.
 
 <h3><a id="Security_Remarks"></a><a id="security_remarks"></a><a id="SECURITY_REMARKS"></a>Security Remarks</h3>
-<b>LOAD_LIBRARY_AS_DATAFILE</b> does not prevent other processes from modifying the module 
-      while it is loaded. Because this can make your application less secure, you should use 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> instead of 
-      <b>LOAD_LIBRARY_AS_DATAFILE</b> when loading a module as a data file, unless you 
-      specifically need to use <b>LOAD_LIBRARY_AS_DATAFILE</b>. Specifying 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> prevents other processes from modifying the module 
-      while it is loaded. Do not specify  <b>LOAD_LIBRARY_AS_DATAFILE</b> and 
+<b>LOAD_LIBRARY_AS_DATAFILE</b> does not prevent other processes from modifying the module
+      while it is loaded. Because this can make your application less secure, you should use
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> instead of
+      <b>LOAD_LIBRARY_AS_DATAFILE</b> when loading a module as a data file, unless you
+      specifically need to use <b>LOAD_LIBRARY_AS_DATAFILE</b>. Specifying
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> prevents other processes from modifying the module
+      while it is loaded. Do not specify  <b>LOAD_LIBRARY_AS_DATAFILE</b> and
       <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> in the same call.
 
-Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to 
-      a DLL for a subsequent <b>LoadLibraryEx</b> call. The 
-      <b>SearchPath</b> function uses a different search order than 
-      <b>LoadLibraryEx</b> and it does not use safe process search 
-      mode unless this is explicitly enabled by calling 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with 
-      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore, 
-      <b>SearchPath</b> is likely to first search the user’s current 
-      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the 
-      current working directory, the path retrieved by 
-      <b>SearchPath</b> will point to the malicious DLL, which 
+Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to
+      a DLL for a subsequent <b>LoadLibraryEx</b> call. The
+      <b>SearchPath</b> function uses a different search order than
+      <b>LoadLibraryEx</b> and it does not use safe process search
+      mode unless this is explicitly enabled by calling
+      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with
+      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore,
+      <b>SearchPath</b> is likely to first search the user’s current
+      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the
+      current working directory, the path retrieved by
+      <b>SearchPath</b> will point to the malicious DLL, which
       <b>LoadLibraryEx</b> will then load.
 
-Do not make assumptions about the operating system version based on a 
-      <b>LoadLibraryEx</b> call that searches for a DLL. If the 
-      application is running in an environment where the DLL is legitimately not present but a malicious version of 
-      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended 
-      techniques described in 
+Do not make assumptions about the operating system version based on a
+      <b>LoadLibraryEx</b> call that searches for a DLL. If the
+      application is running in an environment where the DLL is legitimately not present but a malicious version of
+      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended
+      techniques described in
       <a href="/windows/desktop/SysInfo/getting-the-system-version">Getting the System Version</a>.
 
-For a general discussion of DLL security issues, see 
+For a general discussion of DLL security issues, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-security">Dynamic-Link Library Security</a>.
 
 
@@ -632,7 +632,7 @@ The following code example demonstrates a call to **LoadLibraryExA**.
 
 ```cpp
 //Load the FMAPI DLL
-hLib = ::LoadLibraryEx(L"fmapi.dll", NULL, NULL);    
+hLib = ::LoadLibraryEx(L"fmapi.dll", NULL, NULL);
 if ( !hLib )
 {
       wprintf(L"Could not load fmapi.dll, Error #%d.\n", GetLastError());
@@ -640,7 +640,7 @@ if ( !hLib )
 }
 ```
 
-For an additional example, see 
+For an additional example, see
      <a href="/windows/desktop/NetMgmt/looking-up-text-for-error-code-numbers">Looking Up Text for Error Code Numbers</a>.
 
 <div class="code"></div>

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexa.md
@@ -78,7 +78,7 @@ The module can be a library module (a .dll file) or an executable module (an .ex
 
 If the string specifies a module name without a path and the file name extension is omitted, the function
        appends the default library extension ".DLL" to the module name. To prevent the function from appending
-       .dll to the module name, include a trailing point character (.) in the module name string.
+       ".DLL" to the module name, include a trailing point character (.) in the module name string.
 
 If the string specifies a fully qualified path, the function searches only that path for the module. When
        specifying a path, be sure to use backslashes (\\), not forward slashes (/). For more information about paths,

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
@@ -13,21 +13,21 @@ req.include-header: Windows.h
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
 req.unicode-ansi: LoadLibraryExW (Unicode) and LoadLibraryExA (ANSI)
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
 req.lib: Kernel32.lib
 req.dll: Kernel32.dll
-req.irql: 
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - LoadLibraryExW
@@ -60,39 +60,39 @@ api_name:
 
 ## -description
 
-Loads the specified module into the address space of the calling process. The specified 
+Loads the specified module into the address space of the calling process. The specified
     module may cause other modules to be loaded.
 
 ## -parameters
 
 ### -param lpLibFileName [in]
 
-A string that specifies the file name of the module to load. This name is not related to the name stored in a 
-       library module itself, as specified by the <b>LIBRARY</b> keyword in the module-definition 
+A string that specifies the file name of the module to load. This name is not related to the name stored in a
+       library module itself, as specified by the <b>LIBRARY</b> keyword in the module-definition
        (.def) file.
 
-The module can be a library module (a .dll file) or an executable module (an .exe file). If the 
-       specified module is an executable module, static imports are not loaded; instead, the module is loaded as if 
-       <b>DONT_RESOLVE_DLL_REFERENCES</b> was specified. See the <i>dwFlags</i> 
+The module can be a library module (a .dll file) or an executable module (an .exe file). If the
+       specified module is an executable module, static imports are not loaded; instead, the module is loaded as if
+       <b>DONT_RESOLVE_DLL_REFERENCES</b> was specified. See the <i>dwFlags</i>
        parameter for more information.
 
 If the string specifies a module name without a path and the file name extension is omitted, and the module name does
-       not contain any point character (.), then the function appends the default library extension .dll to the module name.
+       not contain any point character (.), then the function appends the default library extension ".DLL" to the module name.
        To prevent the function from appending .dll to the module name, include a trailing point character (.) in the module
        name string.
 
-If the string specifies a fully qualified path, the function searches only that path for the module. When 
-       specifying a path, be sure to use backslashes (\\), not forward slashes (/). For more information about paths, 
+If the string specifies a fully qualified path, the function searches only that path for the module. When
+       specifying a path, be sure to use backslashes (\\), not forward slashes (/). For more information about paths,
        see <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
-If the string specifies a module name without a path and more than one loaded module has the same base name 
+If the string specifies a module name without a path and more than one loaded module has the same base name
        and extension, the function returns a handle to the module that was loaded first.
 
-If the string specifies a module name without a path and a module of the same name is not already loaded, or 
-       if the string specifies a module name with a relative path, the function searches for the specified module. The 
-       function also searches for modules if loading the specified module causes the system to load other associated 
-       modules (that is, if the module has dependencies). The directories that are searched and the order in which 
-       they are searched depend on the specified path and the <i>dwFlags</i> parameter. For more 
+If the string specifies a module name without a path and a module of the same name is not already loaded, or
+       if the string specifies a module name with a relative path, the function searches for the specified module. The
+       function also searches for modules if loading the specified module causes the system to load other associated
+       modules (that is, if the module has dependencies). The directories that are searched and the order in which
+       they are searched depend on the specified path and the <i>dwFlags</i> parameter. For more
        information, see Remarks.
 
 If the function cannot find the  module or one of its dependencies, the function fails.
@@ -103,8 +103,8 @@ This parameter is reserved for future use. It must be <b>NULL</b>.
 
 ### -param dwFlags [in]
 
-The action to be taken when loading the module. If no flags are specified, the behavior of this function is 
-      identical to that of the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. This 
+The action to be taken when loading the module. If no flags are specified, the behavior of this function is
+      identical to that of the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. This
       parameter can be one of the following values.
 
 <table>
@@ -119,15 +119,15 @@ The action to be taken when loading the module. If no flags are specified, the b
 </dl>
 </td>
 <td width="60%">
-If this value is used, and the executable module is a DLL, the system does not call 
-         <a href="/windows/desktop/Dlls/dllmain">DllMain</a> for process and thread initialization and 
-         termination. Also, the system does not load additional executable modules that are referenced by the 
+If this value is used, and the executable module is a DLL, the system does not call
+         <a href="/windows/desktop/Dlls/dllmain">DllMain</a> for process and thread initialization and
+         termination. Also, the system does not load additional executable modules that are referenced by the
          specified module.
 
-<div class="alert"><b>Note</b>  Do not use this value; it is provided only for backward compatibility. If you are planning to access 
-         only data or resources in the DLL, use <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
-         <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> or both. Otherwise, load the library as a DLL or 
-         executable module using the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> 
+<div class="alert"><b>Note</b>  Do not use this value; it is provided only for backward compatibility. If you are planning to access
+         only data or resources in the DLL, use <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
+         <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> or both. Otherwise, load the library as a DLL or
+         executable module using the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a>
          function.</div>
 <div> </div>
 </td>
@@ -139,16 +139,16 @@ If this value is used, and the executable module is a DLL, the system does not c
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system does not check 
-         <a href="/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd723678(v=ws.10)">AppLocker</a> rules or apply 
-         <a href="/previous-versions/windows/it-pro/windows-server-2003/cc779607(v=ws.10)">Software Restriction Policies</a> 
-         for the DLL. This action applies only to the DLL being loaded and not to its dependencies. This value is 
+If this value is used, the system does not check
+         <a href="/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd723678(v=ws.10)">AppLocker</a> rules or apply
+         <a href="/previous-versions/windows/it-pro/windows-server-2003/cc779607(v=ws.10)">Software Restriction Policies</a>
+         for the DLL. This action applies only to the DLL being loaded and not to its dependencies. This value is
          recommended for use in setup programs that must run extracted DLLs during installation.
 
-<b>Windows Server 2008 R2 and Windows 7:  </b>On systems with KB2532445 installed, the caller must be running as "LocalSystem" or 
-          "TrustedInstaller"; otherwise the system ignores this flag. For more information, see 
-          "You can circumvent AppLocker rules by using an Office macro on a computer that is running Windows 7 or Windows Server 2008 R2" 
-          in the Help and Support Knowledge Base at 
+<b>Windows Server 2008 R2 and Windows 7:  </b>On systems with KB2532445 installed, the caller must be running as "LocalSystem" or
+          "TrustedInstaller"; otherwise the system ignores this flag. For more information, see
+          "You can circumvent AppLocker rules by using an Office macro on a computer that is running Windows 7 or Windows Server 2008 R2"
+          in the Help and Support Knowledge Base at
           <a href="https://support.microsoft.com/kb/2532445">https://support.microsoft.com/kb/2532445</a>.
 
 <b>Windows Server 2008, Windows Vista, Windows Server 2003 and Windows XP:  </b>AppLocker was introduced in Windows 7 and Windows Server 2008 R2.
@@ -162,15 +162,15 @@ If this value is used, the system does not check
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system maps the file into the calling process's virtual address space as if it 
-         were a data file. Nothing is done to execute or prepare to execute the mapped file. Therefore, you cannot 
-         call functions like <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamea">GetModuleFileName</a>,  
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> or 
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> with this DLL. Using this value 
-         causes writes to read-only memory to raise an access violation. Use this flag when you want to load a DLL 
+If this value is used, the system maps the file into the calling process's virtual address space as if it
+         were a data file. Nothing is done to execute or prepare to execute the mapped file. Therefore, you cannot
+         call functions like <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamea">GetModuleFileName</a>,
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> or
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> with this DLL. Using this value
+         causes writes to read-only memory to raise an access violation. Use this flag when you want to load a DLL
          only to extract messages or resources from it.
 
-This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information, 
+This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information,
          see Remarks.
 
 </td>
@@ -182,11 +182,11 @@ This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more info
 </dl>
 </td>
 <td width="60%">
-Similar to <b>LOAD_LIBRARY_AS_DATAFILE</b>, except that the DLL file is opened with 
-         exclusive write access for the calling process. Other processes cannot open the DLL file for write access 
+Similar to <b>LOAD_LIBRARY_AS_DATAFILE</b>, except that the DLL file is opened with
+         exclusive write access for the calling process. Other processes cannot open the DLL file for write access
          while it is in use. However, the DLL can still be opened by other processes.
 
-This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information, 
+This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more information,
          see Remarks.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported until Windows Vista.
@@ -200,12 +200,12 @@ This value can be used with <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>. For more info
 </dl>
 </td>
 <td width="60%">
-If this value is used, the system maps the file into the process's virtual address space as an image file. 
-         However, the loader does not load the static imports or perform the other usual initialization steps. Use 
+If this value is used, the system maps the file into the process's virtual address space as an image file.
+         However, the loader does not load the static imports or perform the other usual initialization steps. Use
          this flag when you want to load a DLL only to extract messages or resources from it.
 
-Unless the application depends on the file having the in-memory layout of an image, this value should be used with either 
-         <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
+Unless the application depends on the file having the in-memory layout of an image, this value should be used with either
+         <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
          <b>LOAD_LIBRARY_AS_DATAFILE</b>. For more information, see the Remarks section.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported  until Windows Vista.
@@ -219,12 +219,12 @@ Unless the application depends on the file having the in-memory layout of an ima
 </dl>
 </td>
 <td width="60%">
-If this value is used, the application's installation directory is searched for the DLL and its 
-         dependencies. Directories in the standard search path are not searched. This value cannot be combined with 
+If this value is used, the application's installation directory is searched for the DLL and its
+         dependencies. Directories in the standard search path are not searched. This value cannot be combined with
          <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -238,16 +238,16 @@ If this value is used, the application's installation directory is searched for 
 </dl>
 </td>
 <td width="60%">
-This value is a combination of <b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>, 
-         <b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>, and 
-         <b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>. Directories in the standard search path are not 
+This value is a combination of <b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>,
+         <b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>, and
+         <b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>. Directories in the standard search path are not
          searched. This value cannot be combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-This value represents the recommended maximum number of directories an application should include in its 
+This value represents the recommended maximum number of directories an application should include in its
          DLL search path.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -261,20 +261,20 @@ This value represents the recommended maximum number of directories an applicati
 </dl>
 </td>
 <td width="60%">
-If this value is used, the directory that contains the DLL is temporarily added to the beginning of the 
-         list of directories that are searched for the DLL's dependencies.  Directories in the standard search path 
+If this value is used, the directory that contains the DLL is temporarily added to the beginning of the
+         list of directories that are searched for the DLL's dependencies.  Directories in the standard search path
          are not searched.
 
-The <i>lpFileName</i> parameter must specify a fully qualified path. This value cannot 
+The <i>lpFileName</i> parameter must specify a fully qualified path. This value cannot
          be combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading 
-         Lib1.dll  with this value causes the system to search for Lib2.dll only in 
-         C:\Dir1. To search for Lib2.dll in C:\Dir1 and all of the directories 
+For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading
+         Lib1.dll  with this value causes the system to search for Lib2.dll only in
+         C:\Dir1. To search for Lib2.dll in C:\Dir1 and all of the directories
          in the DLL search path, combine this value with <b>LOAD_LIBRARY_DEFAULT_DIRS</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -288,12 +288,12 @@ For example, if Lib2.dll is a dependency of C:\Dir1\Lib1.dll, loading
 </dl>
 </td>
 <td width="60%">
-If this value is used, %windows%\system32 is searched for the DLL and its dependencies. 
-         Directories in the standard search path are not searched. This value cannot be combined with 
+If this value is used, %windows%\system32 is searched for the DLL and its dependencies.
+         Directories in the standard search path are not searched. This value cannot be combined with
          <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -307,15 +307,15 @@ If this value is used, %windows%\system32 is searched for the DLL and its depend
 </dl>
 </td>
 <td width="60%">
-If this value is used, directories added using the 
-         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> or the 
-         <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function are searched for the DLL 
-         and its dependencies. If more than one directory has been added, the order in which the directories are 
-         searched is unspecified. Directories in the standard search path are not searched. This value cannot be 
+If this value is used, directories added using the
+         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> or the
+         <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function are searched for the DLL
+         and its dependencies. If more than one directory has been added, the order in which the directories are
+         searched is unspecified. Directories in the standard search path are not searched. This value cannot be
          combined with <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires 
-          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>This value requires
+          <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> to be
           installed.
 
 <b>Windows Server 2003 and Windows XP:  </b>This value is not supported.
@@ -329,13 +329,13 @@ If this value is used, directories added using the
 </dl>
 </td>
 <td width="60%">
-If this value is used and <i>lpFileName</i> specifies an absolute path, the system uses 
-         the alternate file search strategy discussed in the Remarks section to find associated executable modules 
-         that the specified module causes to be loaded. If this value is used and <i>lpFileName</i> 
+If this value is used and <i>lpFileName</i> specifies an absolute path, the system uses
+         the alternate file search strategy discussed in the Remarks section to find associated executable modules
+         that the specified module causes to be loaded. If this value is used and <i>lpFileName</i>
          specifies a relative path, the behavior is undefined.
 
-If this value is not used, or if <i>lpFileName</i> does not specify a path, the system 
-         uses the standard search strategy discussed in the Remarks section to find associated executable modules that 
+If this value is not used, or if <i>lpFileName</i> does not specify a path, the system
+         uses the standard search strategy discussed in the Remarks section to find associated executable modules that
          the specified module causes to be loaded.
 
 This value cannot be combined with any <b>LOAD_LIBRARY_SEARCH</b> flag.
@@ -377,85 +377,85 @@ If this value is used, loading a DLL for execution from the current directory is
 
 If the function succeeds, the return value is a handle to the loaded module.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, 
+If the function fails, the return value is <b>NULL</b>. To get extended error information,
        call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 
-The <b>LoadLibraryEx</b> function is very similar to the 
-     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. The differences consist of a set of 
+The <b>LoadLibraryEx</b> function is very similar to the
+     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function. The differences consist of a set of
      optional behaviors that <b>LoadLibraryEx</b> provides:
 
 <ul>
-<li><b>LoadLibraryEx</b> can load a DLL module without 
+<li><b>LoadLibraryEx</b> can load a DLL module without
       calling the <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function of the DLL.</li>
-<li><b>LoadLibraryEx</b> can load a module in a way that is 
-      optimized for the case where the module will never be executed, loading the module as if it were a data 
+<li><b>LoadLibraryEx</b> can load a module in a way that is
+      optimized for the case where the module will never be executed, loading the module as if it were a data
       file.</li>
-<li><b>LoadLibraryEx</b> can find modules and their 
-      associated modules by using  either of two search strategies or it can search a process-specific set of 
+<li><b>LoadLibraryEx</b> can find modules and their
+      associated modules by using  either of two search strategies or it can search a process-specific set of
       directories.</li>
 </ul>
-You select these optional behaviors by setting the <i>dwFlags</i> parameter; if 
-     <i>dwFlags</i> is zero, 
-     <b>LoadLibraryEx</b> behaves identically to 
+You select these optional behaviors by setting the <i>dwFlags</i> parameter; if
+     <i>dwFlags</i> is zero,
+     <b>LoadLibraryEx</b> behaves identically to
      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a>.
 
-The calling process can use the handle returned by 
-    <b>LoadLibraryEx</b> to identify the module in calls to the 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>, 
-    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>, and 
+The calling process can use the handle returned by
+    <b>LoadLibraryEx</b> to identify the module in calls to the
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>,
+    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>, and
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
-To enable or disable error messages displayed by the loader during DLL loads, use the 
+To enable or disable error messages displayed by the loader during DLL loads, use the
     <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-seterrormode">SetErrorMode</a> function.
 
-It is not safe to call <b>LoadLibraryEx</b> from 
-    <a href="/windows/desktop/Dlls/dllmain">DllMain</a>. For more information, see the Remarks section in 
+It is not safe to call <b>LoadLibraryEx</b> from
+    <a href="/windows/desktop/Dlls/dllmain">DllMain</a>. For more information, see the Remarks section in
     <b>DllMain</b>.
 
-<b>Visual C++:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables: 
-      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the 
-      DLL explicitly using <b>LoadLibraryEx</b> on versions of 
-      Windows prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread 
-      local storage functions instead of <b>_declspec(thread)</b>. For an example, see 
+<b>Visual C++:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables:
+      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the
+      DLL explicitly using <b>LoadLibraryEx</b> on versions of
+      Windows prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread
+      local storage functions instead of <b>_declspec(thread)</b>. For an example, see
       <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage in a Dynamic Link Library</a>.
 
 <h3><a id="Loading_a_DLL_as_a_Data_File_or_Image_Resource"></a><a id="loading_a_dll_as_a_data_file_or_image_resource"></a><a id="LOADING_A_DLL_AS_A_DATA_FILE_OR_IMAGE_RESOURCE"></a>Loading a DLL as a Data File or Image Resource</h3>
-The <b>LOAD_LIBRARY_AS_DATAFILE</b>, 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, and 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> values affect the per-process reference count and the 
-      loading of the specified module. If any of these values is specified for the <i>dwFlags</i> 
-      parameter, the loader checks whether the module was already loaded by the process as an executable DLL. If so, 
-      this means that the module is already mapped into the virtual address space of the calling process. In this 
-      case, <b>LoadLibraryEx</b> returns a handle to the DLL and 
-      increments the DLL reference count. If the DLL module was not already loaded as a DLL, the system maps the 
-      module as a data or image file and not as an executable DLL. In this case, 
-      <b>LoadLibraryEx</b> returns a handle to the loaded data or 
+The <b>LOAD_LIBRARY_AS_DATAFILE</b>,
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, and
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> values affect the per-process reference count and the
+      loading of the specified module. If any of these values is specified for the <i>dwFlags</i>
+      parameter, the loader checks whether the module was already loaded by the process as an executable DLL. If so,
+      this means that the module is already mapped into the virtual address space of the calling process. In this
+      case, <b>LoadLibraryEx</b> returns a handle to the DLL and
+      increments the DLL reference count. If the DLL module was not already loaded as a DLL, the system maps the
+      module as a data or image file and not as an executable DLL. In this case,
+      <b>LoadLibraryEx</b> returns a handle to the loaded data or
       image file but does not increment the reference count for the module and does not make the module visible to functions such as <a href="/windows/desktop/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot">CreateToolhelp32Snapshot</a> or <a href="/windows/desktop/api/psapi/nf-psapi-enumprocessmodules">EnumProcessModules</a>.
 
-If <b>LoadLibraryEx</b> is called twice for the same file 
-      with <b>LOAD_LIBRARY_AS_DATAFILE</b>, 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, or 
+If <b>LoadLibraryEx</b> is called twice for the same file
+      with <b>LOAD_LIBRARY_AS_DATAFILE</b>,
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>, or
       <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>, two separate mappings are created for the file.
 
-When the <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value is used, the module is loaded as an 
-      image using portable executable (PE) section alignment expansion. Relative virtual addresses (RVA) do not have 
-      to be mapped to disk addresses, so resources can be more quickly retrieved from the module. Specifying 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> prevents other processes from modifying the module 
+When the <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value is used, the module is loaded as an
+      image using portable executable (PE) section alignment expansion. Relative virtual addresses (RVA) do not have
+      to be mapped to disk addresses, so resources can be more quickly retrieved from the module. Specifying
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> prevents other processes from modifying the module
       while it is loaded.
 
-Unless an application depends on specific image mapping characteristics, the 
-      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value should be used with either 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or 
-      <b>LOAD_LIBRARY_AS_DATAFILE</b>. This allows the loader to choose whether to load the module 
-      as an image resource or a data file, selecting whichever option enables the system to share pages more 
-      effectively. Resource  functions such as 
+Unless an application depends on specific image mapping characteristics, the
+      <b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b> value should be used with either
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> or
+      <b>LOAD_LIBRARY_AS_DATAFILE</b>. This allows the loader to choose whether to load the module
+      as an image resource or a data file, selecting whichever option enables the system to share pages more
+      effectively. Resource  functions such as
       <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> can use either mapping.
 
 
 
-To determine how a module was loaded, use one of the  following macros to test the handle returned by 
+To determine how a module was loaded, use one of the  following macros to test the handle returned by
       <b>LoadLibraryEx</b>.
 
 
@@ -475,18 +475,18 @@ The following table describes these macros.
 </tr>
 <tr>
 <td><b>LDR_IS_DATAFILE</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as a data file 
-         (<b>LOAD_LIBRARY_AS_DATAFILE</b> or 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as a data file
+         (<b>LOAD_LIBRARY_AS_DATAFILE</b> or
          <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b>).</td>
 </tr>
 <tr>
 <td><b>LDR_IS_IMAGEMAPPING</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as an image file 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as an image file
          (<b>LOAD_LIBRARY_AS_IMAGE_RESOURCE</b>).</td>
 </tr>
 <tr>
 <td><b>LDR_IS_RESOURCE</b>(<i>handle</i>)</td>
-<td>If this macro returns <b>TRUE</b>, the module was loaded as either a data file or an 
+<td>If this macro returns <b>TRUE</b>, the module was loaded as either a data file or an
          image file.</td>
 </tr>
 </table>
@@ -494,139 +494,139 @@ The following table describes these macros.
 
 
 
-Use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> function to free a loaded module, 
-      whether or not loading the module caused its reference count to be incremented. If the module was loaded as a 
-      data or image file, the mapping is destroyed but the reference count is not decremented. Otherwise, the DLL 
-      reference count is decremented. Therefore, it is safe to call 
-      <b>FreeLibrary</b> with any handle returned by 
+Use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> function to free a loaded module,
+      whether or not loading the module caused its reference count to be incremented. If the module was loaded as a
+      data or image file, the mapping is destroyed but the reference count is not decremented. Otherwise, the DLL
+      reference count is decremented. Therefore, it is safe to call
+      <b>FreeLibrary</b> with any handle returned by
       <b>LoadLibraryEx</b>.
 
 <h3><a id="Searching_for_DLLs_and_Dependencies"></a><a id="searching_for_dlls_and_dependencies"></a><a id="SEARCHING_FOR_DLLS_AND_DEPENDENCIES"></a>Searching for DLLs and Dependencies</h3>
-The search path is the set of directories that are searched for a DLL. The 
-      <b>LoadLibraryEx</b> function can search for a DLL using a 
-      standard search path or an altered search path, or it can use a process-specific search path established with 
-      the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> and 
-      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> functions. For a list of directories 
-      and the order in which they are searched, see 
+The search path is the set of directories that are searched for a DLL. The
+      <b>LoadLibraryEx</b> function can search for a DLL using a
+      standard search path or an altered search path, or it can use a process-specific search path established with
+      the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> and
+      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> functions. For a list of directories
+      and the order in which they are searched, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-The <b>LoadLibraryEx</b> function uses the standard search 
+The <b>LoadLibraryEx</b> function uses the standard search
       path in the following cases:
       <ul>
-<li>The file name is specified without a path and the base file name does not match the base file name of a 
+<li>The file name is specified without a path and the base file name does not match the base file name of a
         loaded module, and none of the <b>LOAD_LIBRARY_SEARCH</b> flags are used.</li>
 <li>A path is specified but <b>LOAD_WITH_ALTERED_SEARCH_PATH</b> is not used.</li>
-<li>The application has not specified a default DLL search path for the process using 
+<li>The application has not specified a default DLL search path for the process using
         <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a>.</li>
 </ul>
 
 
-If <i>lpFileName</i> specifies a relative path, the entire relative path is appended to 
-      every token in the DLL search path. To load a module from a relative path without searching any other path, use 
-      <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call 
-      <b>LoadLibraryEx</b> with the nonrelative path. If the module 
-      is being loaded as a datafile and the relative path starts with  ".\" or 
+If <i>lpFileName</i> specifies a relative path, the entire relative path is appended to
+      every token in the DLL search path. To load a module from a relative path without searching any other path, use
+      <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call
+      <b>LoadLibraryEx</b> with the nonrelative path. If the module
+      is being loaded as a datafile and the relative path starts with  ".\" or
       "..\", the relative path is treated as an absolute path.
 
-If <i>lpFileName</i> specifies an absolute path and <i>dwFlags</i> is 
-      set to <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>, 
-      <b>LoadLibraryEx</b> uses the altered search path. 
+If <i>lpFileName</i> specifies an absolute path and <i>dwFlags</i> is
+      set to <b>LOAD_WITH_ALTERED_SEARCH_PATH</b>,
+      <b>LoadLibraryEx</b> uses the altered search path.
       The behavior is undefined when <b>LOAD_WITH_ALTERED_SEARCH_PATH</b> flag is set, and <i>lpFileName</i> specifies a relative path.
 
-The <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function can be used to modify 
-      the search path. This solution is better than using 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or hard-coding the full path 
-      to the DLL. However, be aware that using 
-      <b>SetDllDirectory</b> effectively disables safe DLL search 
-      mode while the specified directory is in the search path and it is not thread safe. If possible, it is best to 
-      use <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> to modify a default process 
-      search path. For more information, see 
+The <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function can be used to modify
+      the search path. This solution is better than using
+      <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or hard-coding the full path
+      to the DLL. However, be aware that using
+      <b>SetDllDirectory</b> effectively disables safe DLL search
+      mode while the specified directory is in the search path and it is not thread safe. If possible, it is best to
+      use <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> to modify a default process
+      search path. For more information, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-An application can specify the directories to search for a single 
-      <b>LoadLibraryEx</b> call by using the 
-      <b>LOAD_LIBRARY_SEARCH_*</b> flags. If more than one 
-      <b>LOAD_LIBRARY_SEARCH</b> flag is specified, the directories are searched in the following 
+An application can specify the directories to search for a single
+      <b>LoadLibraryEx</b> call by using the
+      <b>LOAD_LIBRARY_SEARCH_*</b> flags. If more than one
+      <b>LOAD_LIBRARY_SEARCH</b> flag is specified, the directories are searched in the following
       order:
       <ul>
-<li>The directory that contains the DLL (<b>LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR</b>). This 
+<li>The directory that contains the DLL (<b>LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR</b>). This
         directory is searched only for dependencies of the DLL to be loaded.</li>
 <li>The application directory (<b>LOAD_LIBRARY_SEARCH_APPLICATION_DIR</b>).</li>
-<li>Paths explicitly added to the application search path with the 
-        <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> function 
-        (<b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>) or the 
-        <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. If more than one path 
+<li>Paths explicitly added to the application search path with the
+        <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a> function
+        (<b>LOAD_LIBRARY_SEARCH_USER_DIRS</b>) or the
+        <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. If more than one path
         has been added, the  order in which the paths are searched is unspecified.</li>
 <li>The System32 directory (<b>LOAD_LIBRARY_SEARCH_SYSTEM32</b>).</li>
 </ul>
 
 
-<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>The <b>LOAD_LIBRARY_SEARCH_*</b> flags are available on systems that have 
-       <a href="https://support.microsoft.com/kb/2533623">KB2533623</a> 
-       installed. To determine whether the flags are available, use 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of the 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a>, 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-removedlldirectory">RemoveDllDirectory</a>, or 
-       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function. If 
-       <b>GetProcAddress</b> succeeds, the 
-       <b>LOAD_LIBRARY_SEARCH_*</b> flags can be used with 
+<b>Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  </b>The <b>LOAD_LIBRARY_SEARCH_*</b> flags are available on systems that have
+       <a href="https://support.microsoft.com/kb/2533623">KB2533623</a>
+       installed. To determine whether the flags are available, use
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of the
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-adddlldirectory">AddDllDirectory</a>,
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-removedlldirectory">RemoveDllDirectory</a>, or
+       <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function. If
+       <b>GetProcAddress</b> succeeds, the
+       <b>LOAD_LIBRARY_SEARCH_*</b> flags can be used with
        <b>LoadLibraryEx</b>.
 
-If the application has used the 
-      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function to 
-      establish a DLL search path for the process and none of the <b>LOAD_LIBRARY_SEARCH_*</b> 
-      flags are used, the <b>LoadLibraryEx</b> function uses the 
+If the application has used the
+      <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories">SetDefaultDllDirectories</a> function to
+      establish a DLL search path for the process and none of the <b>LOAD_LIBRARY_SEARCH_*</b>
+      flags are used, the <b>LoadLibraryEx</b> function uses the
       process DLL search path instead of the standard search path.
 
-If a path is specified and there is a redirection file associated with the application, the 
-      <b>LoadLibraryEx</b> function searches for the module in the 
-      application directory. If the module exists in the application directory, 
-      <b>LoadLibraryEx</b> ignores the path specification and 
-      loads the module from the application directory. If the module does not exist in the application directory, the 
-      function loads the module from the specified directory. For more information, see 
+If a path is specified and there is a redirection file associated with the application, the
+      <b>LoadLibraryEx</b> function searches for the module in the
+      application directory. If the module exists in the application directory,
+      <b>LoadLibraryEx</b> ignores the path specification and
+      loads the module from the application directory. If the module does not exist in the application directory, the
+      function loads the module from the specified directory. For more information, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-redirection">Dynamic Link Library Redirection</a>.
 
-If you call <b>LoadLibraryEx</b> with the name of an 
-      assembly without a path specification and the assembly is listed in the system compatible manifest, the call is 
+If you call <b>LoadLibraryEx</b> with the name of an
+      assembly without a path specification and the assembly is listed in the system compatible manifest, the call is
       automatically redirected to the side-by-side assembly.
 
 <h3><a id="Security_Remarks"></a><a id="security_remarks"></a><a id="SECURITY_REMARKS"></a>Security Remarks</h3>
-<b>LOAD_LIBRARY_AS_DATAFILE</b> does not prevent other processes from modifying the module 
-      while it is loaded. Because this can make your application less secure, you should use 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> instead of 
-      <b>LOAD_LIBRARY_AS_DATAFILE</b> when loading a module as a data file, unless you 
-      specifically need to use <b>LOAD_LIBRARY_AS_DATAFILE</b>. Specifying 
-      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> prevents other processes from modifying the module 
-      while it is loaded. Do not specify  <b>LOAD_LIBRARY_AS_DATAFILE</b> and 
+<b>LOAD_LIBRARY_AS_DATAFILE</b> does not prevent other processes from modifying the module
+      while it is loaded. Because this can make your application less secure, you should use
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> instead of
+      <b>LOAD_LIBRARY_AS_DATAFILE</b> when loading a module as a data file, unless you
+      specifically need to use <b>LOAD_LIBRARY_AS_DATAFILE</b>. Specifying
+      <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> prevents other processes from modifying the module
+      while it is loaded. Do not specify  <b>LOAD_LIBRARY_AS_DATAFILE</b> and
       <b>LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE</b> in the same call.
 
-Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to 
-      a DLL for a subsequent <b>LoadLibraryEx</b> call. The 
-      <b>SearchPath</b> function uses a different search order than 
-      <b>LoadLibraryEx</b> and it does not use safe process search 
-      mode unless this is explicitly enabled by calling 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with 
-      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore, 
-      <b>SearchPath</b> is likely to first search the user’s current 
-      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the 
-      current working directory, the path retrieved by 
-      <b>SearchPath</b> will point to the malicious DLL, which 
+Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to
+      a DLL for a subsequent <b>LoadLibraryEx</b> call. The
+      <b>SearchPath</b> function uses a different search order than
+      <b>LoadLibraryEx</b> and it does not use safe process search
+      mode unless this is explicitly enabled by calling
+      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with
+      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore,
+      <b>SearchPath</b> is likely to first search the user’s current
+      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the
+      current working directory, the path retrieved by
+      <b>SearchPath</b> will point to the malicious DLL, which
       <b>LoadLibraryEx</b> will then load.
 
-Do not make assumptions about the operating system version based on a 
-      <b>LoadLibraryEx</b> call that searches for a DLL. If the 
-      application is running in an environment where the DLL is legitimately not present but a malicious version of 
-      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended 
-      techniques described in 
+Do not make assumptions about the operating system version based on a
+      <b>LoadLibraryEx</b> call that searches for a DLL. If the
+      application is running in an environment where the DLL is legitimately not present but a malicious version of
+      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended
+      techniques described in
       <a href="/windows/desktop/SysInfo/getting-the-system-version">Getting the System Version</a>.
 
-For a general discussion of DLL security issues, see 
+For a general discussion of DLL security issues, see
       <a href="/windows/desktop/Dlls/dynamic-link-library-security">Dynamic-Link Library Security</a>.
 
 
 #### Examples
 
-For an example, see 
+For an example, see
      <a href="/windows/desktop/NetMgmt/looking-up-text-for-error-code-numbers">Looking Up Text for Error Code Numbers</a>.
 
 <div class="code"></div>

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryexw.md
@@ -78,7 +78,7 @@ The module can be a library module (a .dll file) or an executable module (an .ex
 
 If the string specifies a module name without a path and the file name extension is omitted, and the module name does
        not contain any point character (.), then the function appends the default library extension ".DLL" to the module name.
-       To prevent the function from appending .dll to the module name, include a trailing point character (.) in the module
+       To prevent the function from appending ".DLL" to the module name, include a trailing point character (.) in the module
        name string.
 
 If the string specifies a fully qualified path, the function searches only that path for the module. When

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryw.md
@@ -90,7 +90,7 @@ If the function cannot find the  module, the function fails. When specifying a p
 
 If the string specifies a module name without a path and the file name extension is omitted, the function
        appends the default library extension ".DLL" to the module name. To prevent the function from appending
-       .dll to the module name, include a trailing point character (.) in the module name string.
+       ".DLL" to the module name, include a trailing point character (.) in the module name string.
 
 ## -returns
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-loadlibraryw.md
@@ -13,21 +13,21 @@ req.include-header: Windows.h
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]
-req.kmdf-ver: 
-req.umdf-ver: 
-req.ddi-compliance: 
+req.kmdf-ver:
+req.umdf-ver:
+req.ddi-compliance:
 req.unicode-ansi: LoadLibraryW (Unicode) and LoadLibraryA (ANSI)
-req.idl: 
-req.max-support: 
-req.namespace: 
-req.assembly: 
-req.type-library: 
+req.idl:
+req.max-support:
+req.namespace:
+req.assembly:
+req.type-library:
 req.lib: Kernel32.lib
 req.dll: Kernel32.dll
-req.irql: 
+req.irql:
 targetos: Windows
-req.typenames: 
-req.redist: 
+req.typenames:
+req.redist:
 ms.custom: 19H1
 f1_keywords:
  - LoadLibraryW
@@ -64,153 +64,153 @@ api_name:
 
 ## -description
 
-Loads the specified  module into the address space of the calling process. The specified 
+Loads the specified  module into the address space of the calling process. The specified
     module may cause other modules to be loaded.
 
-For additional load options, use the 
+For additional load options, use the
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a> function.
 
 ## -parameters
 
 ### -param lpLibFileName [in]
 
-The name of the module. This can be either a library module (a .dll file) or an executable 
-       module (an .exe file). The name specified is the file name of the module and is not related to the 
-       name stored in the library module itself, as specified by the <b>LIBRARY</b> keyword in 
+The name of the module. This can be either a library module (a .dll file) or an executable
+       module (an .exe file). The name specified is the file name of the module and is not related to the
+       name stored in the library module itself, as specified by the <b>LIBRARY</b> keyword in
        the module-definition (.def) file.
 
 If the string specifies a full path, the function searches only that path for the module.
 
-If the string specifies a relative path or a module name without a path, the function uses a standard search 
+If the string specifies a relative path or a module name without a path, the function uses a standard search
        strategy to find the module; for more information, see the Remarks.
 
-If the function cannot find the  module, the function fails. When specifying a path, be sure to use 
-       backslashes (\\), not forward slashes (/). For more information about paths, see 
+If the function cannot find the  module, the function fails. When specifying a path, be sure to use
+       backslashes (\\), not forward slashes (/). For more information about paths, see
        <a href="/windows/desktop/FileIO/naming-a-file">Naming a File or Directory</a>.
 
-If the string specifies a module name without a path and the file name extension is omitted, the function 
-       appends the default library extension .dll to the module name. To prevent the function from appending 
+If the string specifies a module name without a path and the file name extension is omitted, the function
+       appends the default library extension ".DLL" to the module name. To prevent the function from appending
        .dll to the module name, include a trailing point character (.) in the module name string.
 
 ## -returns
 
 If the function succeeds, the return value is a handle to the module.
 
-If the function fails, the return value is NULL. To get extended error information, call 
+If the function fails, the return value is NULL. To get extended error information, call
        <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 
-To enable or disable error messages displayed by the loader during DLL loads, use the 
+To enable or disable error messages displayed by the loader during DLL loads, use the
     <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-seterrormode">SetErrorMode</a> function.
 
-<b>LoadLibrary</b> can be used to load a library module into 
-    the address space of the process and return a handle that can be used in 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of a DLL function. 
-    <b>LoadLibrary</b> can also be used to load other executable 
-    modules. For example, the function can specify an .exe file to get a handle that can be used in 
-    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> or 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>. However, do not use 
-    <b>LoadLibrary</b> to run an .exe file. Instead, use 
+<b>LoadLibrary</b> can be used to load a library module into
+    the address space of the process and return a handle that can be used in
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> to get the address of a DLL function.
+    <b>LoadLibrary</b> can also be used to load other executable
+    modules. For example, the function can specify an .exe file to get a handle that can be used in
+    <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> or
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>. However, do not use
+    <b>LoadLibrary</b> to run an .exe file. Instead, use
     the <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function.
 
-If the specified module is a DLL that is not already loaded for the calling process, the system calls the 
-    DLL's <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function with the 
-    <b>DLL_PROCESS_ATTACH</b> value. If 
-    <b>DllMain</b> returns <b>TRUE</b>, 
-    <b>LoadLibrary</b> returns a handle to the module. If 
-    <b>DllMain</b> returns <b>FALSE</b>, 
-    the system unloads the DLL from the process address space and 
-    <b>LoadLibrary</b> returns <b>NULL</b>. It is 
-    not safe to call <b>LoadLibrary</b> from 
-    <b>DllMain</b>. For more information, see the Remarks section in 
+If the specified module is a DLL that is not already loaded for the calling process, the system calls the
+    DLL's <a href="/windows/desktop/Dlls/dllmain">DllMain</a> function with the
+    <b>DLL_PROCESS_ATTACH</b> value. If
+    <b>DllMain</b> returns <b>TRUE</b>,
+    <b>LoadLibrary</b> returns a handle to the module. If
+    <b>DllMain</b> returns <b>FALSE</b>,
+    the system unloads the DLL from the process address space and
+    <b>LoadLibrary</b> returns <b>NULL</b>. It is
+    not safe to call <b>LoadLibrary</b> from
+    <b>DllMain</b>. For more information, see the Remarks section in
     <b>DllMain</b>.
 
-Module handles are not global or inheritable. A call to 
-    <b>LoadLibrary</b> by one process does not produce a handle that 
-    another process can use — for example, in calling 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>. The other process must make its own 
-    call to <b>LoadLibrary</b> for the module before calling 
+Module handles are not global or inheritable. A call to
+    <b>LoadLibrary</b> by one process does not produce a handle that
+    another process can use — for example, in calling
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a>. The other process must make its own
+    call to <b>LoadLibrary</b> for the module before calling
     <b>GetProcAddress</b>.
 
-If <i>lpFileName</i> does not include a path and there is more than one loaded module with 
+If <i>lpFileName</i> does not include a path and there is more than one loaded module with
     the same base name and extension, the function returns a handle to the module that was loaded first.
 
-If no file name extension is specified in the <i>lpFileName</i> parameter, the default 
-    library extension .dll is appended. However, the file name string can include a trailing point character (.) to 
-    indicate that the module name has no extension. When no path is specified, the function searches for loaded 
-    modules whose base name matches the base name of the module to be loaded. If the name matches, the load succeeds. 
+If no file name extension is specified in the <i>lpFileName</i> parameter, the default
+    library extension .dll is appended. However, the file name string can include a trailing point character (.) to
+    indicate that the module name has no extension. When no path is specified, the function searches for loaded
+    modules whose base name matches the base name of the module to be loaded. If the name matches, the load succeeds.
     Otherwise, the function searches for the file.
 
-The first directory searched is the directory containing the image file used to create the calling process 
-    (for more information, see the 
-    <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function). Doing this allows 
-    private dynamic-link library (DLL) files associated with a process to be found without adding the process's 
-    installed directory to the PATH environment variable. If a relative path is 
-    specified, the entire relative path is appended to every token in the DLL search path list. To load a module from 
-    a relative path without searching any other path, use 
-    <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call 
-    <b>LoadLibrary</b> with the nonrelative path. For more 
-    information on the DLL search order, see 
+The first directory searched is the directory containing the image file used to create the calling process
+    (for more information, see the
+    <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa">CreateProcess</a> function). Doing this allows
+    private dynamic-link library (DLL) files associated with a process to be found without adding the process's
+    installed directory to the PATH environment variable. If a relative path is
+    specified, the entire relative path is appended to every token in the DLL search path list. To load a module from
+    a relative path without searching any other path, use
+    <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a> to get a nonrelative path and call
+    <b>LoadLibrary</b> with the nonrelative path. For more
+    information on the DLL search order, see
     <a href="/windows/desktop/Dlls/dynamic-link-library-search-order">Dynamic-Link Library Search Order</a>.
 
-The search path can be altered using the 
-    <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. This solution is recommended 
-    instead of using <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or 
+The search path can be altered using the
+    <a href="/windows/desktop/api/winbase/nf-winbase-setdlldirectorya">SetDllDirectory</a> function. This solution is recommended
+    instead of using <a href="/windows/desktop/api/winbase/nf-winbase-setcurrentdirectory">SetCurrentDirectory</a> or
     hard-coding the full path to the DLL.
 
-If a path is specified and there is a redirection file for the application, the function searches for the 
-    module in the application's directory. If the module exists in the application's directory, 
-    <b>LoadLibrary</b> ignores the specified path and loads the 
-    module from the application's directory. If the module does not exist in the application's directory, 
-    <b>LoadLibrary</b> loads the module from the specified 
-    directory. For more information, see 
+If a path is specified and there is a redirection file for the application, the function searches for the
+    module in the application's directory. If the module exists in the application's directory,
+    <b>LoadLibrary</b> ignores the specified path and loads the
+    module from the application's directory. If the module does not exist in the application's directory,
+    <b>LoadLibrary</b> loads the module from the specified
+    directory. For more information, see
     <a href="/windows/desktop/Dlls/dynamic-link-library-redirection">Dynamic Link Library Redirection</a>.
 
- If you call <b>LoadLibrary</b> with the name of an assembly 
-    without a path specification and the assembly is listed in the system compatible manifest, the call is 
+ If you call <b>LoadLibrary</b> with the name of an assembly
+    without a path specification and the assembly is listed in the system compatible manifest, the call is
     automatically redirected to the side-by-side assembly.
 
-The system maintains a per-process reference 
-    count on all loaded modules. Calling <b>LoadLibrary</b> 
-    increments the reference count. Calling the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> or 
-    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread">FreeLibraryAndExitThread</a> function decrements 
-    the reference count. The system unloads a module when its reference count reaches zero or when the process 
+The system maintains a per-process reference
+    count on all loaded modules. Calling <b>LoadLibrary</b>
+    increments the reference count. Calling the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a> or
+    <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread">FreeLibraryAndExitThread</a> function decrements
+    the reference count. The system unloads a module when its reference count reaches zero or when the process
     terminates (regardless of the reference count).
 
-<b>Windows Server 2003 and Windows XP:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables: 
-      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the 
-      DLL explicitly using <b>LoadLibrary</b> on versions of Windows 
-      prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread local 
-      storage functions instead of <b>_declspec(thread)</b>. For an example, see 
-      <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage 
+<b>Windows Server 2003 and Windows XP:  </b>The Visual C++ compiler supports a syntax that enables you to declare thread-local variables:
+      <b>_declspec(thread)</b>. If you use this syntax in a DLL, you will not be able to load the
+      DLL explicitly using <b>LoadLibrary</b> on versions of Windows
+      prior to Windows Vista. If your DLL will be loaded explicitly, you must use the thread local
+      storage functions instead of <b>_declspec(thread)</b>. For an example, see
+      <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage
       in a Dynamic Link Library</a>.
 
 <h3><a id="Security_Remarks"></a><a id="security_remarks"></a><a id="SECURITY_REMARKS"></a>Security Remarks</h3>
-Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to 
-      a DLL for a subsequent <b>LoadLibrary</b> call. The 
-      <b>SearchPath</b> function uses a different search order than 
-      <b>LoadLibrary</b> and it does not use safe process search mode 
-      unless this is explicitly enabled by calling 
-      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with 
-      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore, 
-      <b>SearchPath</b> is likely to first search the user’s current 
-      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the current 
-      working directory, the path retrieved by <b>SearchPath</b> will 
-      point to the malicious DLL, which <b>LoadLibrary</b> will then 
+Do not use the <a href="/windows/desktop/api/processenv/nf-processenv-searchpathw">SearchPath</a> function to retrieve a path to
+      a DLL for a subsequent <b>LoadLibrary</b> call. The
+      <b>SearchPath</b> function uses a different search order than
+      <b>LoadLibrary</b> and it does not use safe process search mode
+      unless this is explicitly enabled by calling
+      <a href="/windows/desktop/api/winbase/nf-winbase-setsearchpathmode">SetSearchPathMode</a> with
+      <b>BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE</b>. Therefore,
+      <b>SearchPath</b> is likely to first search the user’s current
+      working directory for the specified DLL. If an attacker has copied a malicious version of a DLL into the current
+      working directory, the path retrieved by <b>SearchPath</b> will
+      point to the malicious DLL, which <b>LoadLibrary</b> will then
       load.
 
-Do not make assumptions about the operating system version based on a 
-      <b>LoadLibrary</b> call that searches for a DLL. If the 
-      application is running in an environment where the DLL is legitimately not present but a malicious version of 
-      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended 
-      techniques described in 
+Do not make assumptions about the operating system version based on a
+      <b>LoadLibrary</b> call that searches for a DLL. If the
+      application is running in an environment where the DLL is legitimately not present but a malicious version of
+      the DLL is in the search path, the malicious version of the DLL may be loaded. Instead, use the recommended
+      techniques described in
       <a href="/windows/desktop/SysInfo/getting-the-system-version">Getting the System Version</a>.
 
 
 #### Examples
 
-For an example, see 
+For an example, see
      <a href="/windows/desktop/Dlls/using-run-time-dynamic-linking">Using Run-Time Dynamic Linking</a>.
 
 <div class="code"></div>


### PR DESCRIPTION
This clarifies the casing for the implied ".DLL" extension that the loader will apply.

Recommend viewing with "ignore whitespace" - https://github.com/MicrosoftDocs/sdk-api/pull/1097/files?diff=split&w=1