### PR TITLE
Revert "Update nf-fileapi-createfilew.md"

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-createfilew.md
@@ -142,7 +142,8 @@ To enable a process to share a file or device while another process has the file
 </dl>
 </td>
 <td width="60%">
-Prevents subsequent open operations on a file or device if they request delete, read, or write access.
+Prevents any process from opening a file or device if it requests delete, read, or write access.
+
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Reverts MicrosoftDocs/sdk-api#804, which is no longer needed thanks for a subsequent PR (#1035).