### PR TITLE
Context shouldn't be a code pointer on Arm32

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-initonceexecuteonce.md
@@ -73,7 +73,7 @@ A parameter to be passed to the callback function.
 
 ### -param Context [in, out, optional]
 
-A parameter that receives data stored with the one-time initialization structure upon success. The low-order <b>INIT_ONCE_CTX_RESERVED_BITS</b> bits of the data are always zero.
+A parameter that receives data stored with the one-time initialization structure upon success. The low-order <b>INIT_ONCE_CTX_RESERVED_BITS</b> bits of the data are always zero. If <i>Context</i> points to a data structure, the data structure must be <b>DWORD</b>-aligned. <i>Context</i> must not be a code pointer on Arm32, because Arm32 code pointers always have the least significant bit set, see the <a href="/cpp/build/overview-of-arm-abi-conventions?view=msvc-170#instruction-set">Arm32 ABI</a> for details.
 
 ## -returns
 


### PR DESCRIPTION
Code pointers on Arm32 Windows always have the low bit set, which means that they cannot be set to the Context parameter for the call back. Plus, Context should be DWORD-aligned.