### PR TITLE
NotifyNetworkConnectivityHintChange improvements - return and remarks

### DIFF
--- a/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
+++ b/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
@@ -74,4 +74,5 @@ To deregister for change notifications, call the CancelMibChangeNotify2 function
 ## -see-also
 
 [PNETWORK_CONNECTIVITY_HINT_CHANGE_CALLBACK](./nc-netioapi-pnetwork_connectivity_hint_change_callback.md)
-[CancelMibChangeNotify2] (./nf-netioapi-cancelmibchangenotify2)
+
+[CancelMibChangeNotify2](./nf-netioapi-cancelmibchangenotify2.md)

--- a/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
+++ b/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
@@ -65,8 +65,13 @@ A pointer to a **HANDLE**. The function sets the value to a handle to the notifi
 
 ## -returns
 
+If the function succeeds, the return value is NO_ERROR. Otherwise, an error code is returned.
+
 ## -remarks
+
+To deregister for change notifications, call the CancelMibChangeNotify2 function passing the NotificationHandle parameter returned by NotifyNetworkConnectivityHintChange.
 
 ## -see-also
 
 [PNETWORK_CONNECTIVITY_HINT_CHANGE_CALLBACK](./nc-netioapi-pnetwork_connectivity_hint_change_callback.md)
+[CancelMibChangeNotify2] (./nf-netioapi-cancelmibchangenotify2)

--- a/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
+++ b/sdk-api-src/content/netioapi/nf-netioapi-notifynetworkconnectivityhintchange.md
@@ -65,14 +65,14 @@ A pointer to a **HANDLE**. The function sets the value to a handle to the notifi
 
 ## -returns
 
-If the function succeeds, the return value is NO_ERROR. Otherwise, an error code is returned.
+If the function succeeds, the return value is **NO_ERROR**. Otherwise, an error code is returned.
 
 ## -remarks
 
-To deregister for change notifications, call the CancelMibChangeNotify2 function passing the NotificationHandle parameter returned by NotifyNetworkConnectivityHintChange.
+To deregister for change notifications, call the **CancelMibChangeNotify2** function, passing the *NotificationHandle* parameter returned by **NotifyNetworkConnectivityHintChange**.
 
 ## -see-also
 
-[PNETWORK_CONNECTIVITY_HINT_CHANGE_CALLBACK](./nc-netioapi-pnetwork_connectivity_hint_change_callback.md)
+* [PNETWORK_CONNECTIVITY_HINT_CHANGE_CALLBACK](./nc-netioapi-pnetwork_connectivity_hint_change_callback.md)
 
-[CancelMibChangeNotify2](./nf-netioapi-cancelmibchangenotify2.md)
+* [CancelMibChangeNotify2](./nf-netioapi-cancelmibchangenotify2.md)


### PR DESCRIPTION
I added return information and, more importantly, noted that the Out PHANDLE argument must be freed with CancelMibChangeNotify2 to cancel the callback.