### PR TITLE
Update nf-bcrypt-bcryptverifysignature.md

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptverifysignature.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptverifysignature.md
@@ -167,6 +167,17 @@ A memory allocation failure occurred.
 <tr>
 <td width="40%">
 <dl>
+<dt><b>STATUS_INVALID_PARAMETER</b></dt>
+</dl>
+</td>
+<td width="60%">
+One of supplied parameters is invalid.
+ 
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
 <dt><b>STATUS_INVALID_HANDLE</b></dt>
 </dl>
 </td>
@@ -190,7 +201,7 @@ The algorithm provider used to create the key handle specified by the <i>hKey</i
 
 ## -remarks
 
- This function decrypts the signature with the provided key and then compares the decrypted value to the specified hash value.
+ This function calculates the signature with provided key and then compares calculated signature value to the specified signature value.
 
 To use this function, you must hash the data by using the same hashing algorithm that was used to create the hash value that was signed. If applicable, you must also specify the same padding scheme that was specified when the signature was created.
 


### PR DESCRIPTION
Customer complains about unexpected STATUS_INVALID_PARAMETER status resulting from BCryptVerifySignature. 
Also, BCryptVerifySignature mechanism description in "Remarks" section is not accurate