### PR TITLE
Update nf-textstor-itextstoreacp-gettext.md

### DIFF
--- a/sdk-api-src/content/textstor/nf-textstor-itextstoreacp-gettext.md
+++ b/sdk-api-src/content/textstor/nf-textstor-itextstoreacp-gettext.md
@@ -60,7 +60,7 @@ Specifies the starting character position.
 
 ### -param acpEnd [in]
 
-Specifies the ending character position. If this parameter is 1, then return all text in the text store.
+Specifies the ending character position. If this parameter is -1, then return all text in the text store.
 
 ### -param pchPlain [out]
 


### PR DESCRIPTION
it should be -1, not 1 for acpEnds to indicate to return full string (like in line 145)