### PR TITLE
Fix copyable function signature for ITextProvider::get_SupportedTextSelection.

### DIFF
--- a/sdk-api-src/content/uiautomationcore/nf-uiautomationcore-itextprovider-get_supportedtextselection.md
+++ b/sdk-api-src/content/uiautomationcore/nf-uiautomationcore-itextprovider-get_supportedtextselection.md
@@ -66,7 +66,7 @@ When this function returns, contains a pointer to the [SupportedTextSelection](.
 ## -syntax
 
 ```cpp
-HRESULT SupportedTextSelection (SupportedTextSelection *pRetVal);
+HRESULT get_SupportedTextSelection (SupportedTextSelection *pRetVal);
 ```
 
 ## -remarks


### PR DESCRIPTION
After this change, the copyable function signature no longer conflicts with the signature declared in UIAutomationCore.h.