### PR TITLE
Update nf-gdiplusmatrix-matrix-matrix(real_real_real_real_real_real).md

### DIFF
--- a/sdk-api-src/content/gdiplusmatrix/nf-gdiplusmatrix-matrix-matrix(real_real_real_real_real_real).md
+++ b/sdk-api-src/content/gdiplusmatrix/nf-gdiplusmatrix-matrix-matrix(real_real_real_real_real_real).md
@@ -59,37 +59,37 @@ Creates and initializes a <b>Matrix::Matrix</b> object based on six numbers that
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the first row, first column.
+Real number that specifies the element in the first row, first column - horizontal scaling component or cosine of rotation angle.
 
 ### -param m12 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the first row, second column.
+Real number that specifies the element in the first row, second column - horizontal shear component or sine of rotation angle.
 
 ### -param m21 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the second row, first column.
+Real number that specifies the element in the second row, first column - vertical shear component or negative sine of rotation angle.
 
 ### -param m22 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the second row, second column.
+Real number that specifies the element in the second row, second column - vertical scaling component or cosine of rotation angle.
 
 ### -param dx [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the third row, first column.
+Real number that specifies the element in the third row, first column - horizontal translation component.
 
 ### -param dy [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the third row, second column.
+Real number that specifies the element in the third row, second column - vertical translation component.
 
 ## -see-also
 

--- a/sdk-api-src/content/gdiplusmatrix/nf-gdiplusmatrix-matrix-matrix(real_real_real_real_real_real).md
+++ b/sdk-api-src/content/gdiplusmatrix/nf-gdiplusmatrix-matrix-matrix(real_real_real_real_real_real).md
@@ -59,37 +59,37 @@ Creates and initializes a <b>Matrix::Matrix</b> object based on six numbers that
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the first row, first column - horizontal scaling component or cosine of rotation angle.
+Real number that specifies the element in the first row, first column&mdash;horizontal scaling component or cosine of rotation angle.
 
 ### -param m12 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the first row, second column - horizontal shear component or sine of rotation angle.
+Real number that specifies the element in the first row, second column&mdash;horizontal shear component or sine of rotation angle.
 
 ### -param m21 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the second row, first column - vertical shear component or negative sine of rotation angle.
+Real number that specifies the element in the second row, first column&mdash;vertical shear component or negative sine of rotation angle.
 
 ### -param m22 [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the second row, second column - vertical scaling component or cosine of rotation angle.
+Real number that specifies the element in the second row, second column&mdash;vertical scaling component or cosine of rotation angle.
 
 ### -param dx [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the third row, first column - horizontal translation component.
+Real number that specifies the element in the third row, first column&mdash;horizontal translation component.
 
 ### -param dy [in]
 
 Type: <b>REAL</b>
 
-Real number that specifies the element in the third row, second column - vertical translation component.
+Real number that specifies the element in the third row, second column&mdash;vertical translation component.
 
 ## -see-also
 


### PR DESCRIPTION
Current descriptions are tautologically non-descript (e.g. m11 is the first row, first column) rather than explaining what they actually mean. See the descriptions in GDI's [XFORM](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-xform) and [DWRITE_MATRIX](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_matrix) for comparison, which are both bitwise compatible with the GDI+ equivalent.

(*Just adding this because I had to look up the definitions myself and couldn't recall which was which 😅, whether it was m12 or m21 which was the negative sine.)