### PR TITLE
Update nf-winbase-createsymboliclinka.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-createsymboliclinka.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createsymboliclinka.md
@@ -131,7 +131,7 @@ The link target is a directory.
 </dl>
 </td>
 <td width="60%">
-Specify this flag to allow creation of symbolic links when the process is not elevated. <a href="/windows/uwp/get-started/enable-your-device-for-development">Developer Mode</a> must first be enabled on the machine before  this option will function.
+Specify this flag to allow creation of symbolic links when the process is not elevated. In UWP, <a href="/windows/uwp/get-started/enable-your-device-for-development">Developer Mode</a> must first be enabled on the machine before  this option will function.  Under MSIX, developer mode is not required to be enabled for this flag.
 
 </td>
 </tr>


### PR DESCRIPTION
Proposed change is based upon testing under MSIX on Windows 10 21H2.  I do not know whether developer mode is still required for UWP, so that should be checked by Microsoft prior to accepting this change.