### PR TITLE
Synchronous IO with overlapped moves file pointer.

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-readfile.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-readfile.md
@@ -283,7 +283,7 @@ Considerations for working with synchronous file handles:
        at the offset that is specified in the 
        <a href="/windows/desktop/api/minwinbase/ns-minwinbase-overlapped">OVERLAPPED</a> structure and 
        <b>ReadFile</b> does not return until the read operation is 
-       complete. The system updates the <b>OVERLAPPED</b> offset 
+       complete. The system updates the <b>OVERLAPPED</b> offset and the file pointer
        before <b>ReadFile</b> returns.</li>
  <li>If <i>lpOverlapped</i> is <b>NULL</b>, then when a synchronous read operation reaches the end of a file, 
        <b>ReadFile</b> returns <b>TRUE</b> and sets 

--- a/sdk-api-src/content/fileapi/nf-fileapi-writefile.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-writefile.md
@@ -389,7 +389,7 @@ Considerations for working with synchronous file handles:
        <a href="/windows/desktop/api/minwinbase/ns-minwinbase-overlapped">OVERLAPPED</a> structure and 
        <b>WriteFile</b> does not return until the write operation is 
        complete. The system updates the <b>OVERLAPPED</b> Internal and InternalHigh fields 
-       before <b>WriteFile</b> returns.</li>
+       and the file pointer before <b>WriteFile</b> returns.</li>
 </ul>
 For more information, see <a href="/windows/desktop/api/fileapi/nf-fileapi-createfilea">CreateFile</a> and 
       <a href="/windows/desktop/FileIO/synchronous-and-asynchronous-i-o">Synchronous and Asynchronous I/O</a>.


### PR DESCRIPTION
The documentation gives the impression that the file pointer of a synchronous file handle is updated by WriteFile/ReadFile only if lpOverlapped is NULL.  In fact it is also updated if it is not NULL. That is surprising, because (1) in this case the operation doesn't use the file position itself, it uses the offset from the overlapped object instead, and (2) the documentation tells you it only updates the overlapped object afterwards (in contrast with respective earlier paragraphs about the NULL case).  A reader might have the impression that this is a drop-in replacement for POSIX pread/pwrite, but it's not, due to this side-effect.

Example:

```
int
main(int argc, char *argv[])
{
	DWORD written;
	HANDLE handle;
	OVERLAPPED overlapped;

	handle = CreateFile("test.txt", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
	if (handle == INVALID_HANDLE_VALUE) {
		printf("CreateFile failed\n");
		return EXIT_FAILURE;
	}
	printf("before pointer %d\n", SetFilePointer(handle, 0, NULL, FILE_CURRENT));
	memset(&overlapped, 0, sizeof(overlapped));
	overlapped.Offset = 0;
	if (!WriteFile(handle, "hello world\n", 12, NULL, &overlapped)) {
		printf("WriteFile failed\n");
		return EXIT_FAILURE;
	}
	printf("after pointer %d\n", SetFilePointer(handle, 0, NULL, FILE_CURRENT));
	return EXIT_SUCCES;
}
```