### PR TITLE
Update nf-wow64apiset-getsystemwow64directory2w.md

### DIFF
--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.dll
-req.dll: Kernel32.lib
+req.lib: KernelBase.dll
+req.dll: OneCore.lib or mincore.lib
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: KernelBase.dll
-req.dll: OneCore.lib or mincore.lib
+req.lib: OneCore.lib or mincore.lib
+req.dll: KernelBase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -40,7 +40,8 @@ topic_type:
 api_type:
  - DllExport
 api_location:
- - kernel32.lib
+ - OneCore.lib
+ - mincore.lib
  - API-MS-Win-Core-Wow64-L1-1-1.dll
  - KernelBase.dll
 api_name:


### PR DESCRIPTION
Documentation refers to Kernel32.dll and Kernel32.lib but there is no such function in them. But this function contained in OneCore.lib and mincore.lib (checked SDK's for 21H2 and Windows 11).
Also lib and dll columns mismatched.