### PR TITLE
NotifyServiceStatusChange: add link to related function

### DIFF
--- a/sdk-api-src/content/winsvc/nf-winsvc-notifyservicestatuschangea.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-notifyservicestatuschangea.md
@@ -253,6 +253,6 @@ To cancel outstanding notifications, close the service handle using the <a href=
 
 <a href="/windows/desktop/api/winsvc/ns-winsvc-service_notify_2a">SERVICE_NOTIFY</a>
 
-
+<a href="/windows/desktop/services/subscribeservicechangenotifications">SubscribeServiceChangeNotifications</a>
 
 <a href="/windows/desktop/Services/service-functions">Service Functions</a>

--- a/sdk-api-src/content/winsvc/nf-winsvc-notifyservicestatuschangew.md
+++ b/sdk-api-src/content/winsvc/nf-winsvc-notifyservicestatuschangew.md
@@ -253,6 +253,6 @@ To cancel outstanding notifications, close the service handle using the <a href=
 
 <a href="/windows/desktop/api/winsvc/ns-winsvc-service_notify_2a">SERVICE_NOTIFY</a>
 
-
+<a href="/windows/desktop/services/subscribeservicechangenotifications">SubscribeServiceChangeNotifications</a>
 
 <a href="/windows/desktop/Services/service-functions">Service Functions</a>


### PR DESCRIPTION
Added link to `SubscribeServiceChangeNotifications()` function documentation to the See Also section. It may be useful as it provides very similar functionality, but is hard to find in this article as well as Service Functions section.