### PR TITLE
Update nf-fileapi-writefile.md

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-writefile.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-writefile.md
@@ -108,7 +108,7 @@ A pointer to the variable that receives the number of bytes written when using a
 This parameter can be <b>NULL</b> only when the <i>lpOverlapped</i> 
         parameter is not <b>NULL</b>.
         
-<b>Windows 7:  </b>This parameter can not be <b>NULL</b>.
+<b>Windows 8 and later:  </b>This parameter can be <b>NULL</b> even if the <i>lpOverlapped</i> parameter is <b>NULL</b>.
 
 For more information, see the Remarks section.
 


### PR DESCRIPTION
In Windows 7 and earlier, if lpNumberOfBytesWritten and lpOverlapped are both NULL, the program will crash.
In Windows 8 and later, if lpNumberOfBytesWritten and lpOverlapped are both NULL, the program will run as normal.
Why Windows 8 added this support but not documented is a mystery.
Probably because lpNumberOfBytesWritten in synchronous writes is duplicated as all bytes must be written in a successful synchronous write.
Formerly merged PR "Windows 7:  This parameter can not be NULL." is not correct.
In fact, in Windows 7, when lpOverlapped is not NULL, this parameter (lpNumberOfBytesWritten) CAN be NULL as usual.