### PR TITLE
Update ne-d3d12-d3d12_heap_flags.md

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_heap_flags.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_heap_flags.md
@@ -69,7 +69,7 @@ The heap is allowed to contain swap-chain surfaces.
 
 ### -field D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER:0x20
 
-The heap is allowed to share resources across adapters. Refer to <a href="/windows/desktop/direct3d12/shared-heaps">Shared Heaps</a>.
+The heap is allowed to share resources across adapters. Refer to <a href="/windows/desktop/direct3d12/shared-heaps">Shared Heaps</a>. A protected session cannot be mixed with resources that are shared across adapters.
 
 ### -field D3D12_HEAP_FLAG_DENY_RT_DS_TEXTURES:0x40
 


### PR DESCRIPTION
Updated page to reflect that D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER cannot be used with protected sessions