### PR TITLE
Fix typo in IFileOpenDialog::GetResults()

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ifileopendialog-getresults.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ifileopendialog-getresults.md
@@ -70,7 +70,7 @@ If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRE
 
 This method can be used whether the selection consists of a single item or multiple items.
 
-<b>IFileOpenDialog::GetResult</b> can be called after the dialog has closed or during the handling of an IFileDialogEvents::OnFileOk event. Calling this method at any other time will fail.
+<b>IFileOpenDialog::GetResults</b> can be called after the dialog has closed or during the handling of an IFileDialogEvents::OnFileOk event. Calling this method at any other time will fail.
 
 
-<a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-imodalwindow-show">Show</a> must return a success code for a result to be available to <b>IFileOpenDialog::GetResult</b>.
+<a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-imodalwindow-show">Show</a> must return a success code for a result to be available to <b>IFileOpenDialog::GetResults</b>.


### PR DESCRIPTION
In the `IFileOpenDialog::GetResults()` documentation, some `GetResults` was written as `GetResult` (missing trailing `s`), which has been corrected.