### PR TITLE
Correct permission requirements

### DIFF
--- a/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexa.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexa.md
@@ -69,7 +69,7 @@ Retrieves the fully qualified path for the file containing the specified module.
 
 A handle to the process that contains the module.  
 
-The handle must have the <b>PROCESS_QUERY_INFORMATION</b> or <b>PROCESS_QUERY_LIMITED_INFORMATION</b> access rights. For more information, see <a href="/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
+The handle must have the <b>PROCESS_QUERY_INFORMATION</b> and <b>PROCESS_VM_READ</b> access rights. For more information, see <a href="/windows/desktop/ProcThread/process-security-and-access-rights">Process Security and Access Rights</a>.
 
 The <b>GetModuleFileNameEx</b> function does not retrieve the path for modules  that were loaded using the <b>LOAD_LIBRARY_AS_DATAFILE</b> flag. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a>.
 


### PR DESCRIPTION
This makes it consistent with the W version of the function