### PR TITLE
HRESULT_FROM_WIN32: Replace HTML escapes in the example

### DIFF
--- a/sdk-api-src/content/winerror/nf-winerror-hresult_from_win32.md
+++ b/sdk-api-src/content/winerror/nf-winerror-hresult_from_win32.md
@@ -68,11 +68,11 @@ This macro is defined as follows:
 // HRESULT_FROM_WIN32(x) used to be a macro, however we now run it as an inline function
 // to prevent double evaluation of 'x'. If you still need the macro, you can use __HRESULT_FROM_WIN32(x)
 //
-#define __HRESULT_FROM_WIN32(x) ((HRESULT)(x) &lt;= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) &amp; 0x0000FFFF) | (FACILITY_WIN32 &lt;&lt; 16) | 0x80000000)))
+#define __HRESULT_FROM_WIN32(x) ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000)))
 
 #ifndef __midl
 FORCEINLINE HRESULT HRESULT_FROM_WIN32(unsigned long x) { 
-   return (HRESULT)(x) &lt;= 0 ? (HRESULT)(x) : (HRESULT) (((x) &amp; 0x0000FFFF) | (FACILITY_WIN32 &lt;&lt; 16) | 0x80000000);
+   return (HRESULT)(x) <= 0 ? (HRESULT)(x) : (HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000);
 }
 #else
 #define HRESULT_FROM_WIN32(x) __HRESULT_FROM_WIN32(x)


### PR DESCRIPTION
I noticed that this example has some HTML escapes left over so I removed them so that the example renders properly.