### PR TITLE
Mark UMS as unsupported in Windows 11+

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
@@ -181,7 +181,7 @@ The <i>lpValue</i> parameter is a pointer to a <a href="/windows/desktop/api/win
 
 After the UMS thread is created, the system queues it to the specified completion list. The UMS thread runs only when an application's UMS scheduler retrieves the UMS thread from the completion list and selects it to run.  For more information, see <a href="/windows/desktop/ProcThread/user-mode-scheduling">User-Mode Scheduling</a>.
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2.
+<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2, and from Windows 11 onwards.
 
 </td>
 </tr>

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute.md
@@ -86,7 +86,7 @@ The attribute key to update in the attribute list. This parameter can be one of 
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a <a href="/windows/desktop/api/winnt/ns-winnt-group_affinity">GROUP_AFFINITY</a> structure that specifies the processor group affinity for the new thread.
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2.
+Supported in Windows 7 and newer and Windows Server 2008 R2 and newer.
 
 </td>
 </tr>
@@ -112,7 +112,7 @@ These handles must be created as inheritable handles and must not include pseudo
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a  <a href="/windows/desktop/api/winnt/ns-winnt-processor_number">PROCESSOR_NUMBER</a> structure that specifies the ideal processor for the new thread.
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2.
+Supported in Windows 7 and newer and Windows Server 2008 R2 and newer.
 
 </td>
 </tr>
@@ -125,7 +125,7 @@ The <i>lpValue</i> parameter is a pointer to a  <a href="/windows/desktop/api/wi
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a <b>WORD</b> that specifies the machine architecture of the child process.
 
-This value is not supported until <b>Windows 11</b>.
+Supported in Windows 11 and newer.
 
 The  <b>WORD</b> pointed to by <i>lpValue</i> can be a value listed on <a href="/windows/win32/sysinfo/image-file-machine-constants">IMAGE FILE MACHINE CONSTANTS</a>.
 </td>
@@ -141,9 +141,9 @@ The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> or <b>DWORD64</b> th
 
 The specified policy overrides the policies set for the application and the system and cannot be changed after the child process starts running.  
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2.
-
 The  <b>DWORD</b> or <b>DWORD64</b> pointed to by <i>lpValue</i> can be one or more of the values listed in the remarks.
+
+Supported in Windows 7 and newer and Windows Server 2008 R2 and newer.
 
 </td>
 </tr>
@@ -167,7 +167,7 @@ Attributes inherited from the specified process include handles, the device map,
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to the node number of the preferred NUMA node for the new process.
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2.
+Supported in Windows 7 and newer and Windows Server 2008 R2 and newer.
 
 </td>
 </tr>
@@ -181,7 +181,9 @@ The <i>lpValue</i> parameter is a pointer to a <a href="/windows/desktop/api/win
 
 After the UMS thread is created, the system queues it to the specified completion list. The UMS thread runs only when an application's UMS scheduler retrieves the UMS thread from the completion list and selects it to run.  For more information, see <a href="/windows/desktop/ProcThread/user-mode-scheduling">User-Mode Scheduling</a>.
 
-<b>Windows Server 2008 and Windows Vista:  </b>This value is not supported until Windows 7 and Windows Server 2008 R2, and from Windows 11 onwards.
+Supported in Windows 7 and newer and Windows Server 2008 R2 and newer.
+
+Not supported in Windows 11 and newer (see [User-Mode Scheduling](/windows/win32/procthread/user-mode-scheduling)).
 
 </td>
 </tr>
@@ -193,7 +195,7 @@ After the UMS thread is created, the system queues it to the specified completio
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a <a href="/windows/desktop/api/winnt/ns-winnt-security_capabilities">SECURITY_CAPABILITIES</a> structure that defines the security capabilities of an app container. If this attribute is set the new process will be created as an AppContainer process.
 
-<b>Windows 7, Windows Server 2008 R2, Windows Server 2008 and Windows Vista:  </b>This value is not supported until  Windows 8 and Windows Server 2012.
+Supported in Windows 8 and newer and Windows Server 2012 and newer.
 
 </td>
 </tr>
@@ -205,7 +207,8 @@ The <i>lpValue</i> parameter is a pointer to a <a href="/windows/desktop/api/win
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> value of <b>PROTECTION_LEVEL_SAME</b>. This specifies the protection level of the child process to be the same as the protection level of its parent process.
 
-<b>Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008 and Windows Vista: </b>This value is not supported until Windows 8.1 and Windows Server 2012 R2.
+Supported in Windows 8.1 and newer and Windows Server 2012 R2 and newer.
+
 </td>
 </tr>
 <tr>
@@ -218,7 +221,8 @@ The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> value that specifies
 
 For information on the possible values for the <b>DWORD</b> to which <i>lpValue</i> points, see Remarks.
 
-<b>Windows 8.1, Windows 8, Windows 7, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008 and Windows Vista: </b>This value is not supported until Windows 10 and Windows Server 2016.
+Supported in Windows 10 and newer and Windows Server 2016 and newer.
+
 </td>
 </tr>
 <tr>
@@ -233,7 +237,8 @@ The <i>lpValue</i> parameter is a pointer to a <b>DWORD</b> value that specifies
 
 For information about the possible values for the <b>DWORD</b> to which <i>lpValue</i> points, see Remarks.
 
-This value is not supported until Windows 10 Version 1703 and Windows Server Version 1709.
+Supported in Windows 10 Version 1703 and newer and Windows Server Version 1709 and newer.
+
 </td>
 </tr>
 <tr>
@@ -244,7 +249,8 @@ This value is not supported until Windows 10 Version 1703 and Windows Server Ver
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a list of job handles to be assigned to the child process, in the order specified.
 
-<b>Windows 8.1, Windows 8, Windows 7, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2, Windows Server 2008 and Windows Vista: </b>This value is not supported until Windows 10 and Windows Server 2016.
+Supported in Windows 10 and newer and Windows Server 2016 and newer.
+
 </td>
 </tr>
 <tr>
@@ -255,7 +261,7 @@ The <i>lpValue</i> parameter is a pointer to a list of job handles to be assigne
 <td width="60%">
 The <i>lpValue</i> parameter is a pointer to a <b>DWORD64</b> value that specifies the set of optional XState features to enable for the new thread.
 
-This value is not supported until Windows 11 and Windows Server 2022.
+Supported in Windows 11 and newer and Windows Server 2022 and newer.
 
 </td>
 </tr>


### PR DESCRIPTION
Calling `UpdateProcThreadAttribute` with `PROC_THREAD_ATTRIBUTE_UMS_THREAD` results in `ERROR_NOT_SUPPORTED` on Windows 11+, which is to be expected, according to the warning on top of [this](https://docs.microsoft.com/en-us/windows/win32/procthread/user-mode-scheduling) page.