### PR TITLE
Clarify ELEMENT_WISE_CLIP casting behavior

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_clip_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_clip_operator_desc.md
@@ -89,6 +89,9 @@ Type: <b><a href="/windows/desktop/WinProg/windows-data-types">FLOAT</a></b>
 
 The maximum value, above which the operator replaces the value with *Max*.
 
+## Remarks
+If the tensor data type is not *float*, then *Min* and *Max* are cast to the tensor data type before applying the clipping operation, which for integers means truncating toward zero and for floating point values rounding to nearest even.
+
 ## Availability
 This operator was introduced in `DML_FEATURE_LEVEL_1_0`.
 

--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_clip_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_clip_operator_desc.md
@@ -90,7 +90,7 @@ Type: <b><a href="/windows/desktop/WinProg/windows-data-types">FLOAT</a></b>
 The maximum value, above which the operator replaces the value with *Max*.
 
 ## Remarks
-If the tensor data type is not *float*, then *Min* and *Max* are cast to the tensor data type before applying the clipping operation, which for integers means truncating toward zero and for floating point values rounding to nearest even.
+If the tensor data type is not **float**, then *Min* and *Max* are cast to the tensor data type before applying the clipping operation (which for integers means truncating toward zero; and for floating point values rounding to the nearest even).
 
 ## Availability
 This operator was introduced in `DML_FEATURE_LEVEL_1_0`.


### PR DESCRIPTION
For https://docs.microsoft.com/en-us/windows/win32/api/directml/ns-directml-dml_element_wise_clip_operator_desc

If the tensor data type is not *float*, then *Min* and *Max* are cast to the tensor data type before applying the clipping operation, which for integers means truncating toward zero and for floating point values rounding to nearest even.