### PR TITLE
Correct registry key path

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-shmessageboxchecka.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-shmessageboxchecka.md
@@ -182,7 +182,7 @@ If the user selects <b>In the future, do not show me this</b> dialog box and cli
 
 The default button displayed by the message box should agree with your <i>iDefault</i> value. The lack of support for the MB_DEFBUTTON2 flag means that <i>iDefault</i> should be set to IDOK if you have specified the MB_OK or MB_OKCANCEL flag. The <i>iDefault</i> value should be set to IDYES if you have set the MB_YESNO flag.
 
-<b>SHMessageBoxCheck</b> records the message boxes that the user has chosen to suppress under the following registry key.
+<b>SHMessageBoxCheck</b> records the message boxes that the user has chosen to suppress under the following registry key:
                 
 <pre><b>HKEY_CURRENT_USER</b>
    <b>Software</b>
@@ -190,8 +190,7 @@ The default button displayed by the message box should agree with your <i>iDefau
          <b>Windows</b>
             <b>CurrentVersion</b>
                <b>Explorer</b>
-                  <b>LowRegistry</b>
-                     <b>DontShowMeThisDialogAgain</b></pre>
+                  <b>DontShowMeThisDialogAgain</b></pre>
 
 
 


### PR DESCRIPTION
Corrects the registry path used to store DoNotShowMeThisDialogAgain values.

Example:
![image](https://user-images.githubusercontent.com/475132/171675649-750f7696-59dd-49df-a9c1-be8a0ffa83ba.png)

