### PR TITLE
Update nf-winuser-postmessagew.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-postmessagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-postmessagew.md
@@ -132,7 +132,7 @@ Type: <b>BOOL</b>
 
 If the function succeeds, the return value is nonzero.
 
-If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. <b>GetLastError</b> returns <b>ERROR_NOT_ENOUGH_QUOTA</b> when the limit is hit.
+If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 


### PR DESCRIPTION
> GetLastError returns ERROR_NOT_ENOUGH_QUOTA when the limit is hit.

The above sentence was at the end of the "returns" section. It looks like copy-pasta to me, so I removed it.