### PR TITLE
Update nf-pdh-pdhexpandwildcardpatha.md

### DIFF
--- a/sdk-api-src/content/pdh/nf-pdh-pdhexpandwildcardpatha.md
+++ b/sdk-api-src/content/pdh/nf-pdh-pdhexpandwildcardpatha.md
@@ -114,6 +114,16 @@ Do not expand the instance name if the path contains a wildcard character for pa
 
 </td>
 </tr>
+	
+<tr>
+<td width="40%"><a id="PDH_REFRESHCOUNTERS"></a><a id="pdh_PDH_REFRESHCOUNTERS"></a><dl>
+<dt><b>PDH_REFRESHCOUNTERS</b></dt>
+</dl>
+</td>
+<td width="60%">
+Refresh the counter list.
+</td>
+</tr>
 </table>
 
 ## -returns


### PR DESCRIPTION
The PDH_REFRESHCOUNTERS flag isn't documented here.  It should be added as it is needed to get accurate information back about transient counters / counters added since the original wildcard counter was added and the time this was called.  This should also be edited in the different PdhExpandWildCardPath* functions which use the same flags.