### PR TITLE
ConnectionTimeout and TransactionTimeout are in milliseconds

### DIFF
--- a/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-get_connectiontimeout.md
+++ b/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-get_connectiontimeout.md
@@ -58,6 +58,12 @@ This property is read/write.
 
 ## -parameters
 
+### -param timeout [out]
+
+Type: <b>DWORD</b>
+
+The duration of the time-out period, in milliseconds.
+
 ## -remarks
 
 The default connection timeout value is two seconds. A responsive UI Automation provider can typically return an automation element to a client in a short length of time.

--- a/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-get_transactiontimeout.md
+++ b/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-get_transactiontimeout.md
@@ -58,6 +58,12 @@ This property is read/write.
 
 ## -parameters
 
+### -param timeout [out]
+
+Type: <b>DWORD</b>
+
+The duration of the time-out period, in milliseconds.
+
 ## -remarks
 
 The default transaction timeout value is 20 seconds.  Because some operations require the provider to process hundreds of elements, the provider might need a significant amount of time to return information to the client.

--- a/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-put_connectiontimeout.md
+++ b/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-put_connectiontimeout.md
@@ -58,6 +58,12 @@ This property is read/write.
 
 ## -parameters
 
+### -param timeout [in]
+
+Type: <b>DWORD</b>
+
+The duration of the time-out period, in milliseconds.
+
 ## -remarks
 
 The default connection timeout value is two seconds. A responsive UI Automation provider can typically return an automation element to a client in a short length of time.

--- a/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-put_transactiontimeout.md
+++ b/sdk-api-src/content/uiautomationclient/nf-uiautomationclient-iuiautomation2-put_transactiontimeout.md
@@ -58,6 +58,12 @@ This property is read/write.
 
 ## -parameters
 
+### -param timeout [in]
+
+Type: <b>DWORD</b>
+
+The duration of the time-out period, in milliseconds.
+
 ## -remarks
 
 The default transaction timeout value is 20 seconds.  Because some operations require the provider to process hundreds of elements, the provider might need a significant amount of time to return information to the client.


### PR DESCRIPTION
IUIAutomation2.ConnectionTimeout and IUIAutomation2.TransactionTimeout values are in milliseconds. This is mentioned in a code comment in UIAutomationClient.idl, but was not mentioned on the docs page. This change documents the parameters to add this information.