### PR TITLE
Update GetThreadContext.md: hThread parameter description: "WOW64" to "Windows XP or Windows Server 2003"

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
@@ -67,7 +67,7 @@ A 64-bit application can retrieve the context of a WOW64 thread using the [Wow64
 A handle to the thread whose context is to be retrieved. The handle must have **THREAD_GET_CONTEXT** access to the thread. For more information, see [Thread Security and Access Rights](/windows/desktop/ProcThread/thread-security-and-access-rights).
       
 
-**WOW64:** The handle must also have **THREAD_QUERY_INFORMATION** access.
+**Windows XP or Windows Server 2003:** The handle must also have **THREAD_QUERY_INFORMATION** access.
 
 ### -param lpContext [in, out]
 


### PR DESCRIPTION
Change: 
  **WOW64:** The handle must also have **THREAD_QUERY_INFORMATION** access.
to
  **Windows XP or Windows Server 2003:** The handle must also have **THREAD_QUERY_INFORMATION** access.