### PR TITLE
Update ResourceMinLODClamp field description in all SRV helped structs

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex1d_array_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex1d_array_srv.md
@@ -74,7 +74,11 @@ Number of textures in the array.
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex1d_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex1d_srv.md
@@ -66,7 +66,11 @@ Set to -1 to indicate all the mipmap levels from <b>MostDetailedMip</b> on down 
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex2d_array_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex2d_array_srv.md
@@ -79,7 +79,11 @@ The index (plane slice number) of the plane to use in an array of textures.
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex2d_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex2d_srv.md
@@ -67,6 +67,10 @@ The index (plane slice number) of the plane to use in the texture.
 
 Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
 
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
+
 ## -remarks
 
 This structure is one member of a shader-resource-view description, <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_shader_resource_view_desc">D3D12_SHADER_RESOURCE_VIEW_DESC</a>.

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex3d_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_tex3d_srv.md
@@ -66,7 +66,11 @@ Set to -1 to indicate all the mipmap levels from <b>MostDetailedMip</b> on down 
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_texcube_array_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_texcube_array_srv.md
@@ -74,7 +74,11 @@ Number of cube textures in the array.
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_texcube_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_texcube_srv.md
@@ -66,7 +66,11 @@ Set to -1 to indicate all the mipmap levels from <b>MostDetailedMip</b> on down 
 
 ### -field ResourceMinLODClamp
 
-A value to clamp sample LOD values to. For example, if you specify 2.0f for the clamp value, you ensure that no individual sample accesses a mip level less than 2.0f.
+Specifies the minimum mipmap level that you can access. Specifying 0.0f means that you can access all of the mipmap levels. Specifying 3.0f means that you can access mipmap levels from 3.0f to `MipCount - 1`.
+
+Better not to use `MostDetailedMip` and `ResourceMinLODClamp` at the same time. One of this field should have a default value i.e. 0. Since `MipLevels` is interpreted differently in conjunction with different fields:
+-   For `MostDetailedMip` mips will be in range: \[`MostDetailedMip`, `MostDetailedMip` + `MipLevels` - 1]
+-   For `ResourceMinLODClamp` mips will be in range: \[`ResourceMinLODClamp`, `MipLevels` - 1]
 
 ## -remarks
 


### PR DESCRIPTION
Updated `ResourceMinLODClamp` field description in all SRV helper structs. Also added remark related to usage `MipLevels` field with  `MostDetailedMip` and `ResourceMinLODClamp`.