### PR TITLE
Fix a typo ns-winnt-image_debug_directory.md

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-image_debug_directory.md
+++ b/sdk-api-src/content/winnt/ns-winnt-image_debug_directory.md
@@ -64,7 +64,7 @@ Reserved.
 
 ### -field TimeDateStamp
 
-The ime and date the debugging information was created.
+The time and date the debugging information was created.
 
 ### -field MajorVersion
 


### PR DESCRIPTION
Just a quick fix I spotted in passing