### PR TITLE
Update ns-winnt-claim_security_attribute_v1.md

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-claim_security_attribute_v1.md
+++ b/sdk-api-src/content/winnt/ns-winnt-claim_security_attribute_v1.md
@@ -64,7 +64,7 @@ A pointer to a string of Unicode characters that contains the name of the securi
 
 ### -field ValueType
 
-A union tag value that indicates the type of information contained in the <b>Values</b> member. The <b>ValueType</b> member must be one of the following values.
+A union tag value that indicates the type of information contained in the <b>Values</b> member. The <b>ValueType</b> member must be one of the following values (see remarks for additional information).
 
 <table>
 <tr>
@@ -258,6 +258,10 @@ Pointer to an array of <b>ValueCount</b> members where each member is a fully qu
 ### -field Values.pOctetString
 
 Pointer to an array of <b>ValueCount</b> members where each member is  an octet string of type <a href="/windows/win32/api/winnt/ns-winnt-claim_security_attribute_octet_string_value">CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE</a>.
+
+## -remarks
+
+The field value type suggests that the value can be an Octet string or a SID. However the <a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/252d7e10-eaf8-44e9-8b8d-205b384f5782">Directory Services documentation for claims entries</a> specifies that effective possible data types for claims are only Int64, UInt64, UnicodeString and Boolean.
 
 ## -see-also
 

--- a/sdk-api-src/content/winnt/ns-winnt-claim_security_attribute_v1.md
+++ b/sdk-api-src/content/winnt/ns-winnt-claim_security_attribute_v1.md
@@ -261,7 +261,7 @@ Pointer to an array of <b>ValueCount</b> members where each member is  an octet 
 
 ## -remarks
 
-The field value type suggests that the value can be an Octet string or a SID. However the <a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/252d7e10-eaf8-44e9-8b8d-205b384f5782">Directory Services documentation for claims entries</a> specifies that effective possible data types for claims are only Int64, UInt64, UnicodeString and Boolean.
+The field value type indicates that the value can be an octet string or a SID. However, the [Directory Services documentation for claims entries](/openspecs/windows_protocols/ms-adts/252d7e10-eaf8-44e9-8b8d-205b384f5782) specifies that effective possible data types for claims are limited to Int64, UInt64, UnicodeString, and Boolean.
 
 ## -see-also
 


### PR DESCRIPTION
Following the documentation from GetTokenInformation it appears that the claims can contain SID and Octet string values. However it turns out to be impossible to configure claims of those types. After consulting with the Directory Services protocol specification it seems that these datatypes are not supported and only integer, boolean and string datatypes are supported. https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/252d7e10-eaf8-44e9-8b8d-205b384f5782