### PR TITLE
Deprecate OpenIcon and CloseWindow functions

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-closewindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-closewindow.md
@@ -48,6 +48,8 @@ req.apiset: ext-ms-win-ntuser-window-l1-1-4 (introduced in Windows 10, version 1
 
 # CloseWindow function
 
+> [!IMPORTANT]
+> This API is deprecated and its use is discouraged. Use <a href="/windows/win32/api/winuser/nf-winuser-showwindow">ShowWindow</a> with <b>SW_SHOWMINIMIZED</b> parameter instead.
 
 ## -description
 

--- a/sdk-api-src/content/winuser/nf-winuser-openicon.md
+++ b/sdk-api-src/content/winuser/nf-winuser-openicon.md
@@ -47,6 +47,8 @@ api_name:
 
 # OpenIcon function
 
+> [!IMPORTANT]
+> This API is deprecated and its use is discouraged. Use <a href="/windows/win32/api/winuser/nf-winuser-showwindow">ShowWindow</a> with <b>SW_NORMAL</b> parameter instead.
 
 ## -description
 


### PR DESCRIPTION
These two methods are still here only for compatibility reasons.

See @oldnewthing's [Where did windows minimize to before the taskbar was invented?](https://devblogs.microsoft.com/oldnewthing/20041028-00/?p=37453) and [Why do minimized windows have an apparent size of 160×31?](https://devblogs.microsoft.com/oldnewthing/20050210-00/?p=36483) blog posts.

Related #1150.