### PR TITLE
Fix dml_batch_normalization_grad_operator note on broadcasting size 1 dimensions

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_batch_normalization_grad_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_batch_normalization_grad_operator_desc.md
@@ -46,8 +46,6 @@ api_name:
 
 Computes backpropagation gradients for [batch normalization](/windows/win32/api/directml/ns-directml-dml_batch_normalization_operator_desc). **DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC** performs multiple computations, which are detailed in the separate output descriptions.
 
-Any dimension in *MeanTensor*, *VarianceTensor*, and *ScaleTensor* can be set to 1 and be automatically broadcast to match *InputTensor*, but otherwise must equal the corresponding dimension's size from *InputTensor*. 
-
 *OutputScaleGradientTensor* and *OutputBiasGradientTensor* are computed using sums across the set of dimensions for which *MeanTensor*, *ScaleTensor* and *VarianceTensor* sizes equal one.
 
 ## -struct-fields


### PR DESCRIPTION
In https://docs.microsoft.com/en-us/windows/win32/api/directml/ns-directml-dml_batch_normalization_grad_operator_desc

Copy pasta from the non-grad version. Broadcasting does *not* automatically happen for size 1 dimensions. Pass 0 for stride.