### PR TITLE
The palette should be deleted when it is no longer needed

### DIFF
--- a/sdk-api-src/content/winddi/nf-winddi-engcreatepalette.md
+++ b/sdk-api-src/content/winddi/nf-winddi-engcreatepalette.md
@@ -143,7 +143,7 @@ The return value is a handle to the new palette if the function is successful. O
 
 The driver can associate the new palette with a device by returning a pointer to the palette in the <a href="/windows/desktop/api/winddi/ns-winddi-devinfo">DEVINFO</a> structure.
 
-A PAL_INDEXED palette associated with the device must have its first index entry set to black (red = 0, green = 0, blue = 0) and its last entry set to white (255, 255, 255). All other entries should be set so that entries whose indexes are one's complements of each other have colors that contrast greatly. For example, if entry 0x9 of a 16 entry palette is set to pure green (0,255,0), entry 0x6 (=~0x9) should be set to a color that contrasts well with green, such as dark purple (128,0,128). Setting entries in this way allows XOR raster operations to behave reasonably. The palette should be deleted when it is no longer needed by using <a href="/windows/win32/api/winddi/nf-winddi-engdeletepalette">EngDeletePalette</a>.
+A PAL_INDEXED palette associated with the device must have its first index entry set to black (red = 0, green = 0, blue = 0) and its last entry set to white (255, 255, 255). All other entries should be set so that entries whose indexes are one's complements of each other have colors that contrast greatly. For example, if entry 0x9 of a 16 entry palette is set to pure green (0,255,0), entry 0x6 (=~0x9) should be set to a color that contrasts well with green, such as dark purple (128,0,128). Setting entries in this way allows XOR raster operations to behave reasonably. You should delete the palette when you no longer need it by using <a href="/windows/win32/api/winddi/nf-winddi-engdeletepalette">EngDeletePalette</a>.
 
 ## -see-also
 

--- a/sdk-api-src/content/winddi/nf-winddi-engcreatepalette.md
+++ b/sdk-api-src/content/winddi/nf-winddi-engcreatepalette.md
@@ -143,7 +143,7 @@ The return value is a handle to the new palette if the function is successful. O
 
 The driver can associate the new palette with a device by returning a pointer to the palette in the <a href="/windows/desktop/api/winddi/ns-winddi-devinfo">DEVINFO</a> structure.
 
-A PAL_INDEXED palette associated with the device must have its first index entry set to black (red = 0, green = 0, blue = 0) and its last entry set to white (255, 255, 255). All other entries should be set so that entries whose indexes are one's complements of each other have colors that contrast greatly. For example, if entry 0x9 of a 16 entry palette is set to pure green (0,255,0), entry 0x6 (=~0x9) should be set to a color that contrasts well with green, such as dark purple (128,0,128). Setting entries in this way allows XOR raster operations to behave reasonably.
+A PAL_INDEXED palette associated with the device must have its first index entry set to black (red = 0, green = 0, blue = 0) and its last entry set to white (255, 255, 255). All other entries should be set so that entries whose indexes are one's complements of each other have colors that contrast greatly. For example, if entry 0x9 of a 16 entry palette is set to pure green (0,255,0), entry 0x6 (=~0x9) should be set to a color that contrasts well with green, such as dark purple (128,0,128). Setting entries in this way allows XOR raster operations to behave reasonably. The palette should be deleted when it is no longer needed by using <a href="/windows/win32/api/winddi/nf-winddi-engdeletepalette">EngDeletePalette</a>.
 
 ## -see-also
 
@@ -155,4 +155,4 @@ A PAL_INDEXED palette associated with the device must have its first index entry
 
 
 
-<a href="/windows/desktop/api/winddi/nf-winddi-engdeletepalette">EngDeletePalette</a>
+<a href="/windows/win32/api/winddi/nf-winddi-engdeletepalette">EngDeletePalette</a>


### PR DESCRIPTION
Explain that The palette should be deleted when it is no longer needed using EngDeletePalette. otherwise the app will have GDI leaks