### PR TITLE
Update nf-wingdi-getdevicecaps.md

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-getdevicecaps.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-getdevicecaps.md
@@ -241,7 +241,7 @@ Number of device-specific fonts.
 </dl>
 </td>
 <td width="60%">
-Number of entries in the device's color table, if the device has a color depth of no more than 8 bits per pixel. For devices with greater color depths, 1 is returned.
+Number of entries in the device's color table, if the device has a color depth of no more than 8 bits per pixel. For devices with greater color depths, -1 is returned.
 
 </td>
 </tr>


### PR DESCRIPTION
Missing minus sign. Running `GetDeviceCaps(hdc, NUMCOLORS)` on my system returns `-1` because it's got more than 256 colors, not 1 as stated in the docs.