### PR TITLE
HttpAddUrlToUrlGroup requires a port number greater than 1024 unless the caller is running as an administrator.

### DIFF
--- a/sdk-api-src/content/http/nf-http-httpaddurltourlgroup.md
+++ b/sdk-api-src/content/http/nf-http-httpaddurltourlgroup.md
@@ -62,7 +62,7 @@ The group ID for the URL group to which requests for the specified URL are route
 
 ### -param pFullyQualifiedUrl [in]
 
-A pointer to a Unicode string that contains a properly formed <a href="/windows/desktop/Http/urlprefix-strings">UrlPrefix String</a> that identifies the URL to be registered.
+A pointer to a Unicode string that contains a properly formed <a href="/windows/desktop/Http/urlprefix-strings">UrlPrefix String</a> that identifies the URL to be registered. If you are not running as an administrator, specify a port number greater than 1024, otherwise you may get an ERROR_ACCESS_DENIED error.
 
 ### -param UrlContext [in, optional]
 


### PR DESCRIPTION
When I call HttpAddUrlToUrlGroup as a member of the built-in Users group account to catch "http://localhost:80/",  I get an ERROR_ACCESS_DENIED error, which is not documented.  Unlike Linux, under Windows, User group members can listen on 80, 443 or other low port without administrator privileges.  I have also ruled out the effect from the Windows firewall, and when I turn off the firewall via firewall.cpl,  HttpAddUrlToUrlGroup still returns ERROR_ACCESS_DENIED for the Users group account.