### PR TITLE
The function is not exported from kernel32.dll

### DIFF
--- a/sdk-api-src/content/appmodel/nf-appmodel-getstagedpackageorigin.md
+++ b/sdk-api-src/content/appmodel/nf-appmodel-getstagedpackageorigin.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Kernel32.lib
-req.dll: Kernel32.dll
+req.dll: Kernelbase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
https://stackoverflow.com/questions/47448559/getstagedpackageorigin-is-not-found-in-kernel32-dll-as-documented-but-in-kernel

https://stackoverflow.com/questions/54234075/lnk2019-unable-to-use-getstagedpackageorigin