### PR TITLE
Correct required lib for virtualalloc2

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-virtualalloc2.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-virtualalloc2.md
@@ -22,7 +22,7 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.lib
+req.lib: onecore.lib
 req.dll: Kernel32.dll
 req.irql: 
 targetos: Windows


### PR DESCRIPTION
Required lib was wrong. I have no idea whether the dll is correct.