### PR TITLE
Update nf-d2d1helper-colorf-colorf(float_float_float_float).md

### DIFF
--- a/sdk-api-src/content/d2d1helper/nf-d2d1helper-colorf-colorf(float_float_float_float).md
+++ b/sdk-api-src/content/d2d1helper/nf-d2d1helper-colorf-colorf(float_float_float_float).md
@@ -76,7 +76,7 @@ The blue component of the color to be constructed.
 
 Type: <b>FLOAT</b>
 
-The alpha value of the color to be constructed. An alpha channel value ranges from 0.0 to 1.0, where 0.0 represents a fully transparent color and 1.0  represents a fully opaque color. This argument is optional and if omitted will default to 1.0 (Fully opaque).
+The alpha value of the color to be constructed. An alpha channel value ranges from 0.0 to 1.0, where 0.0 represents a fully transparent color, and 1.0 represents a fully opaque color. This parameter is optional, and if omitted defaults to 1.0 (fully opaque).
 
 ## -see-also
 

--- a/sdk-api-src/content/d2d1helper/nf-d2d1helper-colorf-colorf(float_float_float_float).md
+++ b/sdk-api-src/content/d2d1helper/nf-d2d1helper-colorf-colorf(float_float_float_float).md
@@ -76,7 +76,7 @@ The blue component of the color to be constructed.
 
 Type: <b>FLOAT</b>
 
-The alpha value of the color to be constructed. An alpha channel value ranges from 0.0 to 1.0, where 0.0 represents a fully transparent color and 1.0  represents a fully opaque color.The default value is 1.0.
+The alpha value of the color to be constructed. An alpha channel value ranges from 0.0 to 1.0, where 0.0 represents a fully transparent color and 1.0  represents a fully opaque color. This argument is optional and if omitted will default to 1.0 (Fully opaque).
 
 ## -see-also
 


### PR DESCRIPTION
Fixed lack of space in alpha parameter ending sentence start (Should have had space after full stop) and added clarification, indicating that the final argument is optional. 

I was initially confused by the example [ https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1solidcolorbrush-setcolor(constd2d1_color_f_) ] which only had three arguments. Additional text for the optional argument might help fewer people be tripped up by this. 