### PR TITLE
Fix typo in nf-winreg-reggetvaluew.md

### DIFF
--- a/sdk-api-src/content/winreg/nf-winreg-reggetvaluew.md
+++ b/sdk-api-src/content/winreg/nf-winreg-reggetvaluew.md
@@ -140,7 +140,7 @@ Restrict type to 32-bit RRF_RT_REG_BINARY | RRF_RT_REG_DWORD.
 </dl>
 </td>
 <td width="60%">
-Restrict type to 64-bit RRF_RT_REG_BINARY | RRF_RT_REG_DWORD.
+Restrict type to 64-bit RRF_RT_REG_BINARY | RRF_RT_REG_QWORD.
 
 </td>
 </tr>


### PR DESCRIPTION
Change "Restrict type to 64-bit RRF_RT_REG_BINARY | RRF_RT_REG_DWORD" to "Restrict type to 64-bit RRF_RT_REG_BINARY | RRF_RT_REG_QWORD".