### PR TITLE
Correct the build number for bcp47mrm APIs for MRT in WinAppSDK

### DIFF
--- a/sdk-api-src/content/bcp47mrm/nf-bcp47mrm-getdistanceofclosestlanguageinlist.md
+++ b/sdk-api-src/content/bcp47mrm/nf-bcp47mrm-getdistanceofclosestlanguageinlist.md
@@ -18,8 +18,8 @@ req.lib:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763 
+req.target-min-winversvr: Windows 10 Build 17763
 req.target-type: 
 req.type-library: 
 req.umdf-ver: 

--- a/sdk-api-src/content/bcp47mrm/nf-bcp47mrm-iswellformedtag.md
+++ b/sdk-api-src/content/bcp47mrm/nf-bcp47mrm-iswellformedtag.md
@@ -18,8 +18,8 @@ req.lib:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.target-type: 
 req.type-library: 
 req.umdf-ver: 


### PR DESCRIPTION
Correct the build number bcp47mrm APIs for MRT in WinAppSDK that were retro-documented and had the incorrect build number listed