### PR TITLE
Update nf-dxgi1_4-idxgiswapchain3-resizebuffers1.md

### DIFF
--- a/sdk-api-src/content/dxgi1_4/nf-dxgi1_4-idxgiswapchain3-resizebuffers1.md
+++ b/sdk-api-src/content/dxgi1_4/nf-dxgi1_4-idxgiswapchain3-resizebuffers1.md
@@ -131,12 +131,6 @@ When a swapchain is created on a multi-GPU adapter, the backbuffers are all crea
           See <a href="/windows/win32/direct3d12/multi-engine">Multi-adapter systems</a>.
         
 
-The only difference between <a href="/windows/win32/api/dxgi/nf-dxgi-idxgiswapchain-resizebuffers">IDXGISwapChain::ResizeBuffers</a> in Windows 8 versus Windows 7 is with
-          flip presentation model swap chains that you create with the <a href="/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a> or DXGI_SWAP_EFFECT_FLIP_DISCARD value set.
-          In Windows 8, you must call <b>ResizeBuffers</b> to realize a transition between full-screen mode and windowed mode;
-          otherwise, your next call to the <a href="/windows/win32/api/dxgi/nf-dxgi-idxgiswapchain-present">IDXGISwapChain::Present</a> method fails.
-        
-
 Also see the Remarks section in <a href="/windows/win32/api/dxgi/nf-dxgi-idxgiswapchain-resizebuffers">IDXGISwapChain::ResizeBuffers</a>, all of which is relevant to <b>ResizeBuffers1</b>.
 
 ## -see-also


### PR DESCRIPTION
Remove some confusing text which was originally copied from ``ResizeBuffers``. It doesn't make any sense in this function which clearly states only works with DirectX 12, is Windows 10 specific, and doesn't apply to Windows 7 or Windows 8.