### PR TITLE
Update nf-dskquota-idiskquotacontrol-initialize.md

### DIFF
--- a/sdk-api-src/content/dskquota/nf-dskquota-idiskquotacontrol-initialize.md
+++ b/sdk-api-src/content/dskquota/nf-dskquota-idiskquotacontrol-initialize.md
@@ -140,7 +140,7 @@ The requested file path is invalid.
 <tr>
 <td width="40%">
 <dl>
-<dt><b>ERROR_NOTSUPPORTED</b></dt>
+<dt><b>ERROR_NOT_SUPPORTED</b></dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
i think the correct error is `ERROR_NOT_SUPPORTED`
There is not such error `ERROR_NOTSUPPORTED`