### PR TITLE
Removing the word network to improve applicability

### DIFF
--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:namedpipeapi.TransactNamedPipe
 title: TransactNamedPipe function (namedpipeapi.h)
-description: Combines the functions that write a message to and read a message from the specified named pipe into a single network operation.
+description: Combines the functions that write a message to and read a message from the specified named pipe into a single operation.
 helpviewer_keywords: ["TransactNamedPipe","TransactNamedPipe function","_win32_transactnamedpipe","base.transactnamedpipe","namedpipeapi/TransactNamedPipe"]
 old-location: base\transactnamedpipe.htm
 tech.root: base

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
@@ -57,7 +57,7 @@ api_name:
 
 ## -description
 
-Combines the functions that write a message to and read a message from the specified named pipe into a single network operation.
+Combines the functions that write a message to and read a message from the specified named pipe into a single operation.
 
 ## -parameters
 


### PR DESCRIPTION
Named pipes can be used a local IPC mechanism. This means you can use TransactNamedPipe without ever touching the network. Removing the word "network" here helps include these situations and does not muddy the definition any.