### PR TITLE
Changed "Lock Workstation" to "Lock"

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-lockworkstation.md
+++ b/sdk-api-src/content/winuser/nf-winuser-lockworkstation.md
@@ -70,7 +70,7 @@ The
 
 Common reasons the workstation might not be locked even if the function succeeds include the following: no user is logged on, the workstation is already locked, the process is not running on the interactive desktop, or the request is denied by the Graphical Identification and Authentication (GINA) DLL.
 
-This function has the same result as pressing Ctrl+Alt+Del and clicking <b>Lock Workstation</b>. To unlock the workstation, the user must log in. There is no function you can call to determine whether the workstation is locked. To receive notification when the user logs in, use the <a href="/windows/desktop/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification">WTSRegisterSessionNotification</a> function to receive <a href="/windows/desktop/TermServ/wm-wtssession-change">WM_WTSSESSION_CHANGE</a> messages. You can use session notifications to track the desktop state so you know whether it is possible to interact with the user.
+This function has the same result as pressing Ctrl+Alt+Del and clicking <b>Lock</b>. To unlock the workstation, the user must log in. There is no function you can call to determine whether the workstation is locked. To receive notification when the user logs in, use the <a href="/windows/desktop/api/wtsapi32/nf-wtsapi32-wtsregistersessionnotification">WTSRegisterSessionNotification</a> function to receive <a href="/windows/desktop/TermServ/wm-wtssession-change">WM_WTSSESSION_CHANGE</a> messages. You can use session notifications to track the desktop state so you know whether it is possible to interact with the user.
 
 
 #### Examples


### PR DESCRIPTION
On my machine (Windows 10) the Ctrl+Alt+Del menu simply says "Lock", not "Lock Workstation".

This was likely written with a previous version of Windows in mind.