### PR TITLE
MEM_EXTENDED_PARAMETER: Fix incorrect links to MEM_ADDRESS_REQUIREMENTS

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
@@ -62,7 +62,7 @@ Represents an extended parameter for a function that manages virtual memory.
 
 A <a href="../winnt/ne-winnt-mem_extended_parameter_type.md">MEM_EXTENDED_PARAMETER_TYPE</a> value that indicates the type of the parameter.
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements.md">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
 
 If <i>Type</i> is set to <b>MemExtendedParameterNumaNode</b>, then <i>ULong</i> must be set to the desired node number.
 
@@ -76,7 +76,7 @@ Reserved.
 
 ### -field DUMMYUNIONNAME.Pointer
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements.md">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
 
 ### -field DUMMYUNIONNAME.Size
 

--- a/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
@@ -62,7 +62,7 @@ Represents an extended parameter for a function that manages virtual memory.
 
 A <a href="../winnt/ne-winnt-mem_extended_parameter_type.md">MEM_EXTENDED_PARAMETER_TYPE</a> value that indicates the type of the parameter.
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements.md">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated [MEM_ADDRESS_REQUIREMENTS](/windows/win32/api/winnt/ns-winnt-mem_address_requirements) structure that specifies the lowest and highest base address and alignment.
 
 If <i>Type</i> is set to <b>MemExtendedParameterNumaNode</b>, then <i>ULong</i> must be set to the desired node number.
 
@@ -76,7 +76,7 @@ Reserved.
 
 ### -field DUMMYUNIONNAME.Pointer
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements.md">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated [MEM_ADDRESS_REQUIREMENTS](/windows/win32/api/winnt/ns-winnt-mem_address_requirements) structure that specifies the lowest and highest base address and alignment.
 
 ### -field DUMMYUNIONNAME.Size
 

--- a/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_extended_parameter.md
@@ -62,7 +62,7 @@ Represents an extended parameter for a function that manages virtual memory.
 
 A <a href="../winnt/ne-winnt-mem_extended_parameter_type.md">MEM_EXTENDED_PARAMETER_TYPE</a> value that indicates the type of the parameter.
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="https://msdn.microsoft.com/en-us/library/Mt832846(v=VS.85).aspx">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
 
 If <i>Type</i> is set to <b>MemExtendedParameterNumaNode</b>, then <i>ULong</i> must be set to the desired node number.
 
@@ -76,7 +76,7 @@ Reserved.
 
 ### -field DUMMYUNIONNAME.Pointer
 
-If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="https://msdn.microsoft.com/en-us/library/Mt832846(v=VS.85).aspx">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
+If <i>Type</i> is set to <b>MemExtendedParameterAddressRequirements</b>, then <i>Pointer</i> must be a pointer to a caller-allocated <a href="../winnt/ns-winnt-mem_address_requirements">MEM_ADDRESS_REQUIREMENTS</a> structure that specifies the lowest and highest base address and alignment.
 
 ### -field DUMMYUNIONNAME.Size
 


### PR DESCRIPTION
The links on this page to MEM_ADDRESS_REQUIREMENTS don't exist anymore so they just lead to the Microsoft technical documentation home page. I've fixed them with links to the actual pages. I'm not entirely sure that `../winnt` is required (could be replaced by `./` or nothing?) but that's what the existing link to MEM_EXTENDED_PARAMETER_TYPE does so it seemed like that was a reasonable idea to follow in case there was a good reason.