### PR TITLE
Update ni-winioctl-fsctl_set_reparse_point.md

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_reparse_point.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_reparse_point.md
@@ -94,6 +94,8 @@ For the implications of overlapped I/O on this operation, see the Remarks sectio
 
 Note that the time stamps may not be updated correctly for a remote file. To ensure consistent results, use unbuffered I/O.
 
+The calling process must have the SE_CREATE_SYMBOLIC_LINK_NAME privilege. For more information, see [Running with Special Privileges](/windows/desktop/SecBP/running-with-special-privileges). 
+
 In Windows 8 and Windows Server 2012, this code is supported by the following technologies.
 
 Technology | Supported


### PR DESCRIPTION
There was no mention of the special privilege that is required to call this FSCTL