### PR TITLE
Update ns-d3d12-d3d12_buffer_rtv.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_rtv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_rtv.md
@@ -56,7 +56,7 @@ Describes the elements in a buffer resource to use in a render-target view.
 
 ### -field FirstElement
 
-Number of bytes between the beginning of the buffer and the first element to access.
+Number of elements between the beginning of the buffer and the first element to access.
 
 ### -field NumElements
 


### PR DESCRIPTION
local testing demonstrates that `FirstElement` refers to the number of elements, not the number of bytes.