### PR TITLE
Line 63 updated

### DIFF
--- a/sdk-api-src/content/wincrypt/ns-wincrypt-cert_trust_status.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-cert_trust_status.md
@@ -60,7 +60,7 @@ The <b>CERT_TRUST_STATUS</b> structure contains trust information about a certif
 
 ### -field dwErrorStatus
 
-The following error status codes are defined for certificates and chains. 
+dwErrorStatus is a bitmask of the following error codes defined for certificates and chains. 
 
 
 


### PR DESCRIPTION
Changed “The following error status codes are defined for certificates and chains.”  to “dwErrorStatus is a bitmask of the following error codes defined for certificates and chains.”