### PR TITLE
Update nf-d3d12-id3d12device4-createheap1.md

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device4-createheap1.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device4-createheap1.md
@@ -62,6 +62,8 @@ Type: **[ID3D12ProtectedResourceSession](./nn-d3d12-id3d12protectedresourcesessi
 
 An optional pointer to an object that represents a session for content protection. If provided, this session indicates that the heap should be protected. You can obtain an **ID3D12ProtectedResourceSession** by calling [ID3D12Device4::CreateProtectedResourceSession](./nf-d3d12-id3d12device4-createprotectedresourcesession.md).
 
+A heap with a protected session cannot be created with the [D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_flags) flag
+
 ### -param riid [in]
 
 Type: **REFIID**

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device4-createheap1.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device4-createheap1.md
@@ -62,7 +62,7 @@ Type: **[ID3D12ProtectedResourceSession](./nn-d3d12-id3d12protectedresourcesessi
 
 An optional pointer to an object that represents a session for content protection. If provided, this session indicates that the heap should be protected. You can obtain an **ID3D12ProtectedResourceSession** by calling [ID3D12Device4::CreateProtectedResourceSession](./nf-d3d12-id3d12device4-createprotectedresourcesession.md).
 
-A heap with a protected session cannot be created with the [D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_flags) flag
+A heap with a protected session can't be created with the [D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER](/windows/win32/api/d3d12/ne-d3d12-d3d12_heap_flags) flag.
 
 ### -param riid [in]
 


### PR DESCRIPTION
Added note regarding protected session should not be used with D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER flag