### PR TITLE
Add PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
@@ -428,7 +428,7 @@ The processor implements the XSAVE and XRSTOR instructions.
 </dl>
 </td>
 <td width="60%">
-This ARM processor implements the ARM v8 instructions set.
+This Arm processor implements the Arm v8 instructions set.
 </td>
 </tr>
 
@@ -439,7 +439,7 @@ This ARM processor implements the ARM v8 instructions set.
 </dl>
 </td>
 <td width="60%">
-This ARM processor implements the ARM v8 extra cryptographic instructions (i.e. AES, SHA1 and SHA2).
+This Arm processor implements the Arm v8 extra cryptographic instructions (i.e. AES, SHA1 and SHA2).
 </td>
 </tr>
 
@@ -450,7 +450,7 @@ This ARM processor implements the ARM v8 extra cryptographic instructions (i.e. 
 </dl>
 </td>
 <td width="60%">
-This ARM processor implements the ARM v8 extra CRC32 instructions.
+This Arm processor implements the Arm v8 extra CRC32 instructions.
 </td>
 </tr>
 
@@ -461,10 +461,21 @@ This ARM processor implements the ARM v8 extra CRC32 instructions.
 </dl>
 </td>
 <td width="60%">
-This ARM processor implements the ARM v8.1 atomic instructions (e.g. CAS, SWP).
+This Arm processor implements the Arm v8.1 atomic instructions (e.g. CAS, SWP).
 </td>
 </tr>
 
+ <tr>
+<td width="40%"><a id="PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE"></a><a id="pf_arm_v83_lrcpc_instructions_available"></a><dl>
+<dt><b>PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE</b></dt>
+<dt>34</dt>
+</dl>
+</td>
+<td width="60%">
+This Arm processor implements the Arm v8.3 LRCPC instructions (e.g. ldapr). Note that certain Arm v8.2 CPUs may optionally support the LRCPC instructions.
+</td>
+</tr>
+ 
 </table>
 
 ## -returns


### PR DESCRIPTION
The Win11 22H2 SDK starts supporting querying the armv8.2 LRCPC capabilities on Arm64 processors, so update the documentation of IsProcessorFeaturePresent accordingly. In addition, change the casing of "ARM" to "Arm" when referring to the companies' CPUs per Arm's request.