### PR TITLE
Update ns-schannel-schannel_cred.md

### DIFF
--- a/sdk-api-src/content/schannel/ns-schannel-schannel_cred.md
+++ b/sdk-api-src/content/schannel/ns-schannel-schannel_cred.md
@@ -51,8 +51,7 @@ api_name:
 
 # SCHANNEL_CRED structure
 
-> [!NOTE]
-> The SCHANNEL_CRED structure is deprecated. Client applications should use <a href="../schannel/ns-schannel-sch_credentials.md">SCH_CREDENTIALS</a> instead.
+**NOTE:** The SCHANNEL_CRED structure is deprecated. Client applications should use <a href="../schannel/ns-schannel-sch_credentials.md">SCH_CREDENTIALS</a> instead.
 
 
 ## -description

--- a/sdk-api-src/content/schannel/ns-schannel-schannel_cred.md
+++ b/sdk-api-src/content/schannel/ns-schannel-schannel_cred.md
@@ -49,12 +49,10 @@ api_name:
  - SCHANNEL_CRED
 ---
 
-# SCHANNEL_CRED structure
-
-**NOTE:** The SCHANNEL_CRED structure is deprecated. Client applications should use <a href="../schannel/ns-schannel-sch_credentials.md">SCH_CREDENTIALS</a> instead.
-
-
 ## -description
+
+> [!NOTE]
+> The **SCHANNEL_CRED** structure is deprecated. You should use [SCH_CREDENTIALS](../schannel/ns-schannel-sch_credentials.md) instead.
 
 The <b>SCHANNEL_CRED</b> structure contains the data for an Schannel credential.
 


### PR DESCRIPTION
SCHANNEL_CRED should be displayed as deprecated and replaced with SCH_CREDENTIALS in a banner at the top of this page. There was a note added but it did not display on the public site. Please advise if there is a better format.