### PR TITLE
Updating imfsensoractivitymonitor example code snippets with working code

### DIFF
--- a/sdk-api-src/content/mfidl/nn-mfidl-imfsensoractivitymonitor.md
+++ b/sdk-api-src/content/mfidl/nn-mfidl-imfsensoractivitymonitor.md
@@ -169,7 +169,7 @@ HRESULT IsCameraInUse(
     bool& inUse
 )
 {
-    wil::com_ptr<MyCameraNotificationCallback> cameraNotificationCallback;
+    wil::com_ptr_nothrow<MyCameraNotificationCallback> cameraNotificationCallback;
     wil::com_ptr_nothrow<IMFSensorActivityMonitor> activityMonitor;
     wil::com_ptr_nothrow<IMFShutdown> spShutdown;
 

--- a/sdk-api-src/content/mfidl/nn-mfidl-imfsensoractivitymonitor.md
+++ b/sdk-api-src/content/mfidl/nn-mfidl-imfsensoractivitymonitor.md
@@ -100,7 +100,7 @@ The next example shows the implementation of the <a href="/windows/desktop/api/m
 
 The OnActivitiesReport function updates a boolean class member to indicate whether the queried sensor device is currently in use and then sets an event to signal that the status has been obtained.
 
-**Note** that The callback can be called multiple times and may not contain any reports hence the event is only set when reports were found.
+**Note** that the callback can be called multiple times and may not contain any reports, so the event is only set when reports were found.
 
 ```cpp
 


### PR DESCRIPTION
* Updating imfsensoractivitymonitor example code snippets with working code
* Also updated the snippets to use c++/winrt for COM callback implementation and WIL return macros/ com ptrs etc.
* Relevant doc/sample links added.