### PR TITLE
DML ArgMax typo in example

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_argmax_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_argmax_operator_desc.md
@@ -126,7 +126,7 @@ AxisCount: 2
 Axes: {0, 1}
 AxisDirection: DML_AXIS_DIRECTION_INCREASING
 OutputTensor: (Sizes:{1, 1}, DataType:UINT32)
-[[7]]  // argmin({1, 2, 3, 3, 0, 4, 2, 5, 2})
+[[7]]  // argmax({1, 2, 3, 3, 0, 4, 2, 5, 2})
 ```
 
 ## -remarks


### PR DESCRIPTION
Should say "argmax", not "argmin". (copy pasta)