### PR TITLE
Error code c0000194

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
@@ -66,7 +66,7 @@ A pointer to the critical section object.
 
 This function does not return a value.
 
-This function can raise <b>EXCEPTION_POSSIBLE_DEADLOCK</b> if a wait operation on the critical section times out. The timeout interval is specified by the following registry value: <b>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager</b>&#92;<b>CriticalSectionTimeout</b>. Do not handle a possible deadlock exception; instead, debug the application.
+This function can raise <b>EXCEPTION_POSSIBLE_DEADLOCK</b>, also known as <b>STATUS_POSSIBLE_DEADLOCK</b>, if a wait operation on the critical section times out. The timeout interval is specified by the following registry value: <b>HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager</b>&#92;<b>CriticalSectionTimeout</b>. Do not handle a possible deadlock exception; instead, debug the application.
 
 ## -remarks
 


### PR DESCRIPTION
This error, c0000194, is defined in ntstatus.h as STATUS_POSSIBLE_DEADLOCK. Developers or support attempting to find out the cause of this exception might be looking for STATUS_POSSIBLE_DEADLOCK instead of EXCEPTION_POSSIBLE_DEADLOCK.