### PR TITLE
Update nf-d3d12-id3d12graphicscommandlist-cleardepthstencilview.md

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-cleardepthstencilview.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-cleardepthstencilview.md
@@ -92,6 +92,8 @@ An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view
 
 ## -remarks
 
+Only direct and bundle commands lists support support this operation.  
+
 <b>ClearDepthStencilView</b> may be used to initialize resources which alias the same heap memory. See <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createplacedresource">CreatePlacedResource</a> for more details.
 
 <h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-cleardepthstencilview.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-cleardepthstencilview.md
@@ -47,7 +47,6 @@ api_name:
 
 # ID3D12GraphicsCommandList::ClearDepthStencilView
 
-
 ## -description
 
 Clears the depth-stencil resource.
@@ -92,31 +91,24 @@ An array of <b>D3D12_RECT</b> structures for the rectangles in the resource view
 
 ## -remarks
 
-Only direct and bundle commands lists support support this operation.  
+Only direct and bundle command lists support this operation.  
 
 <b>ClearDepthStencilView</b> may be used to initialize resources which alias the same heap memory. See <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12device-createplacedresource">CreatePlacedResource</a> for more details.
 
 <h3><a id="Runtime_validation"></a><a id="runtime_validation"></a><a id="RUNTIME_VALIDATION"></a>Runtime validation</h3>
 For floating-point inputs, the runtime will set denormalized values to 0 (while preserving NANs).
-          
 
 Validation failure will result in the call to <a href="/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-close">Close</a> returning <b>E_INVALIDARG</b>.
-          
 
 <h3><a id="Debug_layer"></a><a id="debug_layer"></a><a id="DEBUG_LAYER"></a>Debug layer</h3>
 The debug layer will issue errors if the input colors are denormalized.
-          
 
 The debug layer will issue an error if the subresources referenced by the view are not in the appropriate state.
             For <b>ClearDepthStencilView</b>, the state must be in the state <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_states">D3D12_RESOURCE_STATE_DEPTH_WRITE</a>.
-          
 
-
-#### Examples
+## Examples
 
 The <a href="/windows/desktop/direct3d12/working-samples">D3D12Bundles</a> sample uses <b>ID3D12GraphicsCommandList::ClearDepthStencilView</b> as follows:
-        
-
 
 ```cpp
 // Pipeline objects.
@@ -136,10 +128,7 @@ ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
 ComPtr<ID3D12PipelineState> m_pipelineState1;
 ComPtr<ID3D12PipelineState> m_pipelineState2;
 D3D12_RECT m_scissorRect;
-
 ```
-
-
 
 ```cpp
 void D3D12Bundles::PopulateCommandList(FrameResource* pFrameResource)
@@ -192,13 +181,9 @@ void D3D12Bundles::PopulateCommandList(FrameResource* pFrameResource)
 
     ThrowIfFailed(m_commandList->Close());
 }
-
 ```
 
-
 The <a href="/windows/desktop/direct3d12/working-samples">D3D12Multithreading</a> sample uses <b>ID3D12GraphicsCommandList::ClearDepthStencilView</b> as follows:
-        
-
 
 ```cpp
 void FrameResource::Init()
@@ -223,10 +208,7 @@ void FrameResource::Init()
         ThrowIfFailed(m_sceneCommandLists[i]->Reset(m_sceneCommandAllocators[i].Get(), m_pipelineState.Get()));
     }
 }
-
 ```
-
-
 
 ```cpp
 // Assemble the CommandListPre command list.
@@ -254,14 +236,9 @@ void D3D12Multithreading::MidFrame()
 
     ThrowIfFailed(m_pCurrentFrameResource->m_commandLists[CommandListMid]->Close());
 }
-
 ```
 
-
-See <a href="/windows/desktop/direct3d12/notes-on-example-code">Example Code in the D3D12 Reference</a>.
-        
-
-<div class="code"></div>
+See <a href="/windows/desktop/direct3d12/notes-on-example-code">Example code in the Direct3D 12 reference</a>.
 
 ## -see-also
 


### PR DESCRIPTION
This call can not be used by copy engine or compute queues.  Debug layer will validate this giving:
D3D12 ERROR: ID3D12GraphicsCommandList::ClearDepthStencilView: Invalid API called.  This method is not valid for D3D12_COMMAND_LIST_TYPE_COMPUTE or D3D12_COMMAND_LIST_TYPE_COPY. [ EXECUTION ERROR #932: NO_GRAPHICS_API_SUPPORT].