### PR TITLE
Update nf-wingdi-createbitmap.md

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
@@ -50,9 +50,6 @@ api_name:
  - CreateBitmap
 ---
 
-# CreateBitmap function
-
-
 ## -description
 
 The <b>CreateBitmap</b> function creates a bitmap with the specified width, height, and color format (color planes and bits-per-pixel).
@@ -77,18 +74,13 @@ The number of bits required to identify the color of a single pixel.
 
 ### -param lpBits [in]
 
-A pointer to an array of color data used to set the colors in a rectangle of pixels. 
-
-Each scan line in the rectangle must be <b>DWORD</b> aligned (scan lines that are not <b>DWORD</b> aligned must be padded with zeros). 
- 
-You can use the following formula to calculate the stride (byte width of a single row of pixels) and color data array size: 
+A pointer to an array of color data used to set the colors in a rectangle of pixels. Each scan line in the rectangle must be word aligned (scan lines that are not word aligned must be padded with zeros). The buffer size expected, *cj*, can be calculated using the formula:
 
 ```cpp
-UINT stride = ((((nWidth * nBitCount) + 31) & ~31) >> 3);
-UINT size = stride * nHeight * nPlanes;
+cj = (((nWidth * nPlanes * nBitCount + 15) >> 4) << 1) * nHeight;
 ```
 
-If this parameter is <b>NULL</b>, the contents of the new bitmap is undefined.
+If this parameter is <b>NULL</b>, then the contents of the new bitmap are undefined.
 
 ## -returns
 

--- a/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
@@ -77,7 +77,18 @@ The number of bits required to identify the color of a single pixel.
 
 ### -param lpBits [in]
 
-A pointer to an array of color data used to set the colors in a rectangle of pixels. Each scan line in the rectangle must be word aligned (scan lines that are not word aligned must be padded with zeros). If this parameter is <b>NULL</b>, the contents of the new bitmap is undefined.
+A pointer to an array of color data used to set the colors in a rectangle of pixels. 
+
+Each scan line in the rectangle must be <b>DWORD</b> aligned (scan lines that are not <b>DWORD</b> aligned must be padded with zeros). 
+ 
+You can use the following formula to calculate the stride (byte width of a single row of pixels) and color data array size: 
+
+```cpp
+stride = ((((nWidth * nBitCount) + 31) & ~31) >> 3);
+size = stride * nHeight * nPlanes;
+```
+
+If this parameter is <b>NULL</b>, the contents of the new bitmap is undefined.
 
 ## -returns
 

--- a/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-createbitmap.md
@@ -84,8 +84,8 @@ Each scan line in the rectangle must be <b>DWORD</b> aligned (scan lines that ar
 You can use the following formula to calculate the stride (byte width of a single row of pixels) and color data array size: 
 
 ```cpp
-stride = ((((nWidth * nBitCount) + 31) & ~31) >> 3);
-size = stride * nHeight * nPlanes;
+UINT stride = ((((nWidth * nBitCount) + 31) & ~31) >> 3);
+UINT size = stride * nHeight * nPlanes;
 ```
 
 If this parameter is <b>NULL</b>, the contents of the new bitmap is undefined.


### PR DESCRIPTION
Fix long standing lpBits stride doc issue in CreateBitmap function
Add stride calculation formula from [BITMAPINFOHEADER structure docs](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader#calculating-surface-stride).
Same formula was in old [“DIBs and Their Use” article](https://learn.microsoft.com/previous-versions/ms969901(v=msdn.10)) from 1992.

Looks like **WORD** to **DWORD** alignment requirement was changed somewhere around Windows 3.0 when processor architecture was changed from 16bit to 32bit.