### PR TITLE
Update nf-ntsecapi-lsacallauthenticationpackage.md

### DIFF
--- a/sdk-api-src/content/ntsecapi/nf-ntsecapi-lsacallauthenticationpackage.md
+++ b/sdk-api-src/content/ntsecapi/nf-ntsecapi-lsacallauthenticationpackage.md
@@ -91,7 +91,7 @@ A pointer to a <b>ULONG</b> that receives the length of the returned buffer, in 
 
 ### -param ProtocolStatus [out]
 
-If the function succeeds, this parameter receives a pointer to an <b>NTSTATUS</b> code that indicates the completion status of the authentication package.
+If the function succeeds, this parameter receives an <b>NTSTATUS</b> code that indicates the completion status of the authentication package.
 
 ## -returns
 


### PR DESCRIPTION
Changed the description of the 'ProtocolStatus' parameter. This parameter doesn't receive a pointer to a status. 
The caller must always supply a pointer to a variable, and the ProtocolStatus will contain an NTSTATUS value after a successful call.