### PR TITLE
Add missing backslash in FindFirstFile* functions

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-findfirstfilea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-findfirstfilea.md
@@ -158,16 +158,17 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root 
      directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\Server\Share\*". However, you cannot use an <i>lpFileName</i> 
-    that points to the share itself; for example, "\\Server\Share" is not valid.
+    "\\\\Server\\Share\\*". However, you cannot use an <i>lpFileName</i> 
+    that points to the share itself; for example, "\\\\Server\\Share" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the 
-    directory "C:\Windows", not about a directory or file in 
-    "C:\Windows". To examine the files and directories in 
-    "C:\Windows", use an <i>lpFileName</i> of 
-    "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the 
+    directory "C:\\Windows", not about a directory or file in 
+    "C:\\Windows". To examine the files and directories in 
+    "C:\\Windows", use an <i>lpFileName</i> of 
+    "C:\\Windows\\*".
 
 Be aware that some other thread or process could create or delete a file with this name between the time you 
     query for the result and the time you act on the information. If this is a potential concern for your application, 

--- a/sdk-api-src/content/fileapi/nf-fileapi-findfirstfileexa.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-findfirstfileexa.md
@@ -232,16 +232,17 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 </ul>
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\server\service\*". However, you cannot use an <i>lpFileName</i> that points 
-    to the share itself; for example, "\\server\service" is not valid.
+    "\\\\server\\service\\*". However, you cannot use an <i>lpFileName</i> that points 
+    to the share itself; for example, "\\\\server\\service" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the 
-    directory "C:\Windows", not about a directory or file in 
-    "C:\Windows". To examine the files and directories in 
-    "C:\Windows", use an <i>lpFileName</i> of 
-    "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the 
+    directory "C:\\Windows", not about a directory or file in 
+    "C:\\Windows". To examine the files and directories in 
+    "C:\\Windows", use an <i>lpFileName</i> of 
+    "C:\\Windows\\*".
 
 The following call:
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-findfirstfileexw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-findfirstfileexw.md
@@ -232,16 +232,17 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 </ul>
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\server\service\*". However, you cannot use an <i>lpFileName</i> that points 
-    to the share itself; for example, "\\server\service" is not valid.
+    "\\\\server\\service\\*". However, you cannot use an <i>lpFileName</i> that points 
+    to the share itself; for example, "\\\\server\\service" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the 
-    directory "C:\Windows", not about a directory or file in 
-    "C:\Windows". To examine the files and directories in 
-    "C:\Windows", use an <i>lpFileName</i> of 
-    "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the 
+    directory "C:\\Windows", not about a directory or file in 
+    "C:\\Windows". To examine the files and directories in 
+    "C:\\Windows", use an <i>lpFileName</i> of 
+    "C:\\Windows\\*".
 
 The following call:
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-findfirstfilew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-findfirstfilew.md
@@ -158,16 +158,17 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root 
      directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\Server\Share\*". However, you cannot use an <i>lpFileName</i> 
-    that points to the share itself; for example, "\\Server\Share" is not valid.
+    "\\\\Server\\Share\\*". However, you cannot use an <i>lpFileName</i> 
+    that points to the share itself; for example, "\\\\Server\\Share" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the 
-    directory "C:\Windows", not about a directory or file in 
-    "C:\Windows". To examine the files and directories in 
-    "C:\Windows", use an <i>lpFileName</i> of 
-    "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the 
+    directory "C:\\Windows", not about a directory or file in 
+    "C:\\Windows". To examine the files and directories in 
+    "C:\\Windows", use an <i>lpFileName</i> of 
+    "C:\\Windows\\*".
 
 Be aware that some other thread or process could create or delete a file with this name between the time you 
     query for the result and the time you act on the information. If this is a potential concern for your application, 

--- a/sdk-api-src/content/winbase/nf-winbase-findfirstfiletransacteda.md
+++ b/sdk-api-src/content/winbase/nf-winbase-findfirstfiletransacteda.md
@@ -197,13 +197,14 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 </ul>
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\server\service\*". However, you cannot use an <i>lpFileName</i> that points to 
-    the share itself; for example, "\\server\service" is not valid.
+    "\\\\server\\service\*". However, you cannot use an <i>lpFileName</i> that points to 
+    the share itself; for example, "\\\\server\\service" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the directory 
-    "C:\Windows", not about a directory or file in "C:\Windows". To examine the files and directories in "C:\Windows", use an <i>lpFileName</i> of "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the directory 
+    "C:\\Windows", not about a directory or file in "C:\\Windows". To examine the files and directories in "C:\\Windows", use an <i>lpFileName</i> of "C:\\Windows\\*".
 
 Be aware that some other thread or process could create or delete a file with this name between the time you query for the result 
     and the time you act on the information. If this is a potential concern for your application,  one possible solution is to use the 

--- a/sdk-api-src/content/winbase/nf-winbase-findfirstfiletransactedw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-findfirstfiletransactedw.md
@@ -197,13 +197,14 @@ As stated previously, you cannot use a trailing backslash (\\) in the <i>lpFileN
 </ul>
 <div class="alert"><b>Note</b>  Prepending the string "\\?\" does not allow access to the root directory.</div>
 <div> </div>
+
 On network shares, you can use an <i>lpFileName</i> in the form of the following: 
-    "\\server\service\*". However, you cannot use an <i>lpFileName</i> that points to 
-    the share itself; for example, "\\server\service" is not valid.
+    "\\\\server\\service\*". However, you cannot use an <i>lpFileName</i> that points to 
+    the share itself; for example, "\\\\server\\service" is not valid.
 
 To examine a directory that is not a root directory, use the path to that directory, without a trailing 
-    backslash. For example, an argument of "C:\Windows" returns information about the directory 
-    "C:\Windows", not about a directory or file in "C:\Windows". To examine the files and directories in "C:\Windows", use an <i>lpFileName</i> of "C:\Windows\*".
+    backslash. For example, an argument of "C:\\Windows" returns information about the directory 
+    "C:\\Windows", not about a directory or file in "C:\\Windows". To examine the files and directories in "C:\\Windows", use an <i>lpFileName</i> of "C:\\Windows\\*".
 
 Be aware that some other thread or process could create or delete a file with this name between the time you query for the result 
     and the time you act on the information. If this is a potential concern for your application,  one possible solution is to use the 


### PR DESCRIPTION
Fix `C:\Windows*` to `C:\Windows\*`