### PR TITLE
Clarify recommendation in CloseThreadpoolTimer and CloseThreadpoolWait.

### DIFF
--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpooltimer.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpooltimer.md
@@ -73,7 +73,7 @@ In some cases, callback functions might run after <b>CloseThreadpoolTimer</b> ha
 * Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-setthreadpooltimer">SetThreadpoolTimer</a> function
 or <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-setthreadpooltimerex">SetThreadpoolTimerEx</a> function
 with the <i>pftDueTime</i> parameter set to NULL and the <i>msPeriod</i> and <i>msWindowLength</i> parameters set to 0.
-* Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooltimercallbacks">WaitForThreadpoolTimerCallbacks</a> function.
+* Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooltimercallbacks">WaitForThreadpoolTimerCallbacks</a> function with the <i>fCancelPendingCallbacks</i> parameter set to TRUE.
 * Call <b>CloseThreadpoolTimer</b>.
 
 If there is a cleanup group associated with the timer object, it is not necessary to call this function; calling the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-closethreadpoolcleanupgroupmembers">CloseThreadpoolCleanupGroupMembers</a> function releases the  work, wait, and timer objects associated with the cleanup group.

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait.md
@@ -72,7 +72,7 @@ In some cases, callback functions might run after <b>CloseThreadpoolWait</b> has
 * Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait">SetThreadpoolWait</a> function
 or <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwaitex">SetThreadpoolWaitEx</a> function
 with the <i>h</i> parameter set to NULL.
-* Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolwaitcallbacks">WaitForThreadpoolWaitCallbacks</a> function.
+* Call the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolwaitcallbacks">WaitForThreadpoolWaitCallbacks</a> function with the <i>fCancelPendingCallbacks</i> parameter set to TRUE.
 * Call <b>CloseThreadpoolWait</b>.
 
 If there is a cleanup group associated with the wait object, it is not necessary to call this function; calling the <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-closethreadpoolcleanupgroupmembers">CloseThreadpoolCleanupGroupMembers</a> function releases the  work, wait, and timer objects associated with the cleanup group.


### PR DESCRIPTION
It seems that a 0 duration set must be followed by a wait with cancel as TRUE in order to actually ensure that no further callbacks are called.

We ran into this bug multiple times where by using FALSE we were still getting the occasional unexpected callback, so I think clarifying the documentation here will be of great help to any future readers..