### PR TITLE
sspi: Fix InitializeSecurityContext SSP-specific links

### DIFF
--- a/sdk-api-src/content/sspi/nf-sspi-initializesecuritycontexta.md
+++ b/sdk-api-src/content/sspi/nf-sspi-initializesecuritycontexta.md
@@ -65,31 +65,31 @@ For information about using this function with a specific <a href="/windows/desk
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (CredSSP)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--credssp">InitializeSecurityContext (CredSSP)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Credential Security Support Provider (CredSSP).</td>
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (Digest)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--digest">InitializeSecurityContext (Digest)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Digest security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (Kerberos)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--kerberos">InitializeSecurityContext (Kerberos)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Kerberos security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/previous-versions/windows/desktop/legacy/aa375509(v=vs.85)">InitializeSecurityContext (Negotiate)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--negotiate">InitializeSecurityContext (Negotiate)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Negotiate security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/previous-versions/windows/desktop/legacy/aa375512(v=vs.85)">InitializeSecurityContext (NTLM)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--ntlm">InitializeSecurityContext (NTLM)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the NTLM security package.</td>
 </tr>

--- a/sdk-api-src/content/sspi/nf-sspi-initializesecuritycontextw.md
+++ b/sdk-api-src/content/sspi/nf-sspi-initializesecuritycontextw.md
@@ -65,37 +65,37 @@ For information about using this function with a specific <a href="/windows/desk
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (CredSSP)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--credssp">InitializeSecurityContext (CredSSP)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Credential Security Support Provider (CredSSP).</td>
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (Digest)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--digest">InitializeSecurityContext (Digest)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Digest security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/sspi/nf-sspi-initializesecuritycontexta">InitializeSecurityContext (Kerberos)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--kerberos">InitializeSecurityContext (Kerberos)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Kerberos security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/previous-versions/windows/desktop/legacy/aa375509(v=vs.85)">InitializeSecurityContext (Negotiate)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--negotiate">InitializeSecurityContext (Negotiate)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Negotiate security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/previous-versions/windows/desktop/legacy/aa375512(v=vs.85)">InitializeSecurityContext (NTLM)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--ntlm">InitializeSecurityContext (NTLM)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the NTLM security package.</td>
 </tr>
 <tr>
 <td>
-<a href="/windows/desktop/api/rrascfg/nn-rrascfg-ieapproviderconfig">InitializeSecurityContext (Schannel)</a>
+<a href="/windows/win32/secauthn/initializesecuritycontext--schannel">InitializeSecurityContext (Schannel)</a>
 </td>
 <td>Initiates the client side, outbound security context from a credential handle by using the Schannel security package.</td>
 </tr>


### PR DESCRIPTION
Most of the links to the specific InitializeSecurityContext provider pages (eg: Digest, NTLM, etc) appear to be incorrect. AFAICT pages for the specific providers do not actually exist in sspi doc but do exist in secauthn doc, so I linked to those pages instead.

For example:

InitializeSecurityContext (Digest):
/windows/win32/secauthn/initializesecuritycontext--digest

Ref: ef856c4f

Closes #xxxx

---

Also: IMO Microsoft should add back the github icon to the bottom of the page so that developers know where the documentation source is located, and that way they can submit suggestions in PR (or Issues, if you enable them which I think is also a good idea). I have submitted here once before and almost forgot this was possible, then I remembered there used to be an icon at the bottom of the documentation that led to a github repo, so then I had to comb through my forks to see what repo it was I had submitted at.

/cc @mattdurak 