### PR TITLE
Update nf-evntrace-controltracew.md to document ERROR_ACTIVE_CONNECTIONS return.

### DIFF
--- a/sdk-api-src/content/evntrace/nf-evntrace-controltracew.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-controltracew.md
@@ -273,6 +273,11 @@ are some common errors and their causes.
 - **ERROR_WMI_INSTANCE_NOT_FOUND**
 
   The given session is not running.
+  
+- **ERROR_ACTIVE_CONNECTIONS**
+
+  When returned from a EVENT_TRACE_CONTROL_STOP call, this indicates that
+  the session is already in the process of stopping.
 
 ## -remarks
 


### PR DESCRIPTION
Document ERROR_ACTIVE_CONNECTIONS return, since it's nearly impossible to parse the meaning from the name alone.