### PR TITLE
Windows 7 requires lpNumberOfBytesRead on ReadFile to be set

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-readfile.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-readfile.md
@@ -101,6 +101,8 @@ A pointer to the variable that receives the number of bytes read when using a sy
 This parameter can be <b>NULL</b> only when the <i>lpOverlapped</i> 
        parameter is not <b>NULL</b>.
 
+<b>Windows 7:  </b>This parameter can not be <b>NULL</b>.
+
 For more information, see the Remarks section.
 
 ### -param lpOverlapped [in, out, optional]


### PR DESCRIPTION
There is an undocumented quirk existing on Windows 10 & 11 where you can use `WriteFile` and `ReadFile` without setting  `lpNumberOfBytesWritten` & `lpOverlapped`.

We ran into a bug running code on Windows 7 where it actually *must* be set.
https://github.com/GXTX/YACardEmu/commit/7e9d80b3f2

The page for `WriteFile` already warns about this behavior, so the fix here is to warn on `ReadFile` as well.