### PR TITLE
Update the connectorInstance field description

### DIFF
--- a/sdk-api-src/content/wingdi/ns-wingdi-displayconfig_target_device_name.md
+++ b/sdk-api-src/content/wingdi/ns-wingdi-displayconfig_target_device_name.md
@@ -78,6 +78,8 @@ A value from the <a href="/windows/desktop/api/wingdi/ne-wingdi-displayconfig_vi
 
 The one-based instance number of this particular target only when the adapter has multiple targets of this type. The connector instance is a consecutive one-based number that is unique within each adapter. If this is the only target of this type on the adapter, this value is zero.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ### -field monitorFriendlyDeviceName
 
 A NULL-terminated WCHAR string that is the  device name for the monitor. This name can be used with <i>SetupAPI.dll</i> to obtain the device name that is contained in the installation package.


### PR DESCRIPTION
'type' in this context is too vague. It seems that it may be referring to `DISPLAYCONFIG_TARGET_BASE_TYPE.baseOutputTechnology`?

We were trying to use `connectorInstance` as part of a composite key that would uniquely identify each target monitor connected to an adapter. However, a test system with three monitors connected returned **0** for each of them. The same system with two of those monitors disconnected (leaving only the primary monitor) returned **1** for connectorInstance.

**`connectorInstance`** seems to need a clearer, more comprehensive explanation.

I think it would also be very helpful to identify the fields (from various CCD structs) that, taken together, uniquely identify a target device, and are stable between OS restarts. It seems to me to be a common requirement to identify a display, associate some data/state to it, persist that data between runs of an app, and then retrieve it and use it to locate that display again (if it's connected). We thought connectorInstance would be a good way to do that, but it seems not. Since Microsoft's **Display settings** app seems to do all of this, some explanation would be very helpful and avoid a lot of empirical experimentation...