### PR TITLE
Update nf-fileapifromapp-createfilefromappw.md

### DIFF
--- a/sdk-api-src/content/fileapifromapp/nf-fileapifromapp-createfilefromappw.md
+++ b/sdk-api-src/content/fileapifromapp/nf-fileapifromapp-createfilefromappw.md
@@ -43,7 +43,7 @@ dev_langs:
 
 ## -description
 
-Creates or opens a file or I/O device. The behavior of this function is identical to [**CreateFile**](../winbase/nf-winbase-copyfilea.md), except that this function adheres to the Universal Windows Platform app security model.
+Creates or opens a file or I/O device. The behavior of this function is identical to [**CreateFile**](../fileapi/nf-fileapi-createfilew.md), except that this function adheres to the Universal Windows Platform app security model.
 
 
 ## -parameters


### PR DESCRIPTION
Attempt at fixing the hyperlink of `CreateFile` (used to link to `CopyFileA`). I'm not entirely convinced this is eventually going to refer to the URL of the *published* documentation. Please double-check.