### PR TITLE
Document that `FILE_NAME_INFO` may be modified on failure

### DIFF
--- a/sdk-api-src/content/winbase/ns-winbase-file_name_info.md
+++ b/sdk-api-src/content/winbase/ns-winbase-file_name_info.md
@@ -68,6 +68,12 @@ The size of the <b>FileName</b> string, in bytes.
 
 The file name that is returned.
 
+## -remarks
+
+If the call to `GetFileInformationByHandleEx` fails because there was not enough
+buffer space for the full length of the <b>FileName</b> then the `FileNameLength`
+field will contain the required length of the <b>FileName</b> in bytes.
+
 ## -see-also
 
 <a href="/windows/desktop/api/minwinbase/ne-minwinbase-file_info_by_handle_class">FILE_INFO_BY_HANDLE_CLASS</a>


### PR DESCRIPTION
The `FileNameLength` field of [`FILE_NAME_INFO`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_name_info) may be modified if `GetFileInformationByHandleEx` fails. Documenting this is important for two reasons:

1. it enables handling longer paths without needing to guess the length
2. it may be important to note that the `FileNameLength` field can, in some circumstances, contain a byte length larger than the currently available buffer