### PR TITLE
Update nf-synchapi-sleepex.md

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-sleepex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleepex.md
@@ -69,7 +69,7 @@ Suspends the current thread until the specified condition is met. Execution resu
 
 The time interval for which execution is to be suspended, in milliseconds.
 
-A value of zero, together with the bAlertable parameter set to FALSE, causes the thread to relinquish the remainder of its time slice to any other thread that is ready to run, if there are no pending user APCs on the calling thread. If there are no other threads ready to run and no user APCs are queued, the function returns immediately, and the thread continues execution.<b>Windows XP: </b>A value of zero causes the thread to relinquish the remainder of its time slice to any other thread of equal priority that is ready to run. If there are no other threads of equal priority ready to run, the function returns immediately, and the thread continues execution. This behavior changed starting with Windows Server 2003.
+A value of zero causes the thread to relinquish the remainder of its time slice to any other thread that is ready to run. If there are no other threads ready to run, the function returns immediately, and the thread continues execution.<b>Windows XP: </b>A value of zero causes the thread to relinquish the remainder of its time slice to any other thread of equal priority that is ready to run. If there are no other threads of equal priority ready to run, the function returns immediately, and the thread continues execution. This behavior changed starting with Windows Server 2003.
 
 
 
@@ -77,10 +77,10 @@ A value of INFINITE indicates that the suspension should not time out.
 
 ### -param bAlertable [in]
 
-If this parameter is FALSE, the function does not return until the time-out period has elapsed. If an I/O completion callback occurs, the function does not return and the I/O completion function is not executed. If an APC is queued to the thread, the function does not return and the APC function is not executed.
+If this parameter is FALSE, the function does not return until the time-out period has elapsed. If an I/O completion callback occurs, the function does not immediately return and the I/O completion function is not executed. If an APC is queued to the thread, the function does not immediately return and the APC function is not executed.
 
 If the parameter is TRUE and the thread that called this function is the same thread that called the extended I/O function (<a href="/windows/desktop/api/fileapi/nf-fileapi-readfileex">ReadFileEx</a> or 
-<a href="/windows/desktop/api/fileapi/nf-fileapi-writefileex">WriteFileEx</a>), the function returns when either the time-out period has elapsed or when an I/O completion callback function occurs. If an I/O completion callback occurs, the I/O completion function is called. If an APC is queued to the thread (<a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-queueuserapc">QueueUserAPC</a>), the function returns when either the timer-out period has elapsed or when the APC function is called.
+<a href="/windows/desktop/api/fileapi/nf-fileapi-writefileex">WriteFileEx</a>), the function returns when either the time-out period has elapsed or when an I/O completion callback function occurs. If an I/O completion callback occurs, the I/O completion function is called. If an APC is queued to the thread (<a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-queueuserapc">QueueUserAPC</a>), the function returns when either the time-out period has elapsed or when the APC function is called.
 
 ## -returns
 


### PR DESCRIPTION
In the description of the dwMilliseconds parameter, the mention of pending APCs combined with the bAlertable parameter set to FALSE was misleading.  When bAlertable is FALSE, APCs will not be delivered.  I.e. the result is the same whether an APC is queued or not - no APC callback will execute.  To say "if there are no pending user APCs" implied that this condition would somehow impact the outcome.

In the bAlertable description, I was initially confused by the phrase "the function does not return".  I now understand that it means "does not return immediately".  I added those words for clarity, but leave it at your discretion as to whether that is needed.

Small typo correcting "timer-out" to "time-out"