### PR TITLE
Fix misnamed definition of authz rm flag for CAP

### DIFF
--- a/sdk-api-src/content/authz/nf-authz-authzinitializeresourcemanager.md
+++ b/sdk-api-src/content/authz/nf-authz-authzinitializeresourcemanager.md
@@ -2,12 +2,12 @@
 UID: NF:authz.AuthzInitializeResourceManager
 title: AuthzInitializeResourceManager function (authz.h)
 description: Uses Authz to verify that clients have access to various resources.
-helpviewer_keywords: ["AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION","AUTHZ_RM_FLAG_NO_AUDIT","AUTHZ_RM_FLAG_NO_CENTRALIZED_ACCESS_POLICIES","AuthzInitializeResourceManager","AuthzInitializeResourceManager function [Security]","_win32_authzinitializeresourcemanager","authz/AuthzInitializeResourceManager","security.authzinitializeresourcemanager"]
+helpviewer_keywords: ["AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION","AUTHZ_RM_FLAG_NO_AUDIT","AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES","AuthzInitializeResourceManager","AuthzInitializeResourceManager function [Security]","_win32_authzinitializeresourcemanager","authz/AuthzInitializeResourceManager","security.authzinitializeresourcemanager"]
 old-location: security\authzinitializeresourcemanager.htm
 tech.root: security
 ms.assetid: e3f6b37d-2c33-4b17-97b4-762bf55561c5
 ms.date: 12/05/2018
-ms.keywords: AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION, AUTHZ_RM_FLAG_NO_AUDIT, AUTHZ_RM_FLAG_NO_CENTRALIZED_ACCESS_POLICIES, AuthzInitializeResourceManager, AuthzInitializeResourceManager function [Security], _win32_authzinitializeresourcemanager, authz/AuthzInitializeResourceManager, security.authzinitializeresourcemanager
+ms.keywords: AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION, AUTHZ_RM_FLAG_NO_AUDIT, AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES, AuthzInitializeResourceManager, AuthzInitializeResourceManager function [Security], _win32_authzinitializeresourcemanager, authz/AuthzInitializeResourceManager, security.authzinitializeresourcemanager
 req.header: authz.h
 req.include-header: 
 req.target-type: Windows
@@ -98,8 +98,8 @@ The resource manager is initialized as the identity of the thread token.
 </td>
 </tr>
 <tr>
-<td width="40%"><a id="AUTHZ_RM_FLAG_NO_CENTRALIZED_ACCESS_POLICIES"></a><a id="authz_rm_flag_no_centralized_access_policies"></a><dl>
-<dt><b>AUTHZ_RM_FLAG_NO_CENTRALIZED_ACCESS_POLICIES</b></dt>
+<td width="40%"><a id="AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES"></a><a id="authz_rm_flag_no_central_access_policies"></a><dl>
+<dt><b>AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES</b></dt>
 <dt></dt>
 </dl>
 </td>


### PR DESCRIPTION
Not sure if this was a renaming that occurred in the most recent or previous version. Just happened across it.

Instead of `AUTHZ_RM_FLAG_NO_CENTRALIZED_ACCESS_POLICIES`, it appears to be `AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES`.

Windows SDK 10.0.22000.0, um/AuthZ.h:592-602
```cpp
//
// Flags for AuthzInitializeResourceManager and AuthzInitializeResourceManagerEx
//

#define AUTHZ_RM_FLAG_NO_AUDIT 0x1
#define AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION 0x2
#define AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES 0x4
#define AUTHZ_VALID_RM_INIT_FLAGS (AUTHZ_RM_FLAG_NO_AUDIT | \
        AUTHZ_RM_FLAG_INITIALIZE_UNDER_IMPERSONATION | \
        AUTHZ_RM_FLAG_NO_CENTRAL_ACCESS_POLICIES)
```

![relevant authz.h lines](https://user-images.githubusercontent.com/70316188/166449139-d4c1311b-a11e-4545-b42f-dd4aee28e2e0.png)
