### PR TITLE
Minor correction to structure initialisation for DnsQueryEx

### DIFF
--- a/sdk-api-src/content/windns/nf-windns-dnsqueryex.md
+++ b/sdk-api-src/content/windns/nf-windns-dnsqueryex.md
@@ -66,7 +66,7 @@ A pointer to a <a href="/windows/desktop/api/windns/ns-windns-dns_query_request"
 
 ### -param pQueryResults [in, out]
 
-A pointer to a <a href="/windows/desktop/api/windns/ns-windns-dns_query_result">DNS_QUERY_RESULT</a> structure that contains the results of the query. On input, the <b>version</b> member of  <i>pQueryResults</i> must be <b>DNS_QUERY_REQUEST_VERSION1</b> and all other members should be <b>NULL</b>. On output, the remaining members will be filled as part of the query complete. 
+A pointer to a <a href="/windows/desktop/api/windns/ns-windns-dns_query_result">DNS_QUERY_RESULT</a> structure that contains the results of the query. On input, the <b>version</b> member of  <i>pQueryResults</i> must be <b>DNS_QUERY_RESULTS_VERSION1</b> and all other members should be <b>NULL</b>. On output, the remaining members will be filled as part of the query complete. 
 
 <div class="alert"><b>Note</b>  For asynchronous queries, an application should not free
                             this structure until the <a href="/windows/desktop/api/windns/nc-windns-dns_query_completion_routine">DNS_QUERY_COMPLETION_ROUTINE</a> callback is invoked. When the query completes, the <a href="/windows/desktop/api/windns/ns-windns-dns_query_result">DNS_QUERY_RESULT</a> structure contains a pointer to a list of


### PR DESCRIPTION
The results structure version member was stated as needing initialisation to DNS_QUERY_REQUEST_VERSION1, whereas DNS_QUERY_RESULTS_VERSION1 seems like the intended value.  (Note both are #define as 0x1.)