### PR TITLE
Update nf-processthreadsapi-getprocessinformation.md

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessinformation.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessinformation.md
@@ -102,10 +102,6 @@ If the <i>ProcessInformationClass</i> parameter is
       <code>sizeof(MEMORY_PRIORITY_INFORMATION)</code>.
 
 If the <i>ProcessInformationClass</i> parameter is 
-       <b>ProcessPowerThrottling</b>, this parameter must be 
-       <code>sizeof(PROCESS_POWER_THROTTLING_STATE)</code>.
-
-If the <i>ProcessInformationClass</i> parameter is 
        <b>ProcessProtectionLevelInfo</b>, this parameter must be 
        <code>sizeof(PROCESS_PROTECTION_LEVEL_INFORMATION)</code>.
 


### PR DESCRIPTION
remove the ProcessPowerThrottling relative info in ProcessInformationSize section as this is type is not used in getprocessinformation