### PR TITLE
Clarify that handles should be valid (non-null)

### DIFF
--- a/sdk-api-src/content/mscat/nf-mscat-cryptcatadminreleasecatalogcontext.md
+++ b/sdk-api-src/content/mscat/nf-mscat-cryptcatadminreleasecatalogcontext.md
@@ -58,11 +58,11 @@ The <b>CryptCATAdminReleaseCatalogContext</b> function releases a handle to a ca
 
 ### -param hCatAdmin [in]
 
-Handle previously assigned by the  <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminacquirecontext">CryptCATAdminAcquireContext</a> function.
+Valid handle previously assigned by the  <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminacquirecontext">CryptCATAdminAcquireContext</a> function.
 
 ### -param hCatInfo [in]
 
-Handle previously assigned by the <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminaddcatalog">CryptCATAdminAddCatalog</a> function or the <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminenumcatalogfromhash">CryptCATAdminEnumCatalogFromHash</a> function.
+Valid handle previously assigned by the <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminaddcatalog">CryptCATAdminAddCatalog</a> function or the <a href="/windows/desktop/api/mscat/nf-mscat-cryptcatadminenumcatalogfromhash">CryptCATAdminEnumCatalogFromHash</a> function.
 
 ### -param dwFlags [in]
 


### PR DESCRIPTION
This API will return FALSE, set last error code and internally log the error if either of the handles passed are null.  This documentation should explicitly call out that asking the API to release a null handle is considered an error (many APIs will accept this as a non-error condition). CryptCATAdminEnumCatalogFromHash will assign a null value to the handle when the enumeration ends and in this case a CryptCATAdminReleaseCatalogContext is not just redundant but actually considered an error, which is not completely clear the way the documentation is currently written and a naive implementation (eg scope guard that ensures CryptCATAdminReleaseCatalogContext is always called and ignores the return value) will potentially be silently triggering errors.