### PR TITLE
GetCommandLineW: Replace "previous-versions" link

### DIFF
--- a/sdk-api-src/content/shellapi/nf-shellapi-commandlinetoargvw.md
+++ b/sdk-api-src/content/shellapi/nf-shellapi-commandlinetoargvw.md
@@ -86,7 +86,7 @@ The address returned by <b>CommandLineToArgvW</b> is the address of the first el
 
 <b>CommandLineToArgvW</b> allocates a block of contiguous memory for pointers to the argument strings, and for the argument strings themselves; the calling application must free the memory used by the argument list when it is no longer needed. To free the memory, use a single call to the <a href="/windows/desktop/api/winbase/nf-winbase-localfree">LocalFree</a> function.
 
-For more information about the <i>argv</i> and <i>argc</i> argument convention, see <a href="/previous-versions/88w63h9k(v=vs.85)">Argument Definitions</a> and <a href="/previous-versions/17w5ykft(v=vs.85)">Parsing C++ Command-Line Arguments</a>.
+For more information about the <i>argv</i> and <i>argc</i> argument convention, see <a href="/previous-versions/88w63h9k(v=vs.85)">Argument Definitions</a> and <a href="/cpp/c-language/parsing-c-command-line-arguments">Parsing C Command-Line Arguments</a>.
 
 The <a href="/windows/desktop/api/processenv/nf-processenv-getcommandlinew">GetCommandLineW</a> function can be used to get a command line string that is suitable for use as the <i>lpCmdLine</i> parameter.
 


### PR DESCRIPTION
Replace old "previous-versions" link (MSDN library) with a link to the current documentation.

I found these two viable pages:
- for C: https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170
- for C++: https://learn.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?view=msvc-170#parsing-c-command-line-arguments

I chose the first link (for C), because the URL has no fragment identifier (introduced by a hash (#), https://en.wikipedia.org/wiki/URI_fragment).

What do you think is the better link/page?