### PR TITLE
Add ISwapChainPanelNative::SetSwapChain remarks

### DIFF
--- a/sdk-api-src/content/windows.ui.xaml.media.dxinterop/nf-windows-ui-xaml-media-dxinterop-iswapchainpanelnative-setswapchain.md
+++ b/sdk-api-src/content/windows.ui.xaml.media.dxinterop/nf-windows-ui-xaml-media-dxinterop-iswapchainpanelnative-setswapchain.md
@@ -54,13 +54,19 @@ Sets the DirectX swap chain for <a href="/uwp/api/windows.ui.xaml.controls.swapc
 
 ## -parameters
 
-### -param swapChain [in]
+### -param swapChain [in] [opt]
 
 A configured <a href="/windows/desktop/api/dxgi/nn-dxgi-idxgiswapchain">IDXGISwapChain</a>.
 
 ## -returns
 
 If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
+## -remarks
+
+This method has to be called on the UI thread the parent <a href="/uwp/api/windows.ui.xaml.controls.swapchainpanel">SwapChainPanel</a> belongs to. If called on another thread, it will return `0x8001010E` (`RPC_E_WRONG_THREAD`, "The application called an interface that was marshaled for a different thread").
+
+When called, this method will increment the reference count for the input <a href="/windows/desktop/api/dxgi/nn-dxgi-idxgiswapchain">IDXGISwapChain</a> that is passed as input. This will in turn cause the reference count to the target graphics device in use (eg. an <a href="/windows/win32/api/d3d12/nn-d3d12-id3d12device">ID3D12Device</a>) to be incremented as well. In order to ensure these references are released immediately when the panel is no longer needed, you can call `SetSwapChain` again passing a `null` pointer. This will ensure that all additional references to the object graph starting from the input <a href="/windows/desktop/api/dxgi/nn-dxgi-idxgiswapchain">IDXGISwapChain</a> that had been added by the <a href="/uwp/api/windows.ui.xaml.controls.swapchainpanel">SwapChainPanel</a> instance will be removed. This is especially important to ensure the device in use can properly be released, for instance to recover from device lost scenarios.
 
 ## -see-also
 


### PR DESCRIPTION
This PR adds the following remarks to `ISwapChainPanelNative::SetSwapChain`:
- Calls out the API has to be called from the right UI thread.
- Mentions the fact that `SetSwapChain` will add extra references to the target device, and that calling `SetSwapChain(null)` is needed in order to immediately release them when the panel is no longer needed (eg. to recover from a device lost scenario).

It also adds `[opt]` to the `swapChain` param.

This has tripped me up in ComputeSharp ([see this commit](https://github.com/Sergio0694/ComputeSharp/pull/319/commits/dbb28c35ce68eba7b1879a24fe11166a9b9b90b6)), as the target device was left with way more references than expected, as I wasn't calling `SetSwapChain(null)`. This seems like a rather important aspect of the API for those wanting to recover from device lost scenarios, and it should be properly documented. Also added the remarks on the UI thread while at it 🙂