### PR TITLE
Update nn-shobjidl_core-imodalwindow.md

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nn-shobjidl_core-imodalwindow.md
+++ b/sdk-api-src/content/shobjidl_core/nn-shobjidl_core-imodalwindow.md
@@ -1,7 +1,7 @@
 ---
 UID: NN:shobjidl_core.IModalWindow
 title: IModalWindow (shobjidl_core.h)
-description: Exposes a method that represents a modal window. This interface is used in the Windows XP Passport Wizard.
+description: Exposes a method that represents a modal window.
 helpviewer_keywords: ["IModalWindow","IModalWindow interface [Windows Shell]","IModalWindow interface [Windows Shell]","described","_win32_IModalWindow","shell.IModalWindow","shobjidl_core/IModalWindow"]
 old-location: shell\IModalWindow.htm
 tech.root: shell
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Exposes a method that represents a modal window. This interface is used in the Windows XP Passport Wizard.
+Exposes a method that represents a modal window.
 
 ## -inheritance
 


### PR DESCRIPTION
The Windows XP Passport Wizard is about the least interesting thing about this dialog. It's used broadly for many other purposes.