### PR TITLE
WideCharToMultiByte(): Clarify that terminator is included in the returned size

### DIFF
--- a/sdk-api-src/content/stringapiset/nf-stringapiset-widechartomultibyte.md
+++ b/sdk-api-src/content/stringapiset/nf-stringapiset-widechartomultibyte.md
@@ -254,7 +254,7 @@ Pointer to a buffer that receives the converted string.
 
 ### -param cbMultiByte [in]
 
-Size, in bytes, of the buffer indicated by <i>lpMultiByteStr</i>. If this parameter is set to 0, the function returns the required buffer size for <i>lpMultiByteStr</i> and makes no use of the output parameter itself.
+Size, in bytes, of the buffer indicated by <i>lpMultiByteStr</i>. If this value is 0, the function returns the required buffer size, in bytes, including any terminating null character, and makes no use of the <i>lpMultiByteStr</i> buffer.
 
 ### -param lpDefaultChar [in, optional]
 


### PR DESCRIPTION
Also for consistency with `MultiByteToWideChar()`'s documentation:

https://github.com/MicrosoftDocs/sdk-api/blob/2240eb3d0ffe3fe8fa03953e2766ab51c0a93b75/sdk-api-src/content/stringapiset/nf-stringapiset-multibytetowidechar.md#-param-cchwidechar-in