### PR TITLE
Trying to fix wording of what header to include [WIP]

### DIFF
--- a/sdk-api-src/content/interlockedapi/nf-interlockedapi-initializeslisthead.md
+++ b/sdk-api-src/content/interlockedapi/nf-interlockedapi-initializeslisthead.md
@@ -9,7 +9,7 @@ ms.assetid: 4e34f947-1687-4ea9-aaa1-8d8dc11dad70
 ms.date: 12/05/2018
 ms.keywords: InitializeSListHead, InitializeSListHead function, _win32_initializeslisthead, base.initializeslisthead, interlockedapi/InitializeSListHead, winbase/InitializeSListHead
 req.header: interlockedapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedflushslist.md
+++ b/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedflushslist.md
@@ -9,7 +9,7 @@ ms.assetid: 3fde3377-8a98-4976-a350-2c173b209e8c
 ms.date: 12/05/2018
 ms.keywords: InterlockedFlushSList, InterlockedFlushSList function, _win32_interlockedflushslist, base.interlockedflushslist, interlockedapi/InterlockedFlushSList, winbase/InterlockedFlushSList
 req.header: interlockedapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedpopentryslist.md
+++ b/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedpopentryslist.md
@@ -9,7 +9,7 @@ ms.assetid: 10760fd4-5973-4ab0-991c-7a5951c798a4
 ms.date: 12/05/2018
 ms.keywords: InterlockedPopEntrySList, InterlockedPopEntrySList function, _win32_interlockedpopentryslist, base.interlockedpopentryslist, interlockedapi/InterlockedPopEntrySList, winbase/InterlockedPopEntrySList
 req.header: interlockedapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedpushentryslist.md
+++ b/sdk-api-src/content/interlockedapi/nf-interlockedapi-interlockedpushentryslist.md
@@ -9,7 +9,7 @@ ms.assetid: 60e3b6f7-f556-4699-be90-db7330cfb8ca
 ms.date: 12/05/2018
 ms.keywords: InterlockedPushEntrySList, InterlockedPushEntrySList function, _win32_interlockedpushentryslist, base.interlockedpushentryslist, interlockedapi/InterlockedPushEntrySList, winbase/InterlockedPushEntrySList
 req.header: interlockedapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/interlockedapi/nf-interlockedapi-querydepthslist.md
+++ b/sdk-api-src/content/interlockedapi/nf-interlockedapi-querydepthslist.md
@@ -9,7 +9,7 @@ ms.assetid: 3f9b4481-647f-457f-bdfb-62e6ae4198e5
 ms.date: 12/05/2018
 ms.keywords: QueryDepthSList, QueryDepthSList function, base.querydepthslist, interlockedapi/QueryDepthSList, winbase/QueryDepthSList
 req.header: interlockedapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresult.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresult.md
@@ -9,7 +9,7 @@ ms.assetid: 7f999959-9b22-4491-ae2b-a2674d821110
 ms.date: 12/05/2018
 ms.keywords: GetOverlappedResult, GetOverlappedResult function, _win32_getoverlappedresult, base.getoverlappedresult, ioapiset/GetOverlappedResult, winbase/GetOverlappedResult
 req.header: ioapiset.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/memoryapi/nf-memoryapi-getprocessworkingsetsizeex.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-getprocessworkingsetsizeex.md
@@ -9,7 +9,7 @@ ms.assetid: d2de0bf2-012b-480c-a1a5-54e4d3928381
 ms.date: 12/05/2018
 ms.keywords: GetProcessWorkingSetSizeEx, GetProcessWorkingSetSizeEx function, QUOTA_LIMITS_HARDWS_MAX_DISABLE, QUOTA_LIMITS_HARDWS_MAX_ENABLE, QUOTA_LIMITS_HARDWS_MIN_DISABLE, QUOTA_LIMITS_HARDWS_MIN_ENABLE, base.getprocessworkingsetsizeex, memoryapi/GetProcessWorkingSetSizeEx, winbase/GetProcessWorkingSetSizeEx
 req.header: memoryapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/memoryapi/nf-memoryapi-setprocessworkingsetsizeex.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-setprocessworkingsetsizeex.md
@@ -9,7 +9,7 @@ ms.assetid: 04332239-dfc2-4d32-987a-af187e725b71
 ms.date: 12/05/2018
 ms.keywords: QUOTA_LIMITS_HARDWS_MAX_DISABLE, QUOTA_LIMITS_HARDWS_MAX_ENABLE, QUOTA_LIMITS_HARDWS_MIN_DISABLE, QUOTA_LIMITS_HARDWS_MIN_ENABLE, SetProcessWorkingSetSizeEx, SetProcessWorkingSetSizeEx function, base.setprocessworkingsetsizeex, memoryapi/SetProcessWorkingSetSizeEx, winbase/SetProcessWorkingSetSizeEx
 req.header: memoryapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/minwinbase/ns-minwinbase-overlapped.md
+++ b/sdk-api-src/content/minwinbase/ns-minwinbase-overlapped.md
@@ -9,7 +9,7 @@ ms.assetid: 5037f6b9-e316-483b-a8e2-b58d2587ebd9
 ms.date: 12/05/2018
 ms.keywords: '*LPOVERLAPPED, LPOVERLAPPED, LPOVERLAPPED structure pointer, OVERLAPPED, OVERLAPPED structure, _win32_overlapped_str, base.overlapped_str, minwinbase/LPOVERLAPPED, minwinbase/OVERLAPPED, winbase/LPOVERLAPPED, winbase/OVERLAPPED'
 req.header: minwinbase.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/namespaceapi/nf-namespaceapi-addsidtoboundarydescriptor.md
+++ b/sdk-api-src/content/namespaceapi/nf-namespaceapi-addsidtoboundarydescriptor.md
@@ -9,7 +9,7 @@ ms.assetid: c0dd01a0-1a08-43dc-8cef-dff290e73ca1
 ms.date: 12/05/2018
 ms.keywords: AddSIDToBoundaryDescriptor, AddSIDToBoundaryDescriptor function, base.addsidtoboundarydescriptor, namespaceapi/AddSIDToBoundaryDescriptor, winbase/AddSIDToBoundaryDescriptor
 req.header: namespaceapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/namespaceapi/nf-namespaceapi-closeprivatenamespace.md
+++ b/sdk-api-src/content/namespaceapi/nf-namespaceapi-closeprivatenamespace.md
@@ -9,7 +9,7 @@ ms.assetid: b9b74cf2-bf13-4ceb-9242-bc6a884ac6f1
 ms.date: 12/05/2018
 ms.keywords: ClosePrivateNamespace, ClosePrivateNamespace function, base.closeprivatenamespace, namespaceapi/ClosePrivateNamespace, winbase/ClosePrivateNamespace
 req.header: namespaceapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/namespaceapi/nf-namespaceapi-deleteboundarydescriptor.md
+++ b/sdk-api-src/content/namespaceapi/nf-namespaceapi-deleteboundarydescriptor.md
@@ -9,7 +9,7 @@ ms.assetid: 759d9cd9-9ef2-4bbe-9e99-8aec87f5ba4a
 ms.date: 12/05/2018
 ms.keywords: DeleteBoundaryDescriptor, DeleteBoundaryDescriptor function, base.deleteboundarydescriptor, namespaceapi/DeleteBoundaryDescriptor, winbase/DeleteBoundaryDescriptor
 req.header: namespaceapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/nldef/ne-nldef-nl_dad_state.md
+++ b/sdk-api-src/content/nldef/ne-nldef-nl_dad_state.md
@@ -9,7 +9,7 @@ ms.assetid: 2c67215c-6349-418e-9004-b869d6f5baef
 ms.date: 12/05/2018
 ms.keywords: IP_DAD_STATE, IP_DAD_STATE enumeration [IP Helper], IpDadStateDeprecated, IpDadStateDuplicate, IpDadStateInvalid, IpDadStatePreferred, IpDadStateTentative, NL_DAD_STATE, iphlp.ip_dad_state, iptypes/IP_DAD_STATE, iptypes/IpDadStateDeprecated, iptypes/IpDadStateDuplicate, iptypes/IpDadStateInvalid, iptypes/IpDadStatePreferred, iptypes/IpDadStateTentative, nldef/IP_DAD_STATE, nldef/IpDadStateDeprecated, nldef/IpDadStateDuplicate, nldef/IpDadStateInvalid, nldef/IpDadStatePreferred, nldef/IpDadStateTentative
 req.header: nldef.h
-req.include-header: Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista, Iphlpapi.h
+req.include-header: Iphlpapi.h on Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/nldef/ne-nldef-nl_prefix_origin.md
+++ b/sdk-api-src/content/nldef/ne-nldef-nl_prefix_origin.md
@@ -9,7 +9,7 @@ ms.assetid: fd7e7bbb-8596-4a72-ba63-d898f0048a11
 ms.date: 12/05/2018
 ms.keywords: IP_PREFIX_ORIGIN, IP_PREFIX_ORIGIN enumeration [IP Helper], IpPrefixOriginDhcp, IpPrefixOriginManual, IpPrefixOriginOther, IpPrefixOriginRouterAdvertisement, IpPrefixOriginUnchanged, IpPrefixOriginWellKnown, NL_PREFIX_ORIGIN, iphlp.ip_prefix_origin, iptypes/IP_PREFIX_ORIGIN, iptypes/IpPrefixOriginDhcp, iptypes/IpPrefixOriginManual, iptypes/IpPrefixOriginOther, iptypes/IpPrefixOriginRouterAdvertisement, iptypes/IpPrefixOriginUnchanged, iptypes/IpPrefixOriginWellKnown, nldef/IP_PREFIX_ORIGIN, nldef/IpPrefixOriginDhcp, nldef/IpPrefixOriginManual, nldef/IpPrefixOriginOther, nldef/IpPrefixOriginRouterAdvertisement, nldef/IpPrefixOriginUnchanged, nldef/IpPrefixOriginWellKnown
 req.header: nldef.h
-req.include-header: Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista, Iphlpapi.h
+req.include-header: Iphlpapi.h on Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/nldef/ne-nldef-nl_suffix_origin.md
+++ b/sdk-api-src/content/nldef/ne-nldef-nl_suffix_origin.md
@@ -9,7 +9,7 @@ ms.assetid: 0ffeae3d-cfc4-472e-87f8-ae6d584fb869
 ms.date: 12/05/2018
 ms.keywords: IP_SUFFIX_ORIGIN, IP_SUFFIX_ORIGIN enumeration [IP Helper], IpSuffixOriginDhcp, IpSuffixOriginLinkLayerAddress, IpSuffixOriginManual, IpSuffixOriginOther, IpSuffixOriginRandom, IpSuffixOriginUnchanged, IpSuffixOriginWellKnown, NL_SUFFIX_ORIGIN, iphlp.ip_suffix_origin, iptypes/IP_SUFFIX_ORIGIN, iptypes/IpSuffixOriginDhcp, iptypes/IpSuffixOriginLinkLayerAddress, iptypes/IpSuffixOriginManual, iptypes/IpSuffixOriginOther, iptypes/IpSuffixOriginRandom, iptypes/IpSuffixOriginUnchanged, iptypes/IpSuffixOriginWellKnown, nldef/IP_SUFFIX_ORIGIN, nldef/IpSuffixOriginDhcp, nldef/IpSuffixOriginLinkLayerAddress, nldef/IpSuffixOriginManual, nldef/IpSuffixOriginOther, nldef/IpSuffixOriginRandom, nldef/IpSuffixOriginUnchanged, nldef/IpSuffixOriginWellKnown
 req.header: nldef.h
-req.include-header: Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista, Iphlpapi.h
+req.include-header: Iphlpapi.h on Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008  Windows Vista
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsa.md
+++ b/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsa.md
@@ -9,7 +9,7 @@ ms.assetid: 8ac73f6e-4b42-4730-bf88-4b671f57b63b
 ms.date: 12/05/2018
 ms.keywords: FreeEnvironmentStrings, FreeEnvironmentStrings function, FreeEnvironmentStringsA, FreeEnvironmentStringsW, _win32_freeenvironmentstrings, base.freeenvironmentstrings, processenv/FreeEnvironmentStrings, processenv/FreeEnvironmentStringsA, processenv/FreeEnvironmentStringsW, winbase/FreeEnvironmentStrings, winbase/FreeEnvironmentStringsA, winbase/FreeEnvironmentStringsW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
@@ -9,7 +9,7 @@ ms.assetid: 8ac73f6e-4b42-4730-bf88-4b671f57b63b
 ms.date: 12/05/2018
 ms.keywords: FreeEnvironmentStrings, FreeEnvironmentStrings function, FreeEnvironmentStringsA, FreeEnvironmentStringsW, _win32_freeenvironmentstrings, base.freeenvironmentstrings, processenv/FreeEnvironmentStrings, processenv/FreeEnvironmentStringsA, processenv/FreeEnvironmentStringsW, winbase/FreeEnvironmentStrings, winbase/FreeEnvironmentStringsA, winbase/FreeEnvironmentStringsW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getcommandlinea.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getcommandlinea.md
@@ -9,7 +9,7 @@ ms.assetid: 08dfcab2-eb6e-49a4-80eb-87d4076c98c6
 ms.date: 12/05/2018
 ms.keywords: GetCommandLine, GetCommandLine function, GetCommandLineA, GetCommandLineW, _win32_getcommandline, base.getcommandline, processenv/GetCommandLine, processenv/GetCommandLineA, processenv/GetCommandLineW, winbase/GetCommandLine, winbase/GetCommandLineA, winbase/GetCommandLineW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getcommandlinew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getcommandlinew.md
@@ -9,7 +9,7 @@ ms.assetid: 08dfcab2-eb6e-49a4-80eb-87d4076c98c6
 ms.date: 12/05/2018
 ms.keywords: GetCommandLine, GetCommandLine function, GetCommandLineA, GetCommandLineW, _win32_getcommandline, base.getcommandline, processenv/GetCommandLine, processenv/GetCommandLineA, processenv/GetCommandLineW, winbase/GetCommandLine, winbase/GetCommandLineA, winbase/GetCommandLineW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentstrings.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentstrings.md
@@ -9,7 +9,7 @@ ms.assetid: fb431d83-f3e7-4f2a-bad9-81259681c1f4
 ms.date: 12/05/2018
 ms.keywords: GetEnvironmentStrings, GetEnvironmentStrings function, GetEnvironmentStringsA, GetEnvironmentStringsW, _win32_getenvironmentstrings, base.getenvironmentstrings, processenv/GetEnvironmentStrings, processenv/GetEnvironmentStringsA, processenv/GetEnvironmentStringsW, winbase/GetEnvironmentStrings, winbase/GetEnvironmentStringsA, winbase/GetEnvironmentStringsW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentstringsw.md
@@ -9,7 +9,7 @@ ms.assetid: fb431d83-f3e7-4f2a-bad9-81259681c1f4
 ms.date: 12/05/2018
 ms.keywords: GetEnvironmentStrings, GetEnvironmentStrings function, GetEnvironmentStringsA, GetEnvironmentStringsW, _win32_getenvironmentstrings, base.getenvironmentstrings, processenv/GetEnvironmentStrings, processenv/GetEnvironmentStringsA, processenv/GetEnvironmentStringsW, winbase/GetEnvironmentStrings, winbase/GetEnvironmentStringsA, winbase/GetEnvironmentStringsW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablea.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablea.md
@@ -9,7 +9,7 @@ ms.assetid: 1d4cc328-12e6-4aae-9f58-58675116ad54
 ms.date: 12/05/2018
 ms.keywords: GetEnvironmentVariable, GetEnvironmentVariable function, GetEnvironmentVariableA, GetEnvironmentVariableW, _win32_getenvironmentvariable, base.getenvironmentvariable, processenv/GetEnvironmentVariable, processenv/GetEnvironmentVariableA, processenv/GetEnvironmentVariableW, winbase/GetEnvironmentVariable, winbase/GetEnvironmentVariableA, winbase/GetEnvironmentVariableW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-getenvironmentvariablew.md
@@ -9,7 +9,7 @@ ms.assetid: 1d4cc328-12e6-4aae-9f58-58675116ad54
 ms.date: 12/05/2018
 ms.keywords: GetEnvironmentVariable, GetEnvironmentVariable function, GetEnvironmentVariableA, GetEnvironmentVariableW, _win32_getenvironmentvariable, base.getenvironmentvariable, processenv/GetEnvironmentVariable, processenv/GetEnvironmentVariableA, processenv/GetEnvironmentVariableW, winbase/GetEnvironmentVariable, winbase/GetEnvironmentVariableA, winbase/GetEnvironmentVariableW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-needcurrentdirectoryforexepatha.md
+++ b/sdk-api-src/content/processenv/nf-processenv-needcurrentdirectoryforexepatha.md
@@ -9,7 +9,7 @@ ms.assetid: 2bdc07b9-bb83-48c2-a668-fda5c69d54ee
 ms.date: 12/05/2018
 ms.keywords: NeedCurrentDirectoryForExePath, NeedCurrentDirectoryForExePath function, NeedCurrentDirectoryForExePathA, NeedCurrentDirectoryForExePathW, base.needcurrentdirectoryforexepath, processenv/NeedCurrentDirectoryForExePath, processenv/NeedCurrentDirectoryForExePathA, processenv/NeedCurrentDirectoryForExePathW, winbase/NeedCurrentDirectoryForExePath, winbase/NeedCurrentDirectoryForExePathA, winbase/NeedCurrentDirectoryForExePathW
 req.header: processenv.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processenv/nf-processenv-needcurrentdirectoryforexepathw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-needcurrentdirectoryforexepathw.md
@@ -9,7 +9,7 @@ ms.assetid: 2bdc07b9-bb83-48c2-a668-fda5c69d54ee
 ms.date: 12/05/2018
 ms.keywords: NeedCurrentDirectoryForExePath, NeedCurrentDirectoryForExePath function, NeedCurrentDirectoryForExePathA, NeedCurrentDirectoryForExePathW, base.needcurrentdirectoryforexepath, processenv/NeedCurrentDirectoryForExePath, processenv/NeedCurrentDirectoryForExePathA, processenv/NeedCurrentDirectoryForExePathW, winbase/NeedCurrentDirectoryForExePath, winbase/NeedCurrentDirectoryForExePathA, winbase/NeedCurrentDirectoryForExePathW
 req.header: processenv.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablea.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablea.md
@@ -9,7 +9,7 @@ ms.assetid: 95bd6fa5-886d-41dc-a5c3-ede86dbfa15d
 ms.date: 12/05/2018
 ms.keywords: SetEnvironmentVariable, SetEnvironmentVariable function, SetEnvironmentVariableA, SetEnvironmentVariableW, _win32_setenvironmentvariable, base.setenvironmentvariable, processenv/SetEnvironmentVariable, processenv/SetEnvironmentVariableA, processenv/SetEnvironmentVariableW, winbase/SetEnvironmentVariable, winbase/SetEnvironmentVariableA, winbase/SetEnvironmentVariableW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md
@@ -9,7 +9,7 @@ ms.assetid: 95bd6fa5-886d-41dc-a5c3-ede86dbfa15d
 ms.date: 12/05/2018
 ms.keywords: SetEnvironmentVariable, SetEnvironmentVariable function, SetEnvironmentVariableA, SetEnvironmentVariableW, _win32_setenvironmentvariable, base.setenvironmentvariable, processenv/SetEnvironmentVariable, processenv/SetEnvironmentVariableA, processenv/SetEnvironmentVariableW, winbase/SetEnvironmentVariable, winbase/SetEnvironmentVariableA, winbase/SetEnvironmentVariableW
 req.header: processenv.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -9,7 +9,7 @@ ms.assetid: 3ef0a5b2-4d71-4c17-8188-76a4025287fc
 ms.date: 12/05/2018
 ms.keywords: CreateProcess, CreateProcess function, CreateProcessA, CreateProcessW, _win32_createprocess, base.createprocess, processthreadsapi/CreateProcess, processthreadsapi/CreateProcessA, processthreadsapi/CreateProcessW, winbase/CreateProcess, winbase/CreateProcessA, winbase/CreateProcessW
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessw.md
@@ -9,7 +9,7 @@ ms.assetid: 3ef0a5b2-4d71-4c17-8188-76a4025287fc
 ms.date: 12/05/2018
 ms.keywords: CreateProcess, CreateProcess function, CreateProcessA, CreateProcessW, _win32_createprocess, base.createprocess, processthreadsapi/CreateProcess, processthreadsapi/CreateProcessA, processthreadsapi/CreateProcessW, winbase/CreateProcess, winbase/CreateProcessA, winbase/CreateProcessW
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createremotethread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createremotethread.md
@@ -9,7 +9,7 @@ ms.assetid: f5257f78-b20f-4db5-b63e-3bb4e41a4b19
 ms.date: 12/05/2018
 ms.keywords: CREATE_SUSPENDED, CreateRemoteThread, CreateRemoteThread function, STACK_SIZE_PARAM_IS_A_RESERVATION, _win32_createremotethread, base.createremotethread, processthreadsapi/CreateRemoteThread, winbase/CreateRemoteThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createremotethreadex.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createremotethreadex.md
@@ -9,7 +9,7 @@ ms.assetid: 9c2d9e20-7614-4010-9b8b-4f0e9bc2e6fe
 ms.date: 12/05/2018
 ms.keywords: CREATE_SUSPENDED, CreateRemoteThreadEx, CreateRemoteThreadEx function, STACK_SIZE_PARAM_IS_A_RESERVATION, base.createremotethreadex, processthreadsapi/CreateRemoteThreadEx, winbase/CreateRemoteThreadEx
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows 7 [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 R2 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createthread.md
@@ -9,7 +9,7 @@ ms.assetid: 202a4b42-513a-45de-894a-72e56c706a58
 ms.date: 12/05/2018
 ms.keywords: CREATE_SUSPENDED, CreateThread, CreateThread function, STACK_SIZE_PARAM_IS_A_RESERVATION, _win32_createthread, base.createthread, processthreadsapi/CreateThread, winbase/CreateThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-deleteprocthreadattributelist.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-deleteprocthreadattributelist.md
@@ -9,7 +9,7 @@ ms.assetid: 806326c8-2f1e-4ab8-a6f6-f84763ddc31f
 ms.date: 12/05/2018
 ms.keywords: DeleteProcThreadAttributeList, DeleteProcThreadAttributeList function, base.deleteprocthreadattributelist, processthreadsapi/DeleteProcThreadAttributeList, winbase/DeleteProcThreadAttributeList
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-exitprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-exitprocess.md
@@ -9,7 +9,7 @@ ms.assetid: c26dbf15-62e8-4892-b7c5-2e6c085e4cd5
 ms.date: 12/05/2018
 ms.keywords: ExitProcess, ExitProcess function, _win32_exitprocess, base.exitprocess, processthreadsapi/ExitProcess, winbase/ExitProcess
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-exitthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-exitthread.md
@@ -9,7 +9,7 @@ ms.assetid: e7f6d054-c535-4521-a3b4-800a9174732f
 ms.date: 12/05/2018
 ms.keywords: ExitThread, ExitThread function, _win32_exitthread, base.exitthread, processthreadsapi/ExitThread, winbase/ExitThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-flushprocesswritebuffers.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-flushprocesswritebuffers.md
@@ -9,7 +9,7 @@ ms.assetid: 6dcf6851-59ee-4f6e-b2cb-e36ac5328b92
 ms.date: 12/05/2018
 ms.keywords: FlushProcessWriteBuffers, FlushProcessWriteBuffers function, base.flushprocesswritebuffers, processthreadsapi/FlushProcessWriteBuffers, winbase/FlushProcessWriteBuffers
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocess.md
@@ -9,7 +9,7 @@ ms.assetid: 0471790c-3bb9-4180-8676-941e655b1812
 ms.date: 12/05/2018
 ms.keywords: GetCurrentProcess, GetCurrentProcess function, _win32_getcurrentprocess, base.getcurrentprocess, processthreadsapi/GetCurrentProcess, winbase/GetCurrentProcess
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocessid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocessid.md
@@ -9,7 +9,7 @@ ms.assetid: a442e147-0db0-4911-94de-91728a4b277a
 ms.date: 12/05/2018
 ms.keywords: GetCurrentProcessId, GetCurrentProcessId function, _win32_getcurrentprocessid, base.getcurrentprocessid, processthreadsapi/GetCurrentProcessId, winbase/GetCurrentProcessId
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocessornumber.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocessornumber.md
@@ -9,7 +9,7 @@ ms.assetid: 1f2bebc7-a548-409a-ab74-78a4b55c8fa7
 ms.date: 12/05/2018
 ms.keywords: GetCurrentProcessorNumber, GetCurrentProcessorNumber function, base.getcurrentprocessornumber, processthreadsapi/GetCurrentProcessorNumber, winbase/GetCurrentProcessorNumber
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthread.md
@@ -9,7 +9,7 @@ ms.assetid: 91a11552-66c1-42bd-b837-8a7685977bc9
 ms.date: 12/05/2018
 ms.keywords: GetCurrentThread, GetCurrentThread function, _win32_getcurrentthread, base.getcurrentthread, processthreadsapi/GetCurrentThread, winbase/GetCurrentThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadid.md
@@ -9,7 +9,7 @@ ms.assetid: a496f61a-e027-44e7-8b22-4f6651d7afb2
 ms.date: 12/05/2018
 ms.keywords: GetCurrentThreadId, GetCurrentThreadId function, _win32_getcurrentthreadid, base.getcurrentthreadid, processthreadsapi/GetCurrentThreadId, winbase/GetCurrentThreadId
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getexitcodeprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getexitcodeprocess.md
@@ -9,7 +9,7 @@ ms.assetid: 210f7595-ac12-4bb2-bd77-819649ebec10
 ms.date: 12/05/2018
 ms.keywords: GetExitCodeProcess, GetExitCodeProcess function, _win32_getexitcodeprocess, base.getexitcodeprocess, processthreadsapi/GetExitCodeProcess, winbase/GetExitCodeProcess
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getexitcodethread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getexitcodethread.md
@@ -9,7 +9,7 @@ ms.assetid: 67482c3d-b845-4c0f-8aa1-0e3cf8cb5127
 ms.date: 12/05/2018
 ms.keywords: GetExitCodeThread, GetExitCodeThread function, _win32_getexitcodethread, base.getexitcodethread, processthreadsapi/GetExitCodeThread, winbase/GetExitCodeThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getpriorityclass.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getpriorityclass.md
@@ -9,7 +9,7 @@ ms.assetid: 2a16b18f-8efa-43f0-9f7d-d38cc8a153d3
 ms.date: 12/05/2018
 ms.keywords: GetPriorityClass, GetPriorityClass function, _win32_getpriorityclass, base.getpriorityclass, processthreadsapi/GetPriorityClass, winbase/GetPriorityClass
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocesshandlecount.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocesshandlecount.md
@@ -9,7 +9,7 @@ ms.assetid: bb8cf86b-00b8-4a64-90f8-66ac6dbf9dee
 ms.date: 12/05/2018
 ms.keywords: GetProcessHandleCount, GetProcessHandleCount function, base.getprocesshandlecount, processthreadsapi/GetProcessHandleCount, winbase/GetProcessHandleCount
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista, Windows XP with SP1 [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessid.md
@@ -9,7 +9,7 @@ ms.assetid: 9a024147-8bfe-427a-af12-a63f23328e38
 ms.date: 12/05/2018
 ms.keywords: GetProcessId, GetProcessId function, base.getprocessid, processthreadsapi/GetProcessId, winbase/GetProcessId
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista, Windows XP with SP1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessidofthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessidofthread.md
@@ -9,7 +9,7 @@ ms.assetid: 1878088b-e0fd-4009-b608-f491805948b5
 ms.date: 12/05/2018
 ms.keywords: GetProcessIdOfThread, GetProcessIdOfThread function, base.getprocessidofthread, processthreadsapi/GetProcessIdOfThread, winbase/GetProcessIdOfThread
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocesstimes.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocesstimes.md
@@ -9,7 +9,7 @@ ms.assetid: 4c1e8bd4-5ed2-4c97-bc4f-1083a8b24623
 ms.date: 12/05/2018
 ms.keywords: GetProcessTimes, GetProcessTimes function, _win32_getprocesstimes, base.getprocesstimes, processthreadsapi/GetProcessTimes, winbase/GetProcessTimes
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessversion.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getprocessversion.md
@@ -9,7 +9,7 @@ ms.assetid: ed12f2e5-1674-4885-878f-9ba39415780c
 ms.date: 12/05/2018
 ms.keywords: GetProcessVersion, GetProcessVersion function, _win32_getprocessversion, base.getprocessversion, processthreadsapi/GetProcessVersion, winbase/GetProcessVersion
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadid.md
@@ -9,7 +9,7 @@ ms.assetid: 198dfe9e-713f-46ce-90eb-24bfe42d2bf6
 ms.date: 12/05/2018
 ms.keywords: GetThreadId, GetThreadId function, base.getthreadid, processthreadsapi/GetThreadId, winbase/GetThreadId
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadpriority.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadpriority.md
@@ -9,7 +9,7 @@ ms.assetid: 9e5ce4e8-bdd1-48c3-aa1d-b24b2b7bfb00
 ms.date: 12/05/2018
 ms.keywords: GetThreadPriority, GetThreadPriority function, _win32_getthreadpriority, base.getthreadpriority, processthreadsapi/GetThreadPriority, winbase/GetThreadPriority
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadpriorityboost.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadpriorityboost.md
@@ -9,7 +9,7 @@ ms.assetid: 44edf5e3-7543-482f-89ff-ae9daf495ff3
 ms.date: 12/05/2018
 ms.keywords: GetThreadPriorityBoost, GetThreadPriorityBoost function, _win32_getthreadpriorityboost, base.getthreadpriorityboost, processthreadsapi/GetThreadPriorityBoost, winbase/GetThreadPriorityBoost
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadtimes.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadtimes.md
@@ -9,7 +9,7 @@ ms.assetid: eb61aa05-15d8-4251-947a-54df8433b858
 ms.date: 12/05/2018
 ms.keywords: GetThreadTimes, GetThreadTimes function, _win32_getthreadtimes, base.getthreadtimes, processthreadsapi/GetThreadTimes, winbase/GetThreadTimes
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-initializeprocthreadattributelist.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-initializeprocthreadattributelist.md
@@ -9,7 +9,7 @@ ms.assetid: 58ce70a1-5b73-429f-a062-bacd9b9c5bc8
 ms.date: 12/05/2018
 ms.keywords: InitializeProcThreadAttributeList, InitializeProcThreadAttributeList function, base.initializeprocthreadattributelist, processthreadsapi/InitializeProcThreadAttributeList, winbase/InitializeProcThreadAttributeList
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-openprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-openprocess.md
@@ -9,7 +9,7 @@ ms.assetid: 8f695c38-19c4-49e4-97de-8b64ea536cb1
 ms.date: 12/05/2018
 ms.keywords: OpenProcess, OpenProcess function, _win32_openprocess, base.openprocess, processthreadsapi/OpenProcess, winbase/OpenProcess
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-openthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-openthread.md
@@ -9,7 +9,7 @@ ms.assetid: d020ecc5-89d1-4a0d-a197-15a66e269e86
 ms.date: 12/05/2018
 ms.keywords: OpenThread, OpenThread function, _win32_openthread, base.openthread, processthreadsapi/OpenThread, winbase/OpenThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queryprocessaffinityupdatemode.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queryprocessaffinityupdatemode.md
@@ -9,7 +9,7 @@ ms.assetid: e1c9fab2-45a0-4ea7-bafb-91fc0f22e658
 ms.date: 12/05/2018
 ms.keywords: PROCESS_AFFINITY_ENABLE_AUTO_UPDATE, QueryProcessAffinityUpdateMode, QueryProcessAffinityUpdateMode function, base.queryprocessaffinityupdatemode, processthreadsapi/QueryProcessAffinityUpdateMode, winbase/QueryProcessAffinityUpdateMode
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista with SP1 [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queueuserapc.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queueuserapc.md
@@ -9,7 +9,7 @@ ms.assetid: 5b141372-7c95-4eb2-987b-64fdf7d0783d
 ms.date: 12/05/2018
 ms.keywords: QueueUserAPC, QueueUserAPC function, _win32_queueuserapc, base.queueuserapc, processthreadsapi/QueueUserAPC, winbase/QueueUserAPC
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queueuserapc2.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-queueuserapc2.md
@@ -12,7 +12,7 @@ req.ddi-compliance:
 req.dll: Kernel32.dll
 req.header: processthreadsapi.h
 req.idl: 
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.irql: 
 req.kmdf-ver: 
 req.lib: Kernel32.lib

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-resumethread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-resumethread.md
@@ -9,7 +9,7 @@ ms.assetid: ffc4e474-635b-4bf7-a68f-073899fb3fde
 ms.date: 12/05/2018
 ms.keywords: ResumeThread, ResumeThread function, _win32_resumethread, base.resumethread, processthreadsapi/ResumeThread, winbase/ResumeThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setpriorityclass.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setpriorityclass.md
@@ -9,7 +9,7 @@ ms.assetid: 02686637-427a-4cf1-a4e5-60c707af3084
 ms.date: 12/05/2018
 ms.keywords: ABOVE_NORMAL_PRIORITY_CLASS, BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS, IDLE_PRIORITY_CLASS, NORMAL_PRIORITY_CLASS, PROCESS_MODE_BACKGROUND_BEGIN, PROCESS_MODE_BACKGROUND_END, REALTIME_PRIORITY_CLASS, SetPriorityClass, SetPriorityClass function, _win32_setpriorityclass, base.setpriorityclass, processthreadsapi/SetPriorityClass, winbase/SetPriorityClass
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setprocessaffinityupdatemode.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setprocessaffinityupdatemode.md
@@ -9,7 +9,7 @@ ms.assetid: 46e8f7d2-89b9-42cb-9171-d5ae2ec870da
 ms.date: 12/05/2018
 ms.keywords: PROCESS_AFFINITY_ENABLE_AUTO_UPDATE, SetProcessAffinityUpdateMode, SetProcessAffinityUpdateMode function, base.setprocessaffinityupdatemode, processthreadsapi/SetProcessAffinityUpdateMode, winbase/SetProcessAffinityUpdateMode
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista with SP1 [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setprocessshutdownparameters.md
@@ -9,7 +9,7 @@ ms.assetid: c467950e-31e1-4608-a08a-0736a5524e0e
 ms.date: 12/05/2018
 ms.keywords: SHUTDOWN_NORETRY, SetProcessShutdownParameters, SetProcessShutdownParameters function, _win32_setprocessshutdownparameters, base.setprocessshutdownparameters, processthreadsapi/SetProcessShutdownParameters, winbase/SetProcessShutdownParameters
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadpriority.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadpriority.md
@@ -8,7 +8,7 @@ ms.assetid: e3992e19-b546-4b0b-aa6a-dd9a7e330bf3
 ms.date: 12/05/2018
 ms.keywords: SetThreadPriority, SetThreadPriority function, THREAD_MODE_BACKGROUND_BEGIN, THREAD_MODE_BACKGROUND_END, THREAD_PRIORITY_ABOVE_NORMAL, THREAD_PRIORITY_BELOW_NORMAL, THREAD_PRIORITY_HIGHEST, THREAD_PRIORITY_IDLE, THREAD_PRIORITY_LOWEST, THREAD_PRIORITY_NORMAL, THREAD_PRIORITY_TIME_CRITICAL, _win32_setthreadpriority, base.setthreadpriority, processthreadsapi/SetThreadPriority, winbase/SetThreadPriority
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadpriorityboost.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadpriorityboost.md
@@ -9,7 +9,7 @@ ms.assetid: 5cc16bfe-6792-40e8-91ef-6f54a38e6e33
 ms.date: 12/05/2018
 ms.keywords: SetThreadPriorityBoost, SetThreadPriorityBoost function, _win32_setthreadpriorityboost, base.setthreadpriorityboost, processthreadsapi/SetThreadPriorityBoost, winbase/SetThreadPriorityBoost
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadstackguarantee.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadstackguarantee.md
@@ -9,7 +9,7 @@ ms.assetid: 42595cba-413b-4b71-8d32-f873ed78c39c
 ms.date: 12/05/2018
 ms.keywords: SetThreadStackGuarantee, SetThreadStackGuarantee function, base.setthreadstackguarantee, processthreadsapi/SetThreadStackGuarantee, winbase/SetThreadStackGuarantee
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista, Windows XP Professional x64 Edition [desktop apps only]
 req.target-min-winversvr: Windows Server 2008, Windows Server 2003 with SP1 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-suspendthread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-suspendthread.md
@@ -9,7 +9,7 @@ ms.assetid: 1332abcb-3356-4890-a03c-843358c1a3ce
 ms.date: 12/05/2018
 ms.keywords: SuspendThread, SuspendThread function, _win32_suspendthread, base.suspendthread, processthreadsapi/SuspendThread, winbase/SuspendThread
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-switchtothread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-switchtothread.md
@@ -9,7 +9,7 @@ ms.assetid: d1e6d734-0c5b-4aa0-b1b3-220f2615e56b
 ms.date: 12/05/2018
 ms.keywords: SwitchToThread, SwitchToThread function, _win32_switchtothread, base.switchtothread, processthreadsapi/SwitchToThread, winbase/SwitchToThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminateprocess.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminateprocess.md
@@ -9,7 +9,7 @@ ms.assetid: 0e1a8195-4fd3-43d4-ae9e-1a1e05c2119a
 ms.date: 12/05/2018
 ms.keywords: TerminateProcess, TerminateProcess function, _win32_terminateprocess, base.terminateprocess, processthreadsapi/TerminateProcess, winbase/TerminateProcess
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminatethread.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-terminatethread.md
@@ -9,7 +9,7 @@ ms.assetid: ae1ad0f3-67df-4573-af22-7086f0470361
 ms.date: 12/05/2018
 ms.keywords: TerminateThread, TerminateThread function, _win32_terminatethread, base.terminatethread, processthreadsapi/TerminateThread, winbase/TerminateThread
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsalloc.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsalloc.md
@@ -9,7 +9,7 @@ ms.assetid: cbb3d832-cd92-4875-8366-6b69be7a536f
 ms.date: 12/05/2018
 ms.keywords: TlsAlloc, TlsAlloc function, _win32_tlsalloc, base.tlsalloc, processthreadsapi/TlsAlloc, winbase/TlsAlloc
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsfree.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsfree.md
@@ -9,7 +9,7 @@ ms.assetid: f5b1e8fc-02eb-4a06-b606-2b647944029b
 ms.date: 12/05/2018
 ms.keywords: TlsFree, TlsFree function, _win32_tlsfree, base.tlsfree, processthreadsapi/TlsFree, winbase/TlsFree
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
@@ -9,7 +9,7 @@ ms.assetid: 82bd5ff6-ff0b-42b7-9ece-e9e8531eb5fb
 ms.date: 12/05/2018
 ms.keywords: TlsGetValue, TlsGetValue function, _win32_tlsgetvalue, base.tlsgetvalue, processthreadsapi/TlsGetValue, winbase/TlsGetValue
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlssetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlssetvalue.md
@@ -9,7 +9,7 @@ ms.assetid: 531b4a4a-a251-4ab4-b00a-754783a51283
 ms.date: 12/05/2018
 ms.keywords: TlsSetValue, TlsSetValue function, _win32_tlssetvalue, base.tlssetvalue, processthreadsapi/TlsSetValue, winbase/TlsSetValue
 req.header: processthreadsapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
@@ -9,7 +9,7 @@ ms.assetid: 5fc3e04f-9b2a-440c-a9aa-d78d9b25b341
 ms.date: 02/02/2021
 ms.keywords: PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY, PROC_THREAD_ATTRIBUTE_DESKTOP_APP_POLICY, PROC_THREAD_ATTRIBUTE_GROUP_AFFINITY, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_IDEAL_PROCESSOR, PROC_THREAD_ATTRIBUTE_MACHINE_TYPE, PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, PROC_THREAD_ATTRIBUTE_PARENT_PROCESS, PROC_THREAD_ATTRIBUTE_PREFERRED_NODE, PROC_THREAD_ATTRIBUTE_PROTECTION_LEVEL, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, PROC_THREAD_ATTRIBUTE_UMS_THREAD, PROC_THREAD_ATTRIBUTE_JOB_LIST, UpdateProcThreadAttribute, UpdateProcThreadAttribute function, base.updateprocthreadattribute, processthreadsapi/UpdateProcThreadAttribute, winbase/UpdateProcThreadAttribute
 req.header: processthreadsapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-process_information.md
+++ b/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-process_information.md
@@ -9,7 +9,7 @@ ms.assetid: 78d84499-7e56-4ff7-a8cd-1cf1b275597a
 ms.date: 12/05/2018
 ms.keywords: '*LPPROCESS_INFORMATION, *PPROCESS_INFORMATION, LPPROCESS_INFORMATION, LPPROCESS_INFORMATION structure pointer, PROCESS_INFORMATION, PROCESS_INFORMATION structure, _win32_process_information_str, base.process_information_str, processthreadsapi/LPPROCESS_INFORMATION, processthreadsapi/PROCESS_INFORMATION, winbase/LPPROCESS_INFORMATION, winbase/PROCESS_INFORMATION'
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-startupinfoa.md
+++ b/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-startupinfoa.md
@@ -9,7 +9,7 @@ ms.assetid: cf4b795c-52c1-4573-8328-99ee13f68bb3
 ms.date: 12/05/2018
 ms.keywords: '*LPSTARTUPINFOA, LPSTARTUPINFO, LPSTARTUPINFO structure pointer, STARTF_FORCEOFFFEEDBACK, STARTF_FORCEONFEEDBACK, STARTF_PREVENTPINNING, STARTF_RUNFULLSCREEN, STARTF_TITLEISAPPID, STARTF_TITLEISLINKNAME, STARTF_UNTRUSTEDSOURCE, STARTF_USECOUNTCHARS, STARTF_USEFILLATTRIBUTE, STARTF_USEHOTKEY, STARTF_USEPOSITION, STARTF_USESHOWWINDOW, STARTF_USESIZE, STARTF_USESTDHANDLES, STARTUPINFO, STARTUPINFO structure, STARTUPINFOA, STARTUPINFOW, _win32_startupinfo_str, base.startupinfo_str, processthreadsapi/LPSTARTUPINFO, processthreadsapi/STARTUPINFO, processthreadsapi/STARTUPINFOA, processthreadsapi/STARTUPINFOW, winbase/LPSTARTUPINFO, winbase/STARTUPINFO, winbase/STARTUPINFOA, winbase/STARTUPINFOW'
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-startupinfow.md
+++ b/sdk-api-src/content/processthreadsapi/ns-processthreadsapi-startupinfow.md
@@ -9,7 +9,7 @@ ms.assetid: cf4b795c-52c1-4573-8328-99ee13f68bb3
 ms.date: 12/05/2018
 ms.keywords: '*LPSTARTUPINFOW, LPSTARTUPINFO, LPSTARTUPINFO structure pointer, STARTF_FORCEOFFFEEDBACK, STARTF_FORCEONFEEDBACK, STARTF_PREVENTPINNING, STARTF_RUNFULLSCREEN, STARTF_TITLEISAPPID, STARTF_TITLEISLINKNAME, STARTF_UNTRUSTEDSOURCE, STARTF_USECOUNTCHARS, STARTF_USEFILLATTRIBUTE, STARTF_USEHOTKEY, STARTF_USEPOSITION, STARTF_USESHOWWINDOW, STARTF_USESIZE, STARTF_USESTDHANDLES, STARTUPINFO, STARTUPINFO structure, STARTUPINFOA, STARTUPINFOW, _win32_startupinfo_str, base.startupinfo_str, processthreadsapi/LPSTARTUPINFO, processthreadsapi/STARTUPINFO, processthreadsapi/STARTUPINFOA, processthreadsapi/STARTUPINFOW, winbase/LPSTARTUPINFO, winbase/STARTUPINFO, winbase/STARTUPINFOA, winbase/STARTUPINFOW'
 req.header: processthreadsapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/processtopologyapi/nf-processtopologyapi-getprocessgroupaffinity.md
+++ b/sdk-api-src/content/processtopologyapi/nf-processtopologyapi-getprocessgroupaffinity.md
@@ -9,7 +9,7 @@ ms.assetid: e22a4910-45dd-4eb6-9ed5-a8e0bcdfad7b
 ms.date: 12/05/2018
 ms.keywords: GetProcessGroupAffinity, GetProcessGroupAffinity function, base.getprocessgroupaffinity, processtopologyapi/GetProcessGroupAffinity, winbase/GetProcessGroupAffinity
 req.header: processtopologyapi.h
-req.include-header: Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows 7 [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 R2 [desktop apps only]

--- a/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryidleprocessorcycletime.md
+++ b/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryidleprocessorcycletime.md
@@ -9,7 +9,7 @@ ms.assetid: 75a5c4cf-ccc7-47ab-a2a9-88051e0a7d06
 ms.date: 12/05/2018
 ms.keywords: QueryIdleProcessorCycleTime, QueryIdleProcessorCycleTime function, base.queryidleprocessorcycletime, realtimeapiset/QueryIdleProcessorCycleTime, winbase/QueryIdleProcessorCycleTime
 req.header: realtimeapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryprocesscycletime.md
+++ b/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryprocesscycletime.md
@@ -9,7 +9,7 @@ ms.assetid: 1859bc0f-8065-4104-b421-1b4c020ad5ea
 ms.date: 12/05/2018
 ms.keywords: QueryProcessCycleTime, QueryProcessCycleTime function, base.queryprocesscycletime, realtimeapiset/QueryProcessCycleTime, winbase/QueryProcessCycleTime
 req.header: realtimeapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-querythreadcycletime.md
+++ b/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-querythreadcycletime.md
@@ -9,7 +9,7 @@ ms.assetid: 5828b073-48af-4118-9206-096b87c978e7
 ms.date: 12/05/2018
 ms.keywords: QueryThreadCycleTime, QueryThreadCycleTime function, base.querythreadcycletime, realtimeapiset/QueryThreadCycleTime, winbase/QueryThreadCycleTime
 req.header: realtimeapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps only]
 req.target-min-winversvr: Windows Server 2008 [desktop apps only]

--- a/sdk-api-src/content/synchapi/nf-synchapi-acquiresrwlockexclusive.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-acquiresrwlockexclusive.md
@@ -9,7 +9,7 @@ ms.assetid: 02e987a2-4c2f-4ccb-8816-c04320b568c1
 ms.date: 12/05/2018
 ms.keywords: AcquireSRWLockExclusive, AcquireSRWLockExclusive function, base.acquiresrwlockexclusive, synchapi/AcquireSRWLockExclusive, winbase/AcquireSRWLockExclusive
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-acquiresrwlockshared.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-acquiresrwlockshared.md
@@ -9,7 +9,7 @@ ms.assetid: 86e6d915-c25d-4aee-9ec6-acb970da7069
 ms.date: 12/05/2018
 ms.keywords: AcquireSRWLockShared, AcquireSRWLockShared function, base.acquiresrwlockshared, synchapi/AcquireSRWLockShared, winbase/AcquireSRWLockShared
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-cancelwaitabletimer.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-cancelwaitabletimer.md
@@ -9,7 +9,7 @@ ms.assetid: 614a237b-71b3-4091-975d-4c0b3cd6ec69
 ms.date: 12/05/2018
 ms.keywords: CancelWaitableTimer, CancelWaitableTimer function, _win32_cancelwaitabletimer, base.cancelwaitabletimer, synchapi/CancelWaitableTimer, winbase/CancelWaitableTimer
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventa.md
@@ -9,7 +9,7 @@ ms.assetid: 1f6d946e-c74c-4599-ac3d-b709216a0900
 ms.date: 12/05/2018
 ms.keywords: CreateEvent, CreateEvent function, CreateEventA, CreateEventW, _win32_createevent, base.createevent, synchapi/CreateEvent, synchapi/CreateEventA, synchapi/CreateEventW, winbase/CreateEvent, winbase/CreateEventA, winbase/CreateEventW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
@@ -9,7 +9,7 @@ ms.assetid: 402a721d-8338-4df1-ba0b-074f868a1731
 ms.date: 12/05/2018
 ms.keywords: CREATE_EVENT_INITIAL_SET, CREATE_EVENT_MANUAL_RESET, CreateEventEx, CreateEventEx function, CreateEventExA, CreateEventExW, base.createeventex, synchapi/CreateEventEx, synchapi/CreateEventExA, synchapi/CreateEventExW, winbase/CreateEventEx, winbase/CreateEventExA, winbase/CreateEventExW
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
@@ -9,7 +9,7 @@ ms.assetid: 402a721d-8338-4df1-ba0b-074f868a1731
 ms.date: 12/05/2018
 ms.keywords: CREATE_EVENT_INITIAL_SET, CREATE_EVENT_MANUAL_RESET, CreateEventEx, CreateEventEx function, CreateEventExA, CreateEventExW, base.createeventex, synchapi/CreateEventEx, synchapi/CreateEventExA, synchapi/CreateEventExW, winbase/CreateEventEx, winbase/CreateEventExA, winbase/CreateEventExW
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventw.md
@@ -9,7 +9,7 @@ ms.assetid: 1f6d946e-c74c-4599-ac3d-b709216a0900
 ms.date: 12/05/2018
 ms.keywords: CreateEvent, CreateEvent function, CreateEventA, CreateEventW, _win32_createevent, base.createevent, synchapi/CreateEvent, synchapi/CreateEventA, synchapi/CreateEventW, winbase/CreateEvent, winbase/CreateEventA, winbase/CreateEventW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexa.md
@@ -9,7 +9,7 @@ ms.assetid: c8315d1c-98c9-4f0a-ae0d-800d7d8100cd
 ms.date: 05/03/2020
 ms.keywords: CreateMutex, CreateMutex function, CreateMutexA, CreateMutexW, _win32_createmutex, base.createmutex, synchapi/CreateMutex, synchapi/CreateMutexA, synchapi/CreateMutexW, winbase/CreateMutex, winbase/CreateMutexA, winbase/CreateMutexW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexexa.md
@@ -9,7 +9,7 @@ ms.assetid: c22ec98a-29c0-444e-afa4-fa2ad131a086
 ms.date: 12/05/2018
 ms.keywords: CREATE_MUTEX_INITIAL_OWNER, CreateMutexEx, CreateMutexEx function, CreateMutexExA, CreateMutexExW, base.createmutexex, synchapi/CreateMutexEx, synchapi/CreateMutexExA, synchapi/CreateMutexExW, winbase/CreateMutexEx, winbase/CreateMutexExA, winbase/CreateMutexExW
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexexw.md
@@ -9,7 +9,7 @@ ms.assetid: c22ec98a-29c0-444e-afa4-fa2ad131a086
 ms.date: 12/05/2018
 ms.keywords: CREATE_MUTEX_INITIAL_OWNER, CreateMutexEx, CreateMutexEx function, CreateMutexExA, CreateMutexExW, base.createmutexex, synchapi/CreateMutexEx, synchapi/CreateMutexExA, synchapi/CreateMutexExW, winbase/CreateMutexEx, winbase/CreateMutexExA, winbase/CreateMutexExW
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-createmutexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createmutexw.md
@@ -9,7 +9,7 @@ ms.assetid: c8315d1c-98c9-4f0a-ae0d-800d7d8100cd
 ms.date: 12/05/2018
 ms.keywords: CreateMutex, CreateMutex function, CreateMutexA, CreateMutexW, _win32_createmutex, base.createmutex, synchapi/CreateMutex, synchapi/CreateMutexA, synchapi/CreateMutexW, winbase/CreateMutex, winbase/CreateMutexA, winbase/CreateMutexW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-deletecriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-deletecriticalsection.md
@@ -9,7 +9,7 @@ ms.assetid: 97e29fc3-b155-448e-aaa9-19f0fc2d841e
 ms.date: 12/05/2018
 ms.keywords: DeleteCriticalSection, DeleteCriticalSection function, _win32_deletecriticalsection, base.deletecriticalsection, synchapi/DeleteCriticalSection, winbase/DeleteCriticalSection
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-entercriticalsection.md
@@ -8,7 +8,7 @@ ms.assetid: bb307b7a-66fc-4d19-b774-deca8bf90492
 ms.date: 12/05/2018
 ms.keywords: EnterCriticalSection, EnterCriticalSection function, _win32_entercriticalsection, base.entercriticalsection, synchapi/EnterCriticalSection, winbase/EnterCriticalSection
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initializeconditionvariable.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initializeconditionvariable.md
@@ -9,7 +9,7 @@ ms.assetid: 55cc8d1a-d5a8-4bb2-a5ac-50b4114b1b0b
 ms.date: 12/05/2018
 ms.keywords: InitializeConditionVariable, InitializeConditionVariable function, base.initializeconditionvariable, synchapi/InitializeConditionVariable, winbase/InitializeConditionVariable
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsection.md
@@ -9,7 +9,7 @@ ms.assetid: ad4b182d-a65d-4890-9eda-fdd6d044f736
 ms.date: 12/05/2018
 ms.keywords: InitializeCriticalSection, InitializeCriticalSection function, _win32_initializecriticalsection, base.initializecriticalsection, synchapi/InitializeCriticalSection, winbase/InitializeCriticalSection
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsectionandspincount.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsectionandspincount.md
@@ -9,7 +9,7 @@ ms.assetid: 4b84b305-8bc0-4592-9378-b757bbc0de19
 ms.date: 12/05/2018
 ms.keywords: InitializeCriticalSectionAndSpinCount, InitializeCriticalSectionAndSpinCount function, _win32_initializecriticalsectionandspincount, base.initializecriticalsectionandspincount, synchapi/InitializeCriticalSectionAndSpinCount, winbase/InitializeCriticalSectionAndSpinCount
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsectionex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initializecriticalsectionex.md
@@ -9,7 +9,7 @@ ms.assetid: da84b187-0eb7-4363-8e68-8a525586d7d9
 ms.date: 12/05/2018
 ms.keywords: CRITICAL_SECTION_NO_DEBUG_INFO, InitializeCriticalSectionEx, InitializeCriticalSectionEx function, base.initializecriticalsectionex, synchapi/InitializeCriticalSectionEx, winbase/InitializeCriticalSectionEx
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initializesrwlock.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initializesrwlock.md
@@ -9,7 +9,7 @@ ms.assetid: a94443e1-009c-49ba-a51c-6daa63b07cda
 ms.date: 12/05/2018
 ms.keywords: InitializeSRWLock, InitializeSRWLock function, base.initializesrwlock, synchapi/InitializeSRWLock, winbase/InitializeSRWLock
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initoncebegininitialize.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initoncebegininitialize.md
@@ -9,7 +9,7 @@ ms.assetid: f342e85c-ac81-4470-89ce-a9d0fc5e8f89
 ms.date: 12/05/2018
 ms.keywords: INIT_ONCE_ASYNC, INIT_ONCE_CHECK_ONLY, InitOnceBeginInitialize, InitOnceBeginInitialize function, base.initoncebegininitialize, synchapi/InitOnceBeginInitialize, winbase/InitOnceBeginInitialize
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initoncecomplete.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initoncecomplete.md
@@ -9,7 +9,7 @@ ms.assetid: aad1d1f6-5415-443a-94d2-f4a4d9b68750
 ms.date: 12/05/2018
 ms.keywords: INIT_ONCE_ASYNC, INIT_ONCE_INIT_FAILED, InitOnceComplete, InitOnceComplete function, base.initoncecomplete, synchapi/InitOnceComplete, winbase/InitOnceComplete
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
@@ -9,7 +9,7 @@ ms.assetid: 04c161ed-d1b0-4995-b246-cb64cb67ae47
 ms.date: 12/05/2018
 ms.keywords: InitOnceExecuteOnce, InitOnceExecuteOnce function, base.initonceexecuteonce, synchapi/InitOnceExecuteOnce, winbase/InitOnceExecuteOnce
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-initonceinitialize.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initonceinitialize.md
@@ -9,7 +9,7 @@ ms.assetid: f2943ac5-0e43-4f07-8941-952383e2fa08
 ms.date: 12/05/2018
 ms.keywords: InitOnceInitialize, InitOnceInitialize function, base.initonceinitialize, synchapi/InitOnceInitialize, winbase/InitOnceInitialize
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-leavecriticalsection.md
@@ -9,7 +9,7 @@ ms.assetid: cf740e1d-351f-478c-bdbb-4a776b84acc5
 ms.date: 12/05/2018
 ms.keywords: LeaveCriticalSection, LeaveCriticalSection function, _win32_leavecriticalsection, base.leavecriticalsection, synchapi/LeaveCriticalSection, winbase/LeaveCriticalSection
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-openeventa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-openeventa.md
@@ -9,7 +9,7 @@ ms.assetid: 46741024-ace3-44d6-b8a6-5621ad121a1a
 ms.date: 12/05/2018
 ms.keywords: OpenEvent, OpenEvent function, OpenEventA, OpenEventW, _win32_openevent, base.openevent, synchapi/OpenEvent, synchapi/OpenEventA, synchapi/OpenEventW, winbase/OpenEvent, winbase/OpenEventA, winbase/OpenEventW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-openeventw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-openeventw.md
@@ -9,7 +9,7 @@ ms.assetid: 46741024-ace3-44d6-b8a6-5621ad121a1a
 ms.date: 12/05/2018
 ms.keywords: OpenEvent, OpenEvent function, OpenEventA, OpenEventW, _win32_openevent, base.openevent, synchapi/OpenEvent, synchapi/OpenEventA, synchapi/OpenEventW, winbase/OpenEvent, winbase/OpenEventA, winbase/OpenEventW
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-releasemutex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-releasemutex.md
@@ -9,7 +9,7 @@ ms.assetid: c3e4daa8-92de-455c-847c-ea59225b3aa2
 ms.date: 12/05/2018
 ms.keywords: ReleaseMutex, ReleaseMutex function, _win32_releasemutex, base.releasemutex, synchapi/ReleaseMutex, winbase/ReleaseMutex
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-releasesemaphore.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-releasesemaphore.md
@@ -9,7 +9,7 @@ ms.assetid: 9d444318-4d66-4ec3-a65d-bd3b75db9d9b
 ms.date: 12/05/2018
 ms.keywords: ReleaseSemaphore, ReleaseSemaphore function, _win32_releasesemaphore, base.releasesemaphore, synchapi/ReleaseSemaphore, winbase/ReleaseSemaphore
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-releasesrwlockexclusive.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-releasesrwlockexclusive.md
@@ -9,7 +9,7 @@ ms.assetid: 77f9b8ee-f922-4bd1-b715-ccb1ca891dcc
 ms.date: 06/29/2020
 ms.keywords: ReleaseSRWLockExclusive, ReleaseSRWLockExclusive function, base.releasesrwlockexclusive, synchapi/ReleaseSRWLockExclusive, winbase/ReleaseSRWLockExclusive
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-releasesrwlockshared.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-releasesrwlockshared.md
@@ -9,7 +9,7 @@ ms.assetid: afefd9f2-7fd4-4cba-9a6f-1f9da614dcec
 ms.date: 06/29/2020
 ms.keywords: ReleaseSRWLockShared, ReleaseSRWLockShared function, base.releasesrwlockshared, synchapi/ReleaseSRWLockShared, winbase/ReleaseSRWLockShared
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-resetevent.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-resetevent.md
@@ -9,7 +9,7 @@ ms.assetid: bba7caab-d1ed-4261-aeca-49f847458f4c
 ms.date: 12/05/2018
 ms.keywords: ResetEvent, ResetEvent function, _win32_resetevent, base.resetevent, synchapi/ResetEvent, winbase/ResetEvent
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-setcriticalsectionspincount.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setcriticalsectionspincount.md
@@ -9,7 +9,7 @@ ms.assetid: 4d435c70-2e9b-4923-8726-9c8143dceb15
 ms.date: 12/05/2018
 ms.keywords: SetCriticalSectionSpinCount, SetCriticalSectionSpinCount function, _win32_setcriticalsectionspincount, base.setcriticalsectionspincount, synchapi/SetCriticalSectionSpinCount, winbase/SetCriticalSectionSpinCount
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-setevent.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setevent.md
@@ -9,7 +9,7 @@ ms.assetid: b474eef1-5df9-4729-b940-0c5f201c5f31
 ms.date: 12/05/2018
 ms.keywords: SetEvent, SetEvent function, _win32_setevent, base.setevent, synchapi/SetEvent, winbase/SetEvent
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
@@ -9,7 +9,7 @@ ms.assetid: 237e22dc-696d-473f-8bb5-c28f7c7c75b2
 ms.date: 12/05/2018
 ms.keywords: SetWaitableTimer, SetWaitableTimer function, _win32_setwaitabletimer, base.setwaitabletimer, synchapi/SetWaitableTimer, winbase/SetWaitableTimer
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-sleep.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleep.md
@@ -9,7 +9,7 @@ ms.assetid: 934d37ea-402c-4118-bd7e-87b5fce80fca
 ms.date: 12/05/2018
 ms.keywords: Sleep, Sleep function, _win32_sleep, base.sleep, synchapi/Sleep, winbase/Sleep
 req.header: synchapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablecs.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablecs.md
@@ -9,7 +9,7 @@ ms.assetid: af435aef-710a-4f97-bcfd-dcb7f2ec0253
 ms.date: 12/05/2018
 ms.keywords: SleepConditionVariableCS, SleepConditionVariableCS function, base.sleepconditionvariablecs, synchapi/SleepConditionVariableCS, winbase/SleepConditionVariableCS
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablesrw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleepconditionvariablesrw.md
@@ -9,7 +9,7 @@ ms.assetid: 133f710f-5304-4b92-bec4-d9e8863bfa6d
 ms.date: 12/05/2018
 ms.keywords: SleepConditionVariableSRW, SleepConditionVariableSRW function, base.sleepconditionvariablesrw, synchapi/SleepConditionVariableSRW, winbase/SleepConditionVariableSRW
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-sleepex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-sleepex.md
@@ -9,7 +9,7 @@ ms.assetid: a73cff94-ad63-4110-9f01-6469481c3d55
 ms.date: 12/05/2018
 ms.keywords: SleepEx, SleepEx function, _win32_sleepex, base.sleepex, synchapi/SleepEx, winbase/SleepEx
 req.header: synchapi.h
-req.include-header: Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-tryentercriticalsection.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-tryentercriticalsection.md
@@ -9,7 +9,7 @@ ms.assetid: 5225bda1-6e20-4f6b-9f9b-633c62acfdce
 ms.date: 12/05/2018
 ms.keywords: TryEnterCriticalSection, TryEnterCriticalSection function, _win32_tryentercriticalsection, base.tryentercriticalsection, synchapi/TryEnterCriticalSection, winbase/TryEnterCriticalSection
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjectsex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitformultipleobjectsex.md
@@ -9,7 +9,7 @@ ms.assetid: 47a167fb-4714-4353-b924-a161f367673c
 ms.date: 12/05/2018
 ms.keywords: WaitForMultipleObjectsEx, WaitForMultipleObjectsEx function, _win32_waitformultipleobjectsex, base.waitformultipleobjectsex, synchapi/WaitForMultipleObjectsEx, winbase/WaitForMultipleObjectsEx
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobject.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobject.md
@@ -9,7 +9,7 @@ ms.assetid: e37ebff7-b44e-469d-81ab-7a6bd1a0c822
 ms.date: 12/05/2018
 ms.keywords: WaitForSingleObject, WaitForSingleObject function, _win32_waitforsingleobject, base.waitforsingleobject, synchapi/WaitForSingleObject, winbase/WaitForSingleObject
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobjectex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobjectex.md
@@ -9,7 +9,7 @@ ms.assetid: 530b5340-f8b2-4e00-a3ca-87a7c7372482
 ms.date: 12/05/2018
 ms.keywords: WaitForSingleObjectEx, WaitForSingleObjectEx function, _win32_waitforsingleobjectex, base.waitforsingleobjectex, synchapi/WaitForSingleObjectEx, winbase/WaitForSingleObjectEx
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-wakeallconditionvariable.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-wakeallconditionvariable.md
@@ -9,7 +9,7 @@ ms.assetid: 1a57562a-fbbc-4a5f-910c-7a52a8dccbe3
 ms.date: 12/05/2018
 ms.keywords: WakeAllConditionVariable, WakeAllConditionVariable function, base.wakeallconditionvariable, synchapi/WakeAllConditionVariable, winbase/WakeAllConditionVariable
 req.header: synchapi.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/synchapi/nf-synchapi-wakeconditionvariable.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-wakeconditionvariable.md
@@ -9,7 +9,7 @@ ms.assetid: e175062a-ef25-4341-8197-df7ca6b008e6
 ms.date: 12/05/2018
 ms.keywords: WakeConditionVariable, WakeConditionVariable function, base.wakeconditionvariable, synchapi/WakeConditionVariable, winbase/WakeConditionVariable
 req.header: synchapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/systemtopologyapi/nf-systemtopologyapi-getnumahighestnodenumber.md
+++ b/sdk-api-src/content/systemtopologyapi/nf-systemtopologyapi-getnumahighestnodenumber.md
@@ -9,7 +9,7 @@ ms.assetid: ce944fa7-b42a-4b99-ac8d-30bd026fba21
 ms.date: 12/05/2018
 ms.keywords: GetNumaHighestNodeNumber, GetNumaHighestNodeNumber function, _win32_getnumahighestnodenumber, base.getnumahighestnodenumber, systemtopologyapi/GetNumaHighestNodeNumber, winbase/GetNumaHighestNodeNumber
 req.header: systemtopologyapi.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista, Windows XP Professional x64 Edition, Windows XP with SP2 [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-callbackmayrunlong.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-callbackmayrunlong.md
@@ -9,7 +9,7 @@ ms.assetid: 59364b91-d78b-46e2-b298-42f77e712577
 ms.date: 12/05/2018
 ms.keywords: CallbackMayRunLong, CallbackMayRunLong function, base.callbackmayrunlong, threadpoolapiset/CallbackMayRunLong, winbase/CallbackMayRunLong
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-cancelthreadpoolio.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-cancelthreadpoolio.md
@@ -9,7 +9,7 @@ ms.assetid: e3af8313-2e09-4c88-8cef-671efd4228c7
 ms.date: 12/05/2018
 ms.keywords: CancelThreadpoolIo, CancelThreadpoolIo function, base.cancelthreadpoolio, threadpoolapiset/CancelThreadpoolIo, winbase/CancelThreadpoolIo
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolcleanupgroup.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolcleanupgroup.md
@@ -9,7 +9,7 @@ ms.assetid: e38e4d99-63f2-4bac-8675-cf0f3aa149a7
 ms.date: 12/05/2018
 ms.keywords: CloseThreadpoolCleanupGroup, CloseThreadpoolCleanupGroup function, base.closethreadpoolcleanupgroup, threadpoolapiset/CloseThreadpoolCleanupGroup, winbase/CloseThreadpoolCleanupGroup
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolio.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolio.md
@@ -9,7 +9,7 @@ ms.assetid: 499190de-54e8-4be6-909b-04505bcb0aa6
 ms.date: 12/05/2018
 ms.keywords: CloseThreadpoolIo, CloseThreadpoolIo function, base.closethreadpoolio, threadpoolapiset/CloseThreadpoolIo, winbase/CloseThreadpoolIo
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpooltimer.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpooltimer.md
@@ -9,7 +9,7 @@ ms.assetid: c1270c5d-a1f5-4481-a343-c1ff3301a56e
 ms.date: 12/05/2018
 ms.keywords: CloseThreadpoolTimer, CloseThreadpoolTimer function, base.closethreadpooltimer, threadpoolapiset/CloseThreadpoolTimer, winbase/CloseThreadpoolTimer
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait.md
@@ -9,7 +9,7 @@ ms.assetid: f8323ad2-c0b6-4e5c-b6eb-7195673f8992
 ms.date: 12/05/2018
 ms.keywords: CloseThreadpoolWait, CloseThreadpoolWait function, base.closethreadpoolwait, threadpoolapiset/CloseThreadpoolWait, winbase/CloseThreadpoolWait
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwork.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwork.md
@@ -9,7 +9,7 @@ ms.assetid: 89d7362e-0814-4f7e-a27f-8a297e210559
 ms.date: 12/05/2018
 ms.keywords: CloseThreadpoolWork, CloseThreadpoolWork function, base.closethreadpoolwork, threadpoolapiset/CloseThreadpoolWork, winbase/CloseThreadpoolWork
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpool.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpool.md
@@ -9,7 +9,7 @@ ms.assetid: cc00d7bf-ac52-44ff-a6a8-76c8eaace5e6
 ms.date: 12/05/2018
 ms.keywords: CreateThreadpool, CreateThreadpool function, base.createthreadpool, threadpoolapiset/CreateThreadpool, winbase/CreateThreadpool
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolcleanupgroup.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolcleanupgroup.md
@@ -9,7 +9,7 @@ ms.assetid: 668593fe-2ed1-418d-8cd5-5fac61826ea1
 ms.date: 12/05/2018
 ms.keywords: CreateThreadpoolCleanupGroup, CreateThreadpoolCleanupGroup function, base.createthreadpoolcleanupgroup, threadpoolapiset/CreateThreadpoolCleanupGroup, winbase/CreateThreadpoolCleanupGroup
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolio.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolio.md
@@ -9,7 +9,7 @@ ms.assetid: 621f4747-50fa-4538-bd6a-dbe4dbb05dd1
 ms.date: 12/05/2018
 ms.keywords: CreateThreadpoolIo, CreateThreadpoolIo function, base.createthreadpoolio, threadpoolapiset/CreateThreadpoolIo, winbase/CreateThreadpoolIo
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpooltimer.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpooltimer.md
@@ -9,7 +9,7 @@ ms.assetid: 1fa98b79-e646-4e48-9979-1817d2c1b713
 ms.date: 12/05/2018
 ms.keywords: CreateThreadpoolTimer, CreateThreadpoolTimer function, base.createthreadpooltimer, threadpoolapiset/CreateThreadpoolTimer, winbase/CreateThreadpoolTimer
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-createthreadpoolwait.md
@@ -9,7 +9,7 @@ ms.assetid: ba19f5f9-d4b0-4865-9609-95e7697d61c0
 ms.date: 12/05/2018
 ms.keywords: CreateThreadpoolWait, CreateThreadpoolWait function, base.createthreadpoolwait, threadpoolapiset/CreateThreadpoolWait, winbase/CreateThreadpoolWait
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-disassociatecurrentthreadfromcallback.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-disassociatecurrentthreadfromcallback.md
@@ -9,7 +9,7 @@ ms.assetid: f25f936c-2570-4e8c-807b-42000cd878bb
 ms.date: 12/05/2018
 ms.keywords: DisassociateCurrentThreadFromCallback, DisassociateCurrentThreadFromCallback function, base.disassociatecurrentthreadfromcallback, threadpoolapiset/DisassociateCurrentThreadFromCallback, winbase/DisassociateCurrentThreadFromCallback
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-freelibrarywhencallbackreturns.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-freelibrarywhencallbackreturns.md
@@ -9,7 +9,7 @@ ms.assetid: a29ba988-5d66-4914-9e37-a229bce75af2
 ms.date: 12/05/2018
 ms.keywords: FreeLibraryWhenCallbackReturns, FreeLibraryWhenCallbackReturns function, base.freelibrarywhencallbackreturns, threadpoolapiset/FreeLibraryWhenCallbackReturns, winbase/FreeLibraryWhenCallbackReturns
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-isthreadpooltimerset.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-isthreadpooltimerset.md
@@ -9,7 +9,7 @@ ms.assetid: f9dee0aa-6310-4218-b207-72a24c5019e2
 ms.date: 12/05/2018
 ms.keywords: IsThreadpoolTimerSet, IsThreadpoolTimerSet function, base.isthreadpooltimerset, threadpoolapiset/IsThreadpoolTimerSet, winbase/IsThreadpoolTimerSet
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-leavecriticalsectionwhencallbackreturns.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-leavecriticalsectionwhencallbackreturns.md
@@ -9,7 +9,7 @@ ms.assetid: 43ce27ee-207c-4317-9771-d82f1f4edda2
 ms.date: 12/05/2018
 ms.keywords: LeaveCriticalSectionWhenCallbackReturns, LeaveCriticalSectionWhenCallbackReturns function, base.leavecriticalsectionwhencallbackreturns, threadpoolapiset/LeaveCriticalSectionWhenCallbackReturns, winbase/LeaveCriticalSectionWhenCallbackReturns
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-releasemutexwhencallbackreturns.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-releasemutexwhencallbackreturns.md
@@ -9,7 +9,7 @@ ms.assetid: 0e82c041-8191-477d-8a2e-819b8920bbc8
 ms.date: 12/05/2018
 ms.keywords: ReleaseMutexWhenCallbackReturns, ReleaseMutexWhenCallbackReturns function, base.releasemutexwhencallbackreturns, threadpoolapiset/ReleaseMutexWhenCallbackReturns, winbase/ReleaseMutexWhenCallbackReturns
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-releasesemaphorewhencallbackreturns.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-releasesemaphorewhencallbackreturns.md
@@ -9,7 +9,7 @@ ms.assetid: d5c8d6a0-6bb1-4ecb-aaba-665d81cb3d14
 ms.date: 12/05/2018
 ms.keywords: ReleaseSemaphoreWhenCallbackReturns, ReleaseSemaphoreWhenCallbackReturns function, base.releasesemaphorewhencallbackreturns, threadpoolapiset/ReleaseSemaphoreWhenCallbackReturns, winbase/ReleaseSemaphoreWhenCallbackReturns
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-seteventwhencallbackreturns.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-seteventwhencallbackreturns.md
@@ -9,7 +9,7 @@ ms.assetid: 50e127bc-d518-4f84-88ea-b262572d5248
 ms.date: 12/05/2018
 ms.keywords: SetEventWhenCallbackReturns, SetEventWhenCallbackReturns function, base.seteventwhencallbackreturns, threadpoolapiset/SetEventWhenCallbackReturns, winbase/SetEventWhenCallbackReturns
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolthreadminimum.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolthreadminimum.md
@@ -9,7 +9,7 @@ ms.assetid: 39ab262d-50ff-4aaa-93a8-ded2b0f72615
 ms.date: 12/05/2018
 ms.keywords: SetThreadpoolThreadMinimum, SetThreadpoolThreadMinimum function, base.setthreadpoolthreadminimum, threadpoolapiset/SetThreadpoolThreadMinimum, winbase/SetThreadpoolThreadMinimum
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpooltimer.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpooltimer.md
@@ -9,7 +9,7 @@ ms.assetid: 017f88c6-e14c-47ba-94d2-e7bb0dc95d12
 ms.date: 12/05/2018
 ms.keywords: SetThreadpoolTimer, SetThreadpoolTimer function, base.setthreadpooltimer, threadpoolapiset/SetThreadpoolTimer, winbase/SetThreadpoolTimer
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
@@ -9,7 +9,7 @@ ms.assetid: ebd0ecad-a864-43cf-a1cb-e4c2d595ef81
 ms.date: 12/05/2018
 ms.keywords: SetThreadpoolWait, SetThreadpoolWait function, base.setthreadpoolwait, threadpoolapiset/SetThreadpoolWait, winbase/SetThreadpoolWait
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-startthreadpoolio.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-startthreadpoolio.md
@@ -9,7 +9,7 @@ ms.assetid: 5a817d6f-a8e6-4aaa-b560-0128eacb98b1
 ms.date: 12/05/2018
 ms.keywords: StartThreadpoolIo, StartThreadpoolIo function, base.startthreadpoolio, threadpoolapiset/StartThreadpoolIo, winbase/StartThreadpoolIo
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-submitthreadpoolwork.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-submitthreadpoolwork.md
@@ -9,7 +9,7 @@ ms.assetid: 28df173d-b78c-4158-97d5-63117a2d3967
 ms.date: 12/05/2018
 ms.keywords: SubmitThreadpoolWork, SubmitThreadpoolWork function, base.submitthreadpoolwork, threadpoolapiset/SubmitThreadpoolWork, winbase/SubmitThreadpoolWork
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-trysubmitthreadpoolcallback.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-trysubmitthreadpoolcallback.md
@@ -9,7 +9,7 @@ ms.assetid: 689d197e-195f-419c-9317-b30c614038c4
 ms.date: 12/05/2018
 ms.keywords: TrySubmitThreadpoolCallback, TrySubmitThreadpoolCallback function, base.trysubmitthreadpoolcallback, threadpoolapiset/TrySubmitThreadpoolCallback, winbase/TrySubmitThreadpoolCallback
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooliocallbacks.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooliocallbacks.md
@@ -9,7 +9,7 @@ ms.assetid: 68dc640d-8678-441d-88bd-01284d98a251
 ms.date: 12/05/2018
 ms.keywords: WaitForThreadpoolIoCallbacks, WaitForThreadpoolIoCallbacks function, base.waitforthreadpooliocallbacks, threadpoolapiset/WaitForThreadpoolIoCallbacks, winbase/WaitForThreadpoolIoCallbacks
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooltimercallbacks.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpooltimercallbacks.md
@@ -9,7 +9,7 @@ ms.assetid: 511488b8-9e92-47b9-8b3c-7ece9d9f996c
 ms.date: 12/05/2018
 ms.keywords: WaitForThreadpoolTimerCallbacks, WaitForThreadpoolTimerCallbacks function, base.waitforthreadpooltimercallbacks, threadpoolapiset/WaitForThreadpoolTimerCallbacks, winbase/WaitForThreadpoolTimerCallbacks
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolwaitcallbacks.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolwaitcallbacks.md
@@ -9,7 +9,7 @@ ms.assetid: 49c40b35-a0ed-40a1-9c35-5d3985ebd98f
 ms.date: 12/05/2018
 ms.keywords: WaitForThreadpoolWaitCallbacks, WaitForThreadpoolWaitCallbacks function, base.waitforthreadpoolwaitcallbacks, threadpoolapiset/WaitForThreadpoolWaitCallbacks, winbase/WaitForThreadpoolWaitCallbacks
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolworkcallbacks.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-waitforthreadpoolworkcallbacks.md
@@ -9,7 +9,7 @@ ms.assetid: 97c16892-d6ef-4216-ac79-344e83ab35bc
 ms.date: 12/05/2018
 ms.keywords: WaitForThreadpoolWorkCallbacks, WaitForThreadpoolWorkCallbacks function, base.waitforthreadpoolworkcallbacks, threadpoolapiset/WaitForThreadpoolWorkCallbacks, winbase/WaitForThreadpoolWorkCallbacks
 req.header: threadpoolapiset.h
-req.include-header: Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/threadpoollegacyapiset/nf-threadpoollegacyapiset-queueuserworkitem.md
+++ b/sdk-api-src/content/threadpoollegacyapiset/nf-threadpoollegacyapiset-queueuserworkitem.md
@@ -9,7 +9,7 @@ ms.assetid: 96f34b51-3784-4bb7-ae40-067f8113ff39
 ms.date: 12/05/2018
 ms.keywords: QueueUserWorkItem, QueueUserWorkItem function, WT_EXECUTEDEFAULT, WT_EXECUTEINIOTHREAD, WT_EXECUTEINPERSISTENTTHREAD, WT_EXECUTELONGFUNCTION, WT_TRANSFER_IMPERSONATION, _win32_queueuserworkitem, base.queueuserworkitem, threadpoollegacyapiset/QueueUserWorkItem, winbase/QueueUserWorkItem
 req.header: threadpoollegacyapiset.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps only]
 req.target-min-winversvr: Windows Server 2003 [desktop apps only]

--- a/sdk-api-src/content/winbase/nf-winbase-getenvironmentvariable.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getenvironmentvariable.md
@@ -9,7 +9,7 @@ ms.assetid: 1d4cc328-12e6-4aae-9f58-58675116ad54
 ms.date: 12/05/2018
 ms.keywords: GetEnvironmentVariable, GetEnvironmentVariable function, GetEnvironmentVariableA, GetEnvironmentVariableW, _win32_getenvironmentvariable, base.getenvironmentvariable, processenv/GetEnvironmentVariable, processenv/GetEnvironmentVariableA, processenv/GetEnvironmentVariableW, winbase/GetEnvironmentVariable, winbase/GetEnvironmentVariableA, winbase/GetEnvironmentVariableW
 req.header: winbase.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/winbase/nf-winbase-setenvironmentvariable.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setenvironmentvariable.md
@@ -9,7 +9,7 @@ ms.assetid: 95bd6fa5-886d-41dc-a5c3-ede86dbfa15d
 ms.date: 12/05/2018
 ms.keywords: SetEnvironmentVariable, SetEnvironmentVariable function, SetEnvironmentVariableA, SetEnvironmentVariableW, _win32_setenvironmentvariable, base.setenvironmentvariable, processenv/SetEnvironmentVariable, processenv/SetEnvironmentVariableA, processenv/SetEnvironmentVariableW, winbase/SetEnvironmentVariable, winbase/SetEnvironmentVariableA, winbase/SetEnvironmentVariableW
 req.header: winbase.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64process.md
@@ -9,7 +9,7 @@ ms.assetid: 5a237542-e432-487c-aa59-2ede427dd1eb
 ms.date: 12/05/2018
 ms.keywords: IsWow64Process, IsWow64Process function, _win32_iswow64process, base.iswow64process, winbase/IsWow64Process, wow64apiset/IsWow64Process
 req.header: wow64apiset.h
-req.include-header: Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2, Windows.h
+req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
 req.target-type: Windows
 req.target-min-winverclnt: Windows Vista, Windows XP with SP2 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008, Windows Server 2003 with SP1 [desktop apps \| UWP apps]


### PR DESCRIPTION
- The wording for which header to include is very awkward for a number of functions (I counted 162 occurrences overall). It seems to suggest that on older Windows versions you ought to include Windows.h but on newer ones you can use the header in which it is regularly declared.
- Since the string from `req.include-header:` appears to go into parentheses and gets an "include " slapped in front, this should fix the wording up a bit.

Regular expression used:
* search: `(req\.include-header:)\s+?(Windows .+?),\s+?([a-zA-Z0-9]+?\.h)`
* replace: `\1 \3 on \2`

This is the first part and still WIP. Since you don't allow issues, but only pull requests, it's the best I could come up with to get a discussion started on this awkward wording and how to fix it.

Best regards,

Oliver