### PR TITLE
Update nf-gdipluspen-pen-pen(constbrush_real).md

### DIFF
--- a/sdk-api-src/content/gdipluspen/nf-gdipluspen-pen-pen(constbrush_real).md
+++ b/sdk-api-src/content/gdipluspen/nf-gdipluspen-pen-pen(constbrush_real).md
@@ -65,7 +65,7 @@ Pointer to a brush to base this pen on.
 
 Type: <b>REAL</b>
 
-Optional. Real number that specifies the width of this pen's stroke. The default value is 1.0.  If this value is 0, the width in device units is always 1 pixel, except that the `width` will not be affected by scale-transform operations that are in effect for the Graphics object that the <xref:System.Drawing.Pen> is used for, resulting in the width to be always 1 pixel.
+Optional. Real number that specifies the width of this pen's stroke. The default value is 1.0.  If this value is 0, the width in device units is always 1 pixel, except that the `width` will not be affected by scale-transform operations that are in effect for the Graphics object that the <xref:System.Drawing.Pen> is used for; the width will always be 1 pixel.
 
 ## -remarks
 

--- a/sdk-api-src/content/gdipluspen/nf-gdipluspen-pen-pen(constbrush_real).md
+++ b/sdk-api-src/content/gdipluspen/nf-gdipluspen-pen-pen(constbrush_real).md
@@ -65,7 +65,7 @@ Pointer to a brush to base this pen on.
 
 Type: <b>REAL</b>
 
-Optional. Real number that specifies the width of this pen's stroke. The default value is 1.0.
+Optional. Real number that specifies the width of this pen's stroke. The default value is 1.0.  If this value is 0, the width in device units is always 1 pixel, except that the `width` will not be affected by scale-transform operations that are in effect for the Graphics object that the <xref:System.Drawing.Pen> is used for, resulting in the width to be always 1 pixel.
 
 ## -remarks
 


### PR DESCRIPTION
This is to address an incomplete explanation of what happens when width is set to 0.