### PR TITLE
Fix links

### DIFF
--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_delete_class_key.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_delete_class_key.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-The <b>CM_Delete_Class_Key</b> function removes the specified installed <a href="/windows-hardware/drivers/">device class</a> from the system.
+The <b>CM_Delete_Class_Key</b> function removes the specified installed <a href="/windows-hardware/drivers/install/overview-of-device-setup-classes">device class</a> from the system.
 
 ## -parameters
 

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_enumerate_classes.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_enumerate_classes.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The <b>CM_Enumerate_Classes</b> function, when called repeatedly, enumerates the local machine's installed <a href="/windows-hardware/drivers/">device classes</a> by supplying each class's GUID.
+The <b>CM_Enumerate_Classes</b> function, when called repeatedly, enumerates the local machine's installed <a href="/windows-hardware/drivers/install/overview-of-device-setup-classes">device classes</a> by supplying each class's GUID.
 
 ## -parameters
 

--- a/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_enumerate_classes_ex.md
+++ b/sdk-api-src/content/cfgmgr32/nf-cfgmgr32-cm_enumerate_classes_ex.md
@@ -52,7 +52,7 @@ api_name:
 
 <p class="CCE_Message">[Beginning with Windows 8 and Windows Server 2012, this function has been deprecated.  Please use <a href="/windows/desktop/api/cfgmgr32/nf-cfgmgr32-cm_enumerate_classes">CM_Enumerate_Classes</a> instead.]
 
-The <b>CM_Enumerate_Classes_Ex</b> function, when called repeatedly, enumerates a local or a remote machine's installed <a href="/windows-hardware/drivers/">device classes</a>, by supplying each class's GUID.
+The <b>CM_Enumerate_Classes_Ex</b> function, when called repeatedly, enumerates a local or a remote machine's installed <a href="/windows-hardware/drivers/install/overview-of-device-setup-classes">device classes</a>, by supplying each class's GUID.
 
 ## -parameters
 


### PR DESCRIPTION
`<a href="/windows-hardware/drivers/">device class</a>` -> `<a href="/windows-hardware/drivers/install/overview-of-device-setup-classes">device classes</a>`