### PR TITLE
Add a note about unified device property model to old cfgmgr32/setupapi accessors

### DIFF
--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_child.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_child.md
@@ -54,6 +54,9 @@ api_name:
 
 The <b>CM_Get_Child</b> function is used to retrieve a device instance handle to the first child node of a specified device node (<a href="/windows-hardware/drivers/">devnode</a>) in the local machine's <a href="/windows-hardware/drivers/kernel/device-tree">device tree</a>.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_Children**](/windows-hardware/drivers/install/devpkey-device-children) [property key](/windows-hardware/drivers/install/property-keys) to represent device children. See [Retrieving Device Relations](/windows-hardware/drivers/install/retrieving-device-relations) for details.
+
 ## -parameters
 
 ### -param pdnDevInst [out]

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_id_size.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_id_size.md
@@ -54,6 +54,9 @@ api_name:
 
 The <b>CM_Get_Device_ID_Size</b> function retrieves the buffer size required to hold a <a href="/windows-hardware/drivers/install/device-instance-ids">device instance ID</a> for a <a href="/windows-hardware/drivers/">device instance</a> on the local machine.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_InstanceId**](/windows-hardware/drivers/install/devpkey-device-instanceid) [property key](/windows-hardware/drivers/install/property-keys) to represent the device instance identifier. See [Retrieving a Device Instance Identifier](/windows-hardware/drivers/install/retrieving-a-device-instance-identifier) for details.
+
 ## -parameters
 
 ### -param pulLen [out]

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_ida.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_ida.md
@@ -52,6 +52,9 @@ dev_langs:
 
 The <b>CM_Get_Device_ID</b> function retrieves the <a href="/windows-hardware/drivers/install/device-instance-ids">device instance ID</a> for a specified <a href="/windows-hardware/drivers/">device instance</a> on the local machine.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_InstanceId**](/windows-hardware/drivers/install/devpkey-device-instanceid) [property key](/windows-hardware/drivers/install/property-keys) to represent the device instance identifier. See [Retrieving a Device Instance Identifier](/windows-hardware/drivers/install/retrieving-a-device-instance-identifier) for details.
+
 ## -parameters
 
 ### -param dnDevInst [in]

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_idw.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_device_idw.md
@@ -57,6 +57,9 @@ api_name:
 
 The <b>CM_Get_Device_ID</b> function retrieves the <a href="/windows-hardware/drivers/install/device-instance-ids">device instance ID</a> for a specified <a href="/windows-hardware/drivers/">device instance</a> on the local machine.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_InstanceId**](/windows-hardware/drivers/install/devpkey-device-instanceid) [property key](/windows-hardware/drivers/install/property-keys) to represent the device instance identifier. See [Retrieving a Device Instance Identifier](/windows-hardware/drivers/install/retrieving-a-device-instance-identifier) for details.
+
 ## -parameters
 
 ### -param dnDevInst [in]

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_parent.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_parent.md
@@ -54,6 +54,9 @@ api_name:
 
 The <b>CM_Get_Parent</b> function obtains a device instance handle to the parent node of a specified device node (<a href="/windows-hardware/drivers/">devnode</a>) in the local machine's device tree.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_Parent**](/windows-hardware/drivers/install/devpkey-device-parent) [property key](/windows-hardware/drivers/install/property-keys) to represent device parent. See [Retrieving Device Relations](/windows-hardware/drivers/install/retrieving-device-relations) for details.
+
 ## -parameters
 
 ### -param pdnDevInst [out]

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_sibling.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_get_sibling.md
@@ -54,6 +54,9 @@ api_name:
 
 The <b>CM_Get_Sibling</b> function obtains a device instance handle to the next sibling node of a specified device node (<a href="/windows-hardware/drivers/">devnode</a>) in the local machine's <a href="/windows-hardware/drivers/kernel/device-tree">device tree</a>.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_Siblings**](/windows-hardware/drivers/install/devpkey-device-siblings) [property key](/windows-hardware/drivers/install/property-keys) to represent device siblings. See [Retrieving Device Relations](/windows-hardware/drivers/install/retrieving-device-relations) for details.
+
 ## -parameters
 
 ### -param pdnDevInst [out]

--- a/sdk-api-src/content/setupapi/nf-setupapi-setupdigetdeviceinstanceida.md
+++ b/sdk-api-src/content/setupapi/nf-setupapi-setupdigetdeviceinstanceida.md
@@ -53,6 +53,9 @@ api_name:
 
 The <b>SetupDiGetDeviceInstanceId</b> function retrieves the <a href="/windows-hardware/drivers/install/device-instance-ids">device instance ID</a> that is associated with a device information element.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_InstanceId**](/windows-hardware/drivers/install/devpkey-device-instanceid) [property key](/windows-hardware/drivers/install/property-keys) to represent the device instance identifier. See [Retrieving a Device Instance Identifier](/windows-hardware/drivers/install/retrieving-a-device-instance-identifier) for details.
+
 ## -parameters
 
 ### -param DeviceInfoSet [in]

--- a/sdk-api-src/content/setupapi/nf-setupapi-setupdigetdeviceinstanceidw.md
+++ b/sdk-api-src/content/setupapi/nf-setupapi-setupdigetdeviceinstanceidw.md
@@ -53,6 +53,9 @@ api_name:
 
 The <b>SetupDiGetDeviceInstanceId</b> function retrieves the <a href="/windows-hardware/drivers/install/device-instance-ids">device instance ID</a> that is associated with a device information element.
 
+> [!NOTE]
+> In Windows Vista and later versions of Windows, the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-) uses the [**DEVPKEY_Device_InstanceId**](/windows-hardware/drivers/install/devpkey-device-instanceid) [property key](/windows-hardware/drivers/install/property-keys) to represent the device instance identifier. See [Retrieving a Device Instance Identifier](/windows-hardware/drivers/install/retrieving-a-device-instance-identifier) for details.
+
 ## -parameters
 
 ### -param DeviceInfoSet [in]


### PR DESCRIPTION
CM_Get_Child
CM_Get_Device_IDA
CM_Get_Device_IDW
CM_Get_Device_ID_Size
CM_Get_Parent
CM_Get_Sibling
SetupDiGetDeviceInstanceIdA
SetupDiGetDeviceInstanceIdW

Without it, it was hard to understand that there was an (preferred?) alternative.