### PR TITLE
Update nf-libloaderapi-getprocaddress.md

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getprocaddress.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getprocaddress.md
@@ -59,7 +59,7 @@ api_name:
 
 ## -description
 
-Retrieves the address of an exported function or variable from the specified dynamic-link library (DLL).
+Retrieves the address of an exported function (also known as a procedure) or variable from the specified dynamic-link library (DLL).
 
 ## -parameters
 


### PR DESCRIPTION
Keep finding developers and IT pros that don't know that the Proc in GetProcAddress is for procedure. Adding a little helper text to help them connect the dots between the name and the operation that it does.