### PR TITLE
remove "[desktop apps only]" from RegGetValue docs

### DIFF
--- a/sdk-api-src/content/winreg/nf-winreg-reggetvaluea.md
+++ b/sdk-api-src/content/winreg/nf-winreg-reggetvaluea.md
@@ -11,8 +11,8 @@ ms.keywords: RRF_NOEXPAND, RRF_RT_ANY, RRF_RT_DWORD, RRF_RT_QWORD, RRF_RT_REG_BI
 req.header: winreg.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista, Windows XP Professional x64 Edition [desktop apps only]
-req.target-min-winversvr: Windows Server 2008, Windows Server 2003 with SP1 [desktop apps only]
+req.target-min-winverclnt: Windows Vista, Windows XP Professional x64 Edition
+req.target-min-winversvr: Windows Server 2008, Windows Server 2003 with SP1
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
The APIs are available on all windows editions.

“desktop apps only” means the APIs use is blocked by not making the API definitions available when compiling a UWP App project (see WINAPI_FAIMILY_PARTITION stuff below) and by verifying that binaries, submitted to the Windows Store did not call these APIs (this is known as the WACK).

On this API we changed this policy and allow use from apps based on the use of `WINAPI_PARTITION_APP`

winbase.h from Windows 11 SDK (22000)
```cpp
#pragma region Application Family or OneCore Family
#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP | WINAPI_PARTITION_SYSTEM)

…

WINADVAPI
LSTATUS
APIENTRY
RegGetValueW(
    _In_ HKEY hkey,
```