### PR TITLE
Fix COLORREF links pointing to a 404

### DIFF
--- a/sdk-api-src/content/dwmapi/ne-dwmapi-dwmwindowattribute.md
+++ b/sdk-api-src/content/dwmapi/ne-dwmapi-dwmwindowattribute.md
@@ -152,19 +152,19 @@ This value is supported starting with Windows 11 Build 22000.
 
 ### -field DWMWA_BORDER_COLOR
 
-Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the window border. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](./gdi/colorref.md). The app is responsible for changing the border color according to state changes, such as a change in window activation. 
+Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the window border. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](/windows/win32/gdi/colorref). The app is responsible for changing the border color according to state changes, such as a change in window activation. 
 
 This value is supported starting with Windows 11 Build 22000.
 
 ### -field DWMWA_CAPTION_COLOR
 
-Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the caption. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](./gdi/colorref.md). 
+Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the caption. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](/windows/win32/gdi/colorref). 
 
 This value is supported starting with Windows 11 Build 22000.
 
 ### -field DWMWA_TEXT_COLOR
 
-Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the caption text. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](./gdi/colorref.md). 
+Use with [DwmSetWindowAttribute](/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute). Specifies the color of the caption text. The <i>pvAttribute</i> parameter points to a value of type [COLORREF](/windows/win32/gdi/colorref). 
 
 This value is supported starting with Windows 11 Build 22000.
 


### PR DESCRIPTION
This pull request fixes links to documentation on `COLORREF` on [DWMWINDOWATTRIBUTE enumeration (dwmapi.h)](https://docs.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) pointing to a 404 page.