### PR TITLE
RegDeleteTree: RegDeleteKeyTransacted docs say HKEY can be transacted here

### DIFF
--- a/sdk-api-src/content/winreg/nf-winreg-regdeletetreea.md
+++ b/sdk-api-src/content/winreg/nf-winreg-regdeletetreea.md
@@ -69,9 +69,12 @@ Deletes the subkeys and values of the specified key recursively.
 A handle to an open registry key. The key must have been opened with the following access rights: DELETE, KEY_ENUMERATE_SUB_KEYS, and KEY_QUERY_VALUE. For more information, see 
 <a href="/windows/desktop/SysInfo/registry-key-security-and-access-rights">Registry Key Security and Access Rights</a>.
 
-This handle is returned by the 
-<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeyexa">RegCreateKeyEx</a> or 
-<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeyexa">RegOpenKeyEx</a> function, or it can be one of the following 
+This handle is returned by the
+<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeyexa">RegCreateKeyEx</a>,
+<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeytransacteda">RegCreateKeyTransacted</a>,
+<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeyexa">RegOpenKeyEx</a>, or
+<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeytransacteda">RegOpenKeyTransacted</a> function,
+or it can be one of the following 
 <a href="/windows/desktop/SysInfo/predefined-keys">Predefined Keys</a>:<dl>
 <dd><b>HKEY_CLASSES_ROOT</b></dd>
 <dd><b>HKEY_CURRENT_CONFIG</b></dd>
@@ -110,10 +113,8 @@ To compile an application that uses this function, define _WIN32_WINNT as 0x0600
 
 <a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeya">RegDeleteKey</a>
 
-
-
 <a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeyexa">RegDeleteKeyEx</a>
 
-
+<a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeytransacteda">RegDeleteKeyTransacted</a>
 
 <a href="/windows/desktop/SysInfo/registry-functions">Registry Functions</a>

--- a/sdk-api-src/content/winreg/nf-winreg-regdeletetreew.md
+++ b/sdk-api-src/content/winreg/nf-winreg-regdeletetreew.md
@@ -69,9 +69,12 @@ Deletes the subkeys and values of the specified key recursively.
 A handle to an open registry key. The key must have been opened with the following access rights: DELETE, KEY_ENUMERATE_SUB_KEYS, and KEY_QUERY_VALUE. For more information, see 
 <a href="/windows/desktop/SysInfo/registry-key-security-and-access-rights">Registry Key Security and Access Rights</a>.
 
-This handle is returned by the 
-<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeyexa">RegCreateKeyEx</a> or 
-<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeyexa">RegOpenKeyEx</a> function, or it can be one of the following 
+This handle is returned by the
+<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeyexa">RegCreateKeyEx</a>,
+<a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeytransacteda">RegCreateKeyTransacted</a>,
+<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeyexa">RegOpenKeyEx</a>, or
+<a href="/windows/desktop/api/winreg/nf-winreg-regopenkeytransacteda">RegOpenKeyTransacted</a> function,
+or it can be one of the following 
 <a href="/windows/desktop/SysInfo/predefined-keys">Predefined Keys</a>:<dl>
 <dd><b>HKEY_CLASSES_ROOT</b></dd>
 <dd><b>HKEY_CURRENT_CONFIG</b></dd>
@@ -110,10 +113,8 @@ To compile an application that uses this function, define _WIN32_WINNT as 0x0600
 
 <a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeya">RegDeleteKey</a>
 
-
-
 <a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeyexa">RegDeleteKeyEx</a>
 
-
+<a href="/windows/desktop/api/winreg/nf-winreg-regdeletekeytransacteda">RegDeleteKeyTransacted</a>
 
 <a href="/windows/desktop/SysInfo/registry-functions">Registry Functions</a>


### PR DESCRIPTION
Quote from `RegDeleteKeyTransacted`'s docs:
> If the function succeeds, RegDeleteKeyTransacted removes the specified key from the registry. The entire key, including all of its values, is removed. To remove the entire tree as a transacted operation, use the [RegDeleteTree](https://docs.microsoft.com/en-us/windows/desktop/api/winreg/nf-winreg-regdeletetreea) function with a handle returned from [RegCreateKeyTransacted](https://docs.microsoft.com/en-us/windows/desktop/api/winreg/nf-winreg-regcreatekeytransacteda) or [RegOpenKeyTransacted](https://docs.microsoft.com/en-us/windows/desktop/api/winreg/nf-winreg-regopenkeytransacteda).