### PR TITLE
Clarify LeaveCriticalSection guarantees

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
@@ -80,6 +80,8 @@ If a thread calls
 <b>LeaveCriticalSection</b> when it does not have ownership of the specified critical section object, an error occurs that may cause another thread using 
 <a href="/windows/desktop/api/synchapi/nf-synchapi-entercriticalsection">EnterCriticalSection</a> to wait indefinitely.
 
+It is guaranteed that the specified CRITICAL_SECTION structure is not accessed by <b>LeaveCriticalSection</b> after the ownership of a critical section object was released.
+
 Any thread of the process can use the 
 <a href="/windows/desktop/api/synchapi/nf-synchapi-deletecriticalsection">DeleteCriticalSection</a> function to release the system resources that were allocated when the critical section object was initialized. After this function has been called, the critical section object can no longer be used for synchronization.
 

--- a/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
@@ -71,16 +71,11 @@ The threads of a single process can use a critical-section object for mutual-exc
 <a href="/windows/desktop/api/synchapi/nf-synchapi-initializecriticalsection">InitializeCriticalSection</a> or 
 <a href="/windows/desktop/api/synchapi/nf-synchapi-initializecriticalsectionandspincount">InitializeCriticalSectionAndSpinCount</a> function to initialize the object.
 
-A thread uses the 
-<a href="/windows/desktop/api/synchapi/nf-synchapi-entercriticalsection">EnterCriticalSection</a> or 
-<a href="/windows/desktop/api/synchapi/nf-synchapi-tryentercriticalsection">TryEnterCriticalSection</a> function to acquire ownership of a critical section object. To release its ownership, the thread must call 
-<b>LeaveCriticalSection</b> once for each time that it entered the critical section.
+A thread uses the <a href="/windows/desktop/api/synchapi/nf-synchapi-entercriticalsection">EnterCriticalSection</a> or <a href="/windows/desktop/api/synchapi/nf-synchapi-tryentercriticalsection">TryEnterCriticalSection</a> function to acquire ownership of a critical section object. To release its ownership, the thread must call <b>LeaveCriticalSection</b> once for each time that it entered the critical section.
 
-If a thread calls 
-<b>LeaveCriticalSection</b> when it does not have ownership of the specified critical section object, an error occurs that may cause another thread using 
-<a href="/windows/desktop/api/synchapi/nf-synchapi-entercriticalsection">EnterCriticalSection</a> to wait indefinitely.
+If a thread calls <b>LeaveCriticalSection</b> when it does not have ownership of the specified critical section object, an error occurs that may cause another thread using <a href="/windows/desktop/api/synchapi/nf-synchapi-entercriticalsection">EnterCriticalSection</a> to wait indefinitely.
 
-It is guaranteed that the specified CRITICAL_SECTION structure is not accessed by <b>LeaveCriticalSection</b> after the ownership of a critical section object was released.
+<b>LeaveCriticalSection</b> does not access the specified CRITICAL_SECTION structure after the ownership of a critical section object is released.
 
 Any thread of the process can use the 
 <a href="/windows/desktop/api/synchapi/nf-synchapi-deletecriticalsection">DeleteCriticalSection</a> function to release the system resources that were allocated when the critical section object was initialized. After this function has been called, the critical section object can no longer be used for synchronization.


### PR DESCRIPTION
In [nf-synchapi-deletecriticalsection.md](https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/synchapi/nf-synchapi-deletecriticalsection.md) the following was stated:
> The caller is responsible for ensuring that the critical section object is unowned and the specified CRITICAL_SECTION structure is not being accessed by any critical section functions called by other threads in the process.

This puts a note on a CRITICAL_SECTION structure access, but it was never stated, how this structure is accessed by LeaveCriticalSection.

The proposed change ensures that this structure is only accessed until a critical section object ownership is released.
