### PR TITLE
Fixed wrong link under the style field

### DIFF
--- a/sdk-api-src/content/winuser/ns-winuser-wndclassexw.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassexw.md
@@ -73,7 +73,7 @@ The size, in bytes, of this structure. Set this member to <code>sizeof(WNDCLASSE
 
 Type: <b>UINT</b>
 
-The class style(s). This member can be any combination of the <a href="/windows/desktop/winmsg/about-window-classes">Class Styles</a>.
+The class style(s). This member can be any combination of the <a href="/windows/win32/winmsg/window-class-styles">Class Styles</a>.
 
 ### -field lpfnWndProc
 


### PR DESCRIPTION
The description of the style field implies that the link will take you to the page which has a list of the Window Class Styles. However, currently, it does not. Instead, it sends you to a general page about window classes (https://learn.microsoft.com/en-us/windows/win32/winmsg/about-window-classes). This can be very confusing for someone who is new to Win32 and was expecting a list of the styles. This pull request should fix that issue and thus make it easier to use this page.