### PR TITLE
Update ns-d3d12-d3d12_rasterizer_desc.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_rasterizer_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_rasterizer_desc.md
@@ -110,7 +110,7 @@ Specifies whether to enable line antialiasing; only applies if doing line drawin
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">UINT</a></b>
 
-The sample count that is forced while UAV rendering or rasterizing. Valid values are 0, 1, 2, 4, 8, and optionally 16. 0 indicates that the sample count is not forced.
+The sample count that is forced while UAV rendering or rasterizing. Valid values are 0, 1, 4, 8, and optionally 16. 0 indicates that the sample count is not forced.
 
 <div class="alert"><b>Note</b>  If you want to render with <b>ForcedSampleCount</b> set to 1 or greater, you must follow these guidelines:
 


### PR DESCRIPTION
Mismatch with spec:  See here https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#3.5.6.1%20Forcing%20Rasterizer%20Sample%20Count

ForcedSampleCount doesn't support 2