### PR TITLE
Update the document to reflect actual annotations

### DIFF
--- a/sdk-api-src/content/winver/nf-winver-getfileversioninfoexa.md
+++ b/sdk-api-src/content/winver/nf-winver-getfileversioninfoexa.md
@@ -119,7 +119,7 @@ The name of the file. If a full path is not specified, the function uses the sea
 
 Type: <b>DWORD</b>
 
-This parameter is ignored.
+This parameter is reserved, and expected to be zero (0).
 
 ### -param dwLen [in]
 


### PR DESCRIPTION
In the library header winver.h, this function has _Reserved_ annotation on the third "dwHandle" parameter, requiring the value to be NULL or 0(zero). But currently this document indicates that the value will be ignored instead. Either update the document to reflect the current annotation on the parameter, or have the owner of the header to update the annotation to reflect the actual behavior if the function really ignores this value.