### PR TITLE
Update IMFTransform::ProcessMessage to clarify calling order of various messages

### DIFF
--- a/sdk-api-src/content/mftransform/ne-mftransform-mft_message_type.md
+++ b/sdk-api-src/content/mftransform/ne-mftransform-mft_message_type.md
@@ -59,19 +59,21 @@ Defines messages for a Media Foundation transform (MFT). To send a message to an
 ### -field MFT_MESSAGE_COMMAND_FLUSH:0
 
 Requests the MFT to flush all stored data. 
+Should only be called after streaming has started using the MFT_MESSAGE_NOTIFY_BEGIN_STREAMING message.
 
 See <a href="/windows/desktop/medfound/mft-message-command-flush">MFT_MESSAGE_COMMAND_FLUSH</a>.
 
 ### -field MFT_MESSAGE_COMMAND_DRAIN:0x1
 
 Requests the MFT to drain any stored data.
+Should only be called after streaming has started using the MFT_MESSAGE_NOTIFY_BEGIN_STREAMING message.
 
 See <a href="/windows/desktop/medfound/mft-message-command-drain">MFT_MESSAGE_COMMAND_DRAIN</a>.
 
 ### -field MFT_MESSAGE_SET_D3D_MANAGER:0x2
 
 Sets or clears the <a href="/windows/desktop/medfound/direct3d-device-manager">Direct3D Device Manager</a> for DirectX Video Acceleration (DXVA).
-            
+Must be called before SetInputType or SetOutputType.
             
           
 
@@ -88,7 +90,7 @@ See <a href="/windows/desktop/medfound/mft-message-set-d3d-manager">MFT_MESSAGE_
 ### -field MFT_MESSAGE_NOTIFY_BEGIN_STREAMING:0x10000000
 
 Notifies the MFT that streaming is about to begin.
-            
+Must be called after SetInputType and SetOutputType.
           
 
 See <a href="/windows/desktop/medfound/mft-message-notify-begin-streaming">MFT_MESSAGE_NOTIFY_BEGIN_STREAMING</a>.
@@ -104,7 +106,7 @@ See <a href="/windows/desktop/medfound/mft-message-notify-end-streaming">MFT_MES
 ### -field MFT_MESSAGE_NOTIFY_END_OF_STREAM:0x10000002
 
 Notifies the MFT that an input stream has ended.
-            
+
           
 
 See <a href="/windows/desktop/medfound/mft-message-notify-end-of-stream">MFT_MESSAGE_NOTIFY_END_OF_STREAM</a>.
@@ -112,6 +114,7 @@ See <a href="/windows/desktop/medfound/mft-message-notify-end-of-stream">MFT_MES
 ### -field MFT_MESSAGE_NOTIFY_START_OF_STREAM:0x10000003
 
 Notifies the MFT that the first sample is about to be processed. 
+Must be called after SetInputType and SetOutputType.
 
 See
             

--- a/sdk-api-src/content/mftransform/nf-mftransform-imftransform-processmessage.md
+++ b/sdk-api-src/content/mftransform/nf-mftransform-imftransform-processmessage.md
@@ -113,7 +113,7 @@ The media type is not set on one or more streams.
 
 ## -remarks
 
-Before calling this method, set the media types on all input and output streams.
+Each message type has a different requirement for calling order, see the <a href="/windows/desktop/api/mftransform/ne-mftransform-mft_message_type">MFT_MESSAGE_TYPE</a> enumeration for more details.
       
 
 The MFT might ignore certain message types. If so, the method returns <b>S_OK</b>. An error code indicates that the transform handles this message type but was unable to process the message in this instance.


### PR DESCRIPTION
Removed the remark that implied all message types should be called after media types are set.  This is not true.  The exact calling order depends on which message is being sent.  Each message type has different calling order requirements.   Added information about calling order for the most common messages to the MFT_MESSAGE_TYPE enumeration page.