### PR TITLE
Remove silly WPSTYLE_MAX remark

### DIFF
--- a/sdk-api-src/content/shlobj_core/ns-shlobj_core-wallpaperopt.md
+++ b/sdk-api-src/content/shlobj_core/ns-shlobj_core-wallpaperopt.md
@@ -102,7 +102,7 @@ The wallpaper style; one of the following values:
 
 #### WPSTYLE_SPAN (0x5)
 
-0x5. <b>Introduced in Windows 8</b>. Spans the wallpaper across multiple monitors. When this value is set, the <b>WPSTYLE_MAX</b> value must also be set.
+0x5. <b>Introduced in Windows 8</b>. Spans the wallpaper across multiple monitors.
 
 
 


### PR DESCRIPTION
You can't set it to WPSTYLE_MAX because it 
1) is not the same as WPSTYLE_SPAN.
2) is not even a valid value, it is only for range checks.