### PR TITLE
Update nf-winuser-tounicodeex.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -66,19 +66,19 @@ The virtual-key code to be translated. See <a href="/windows/desktop/inputdev/vi
 
 Type: <b>UINT</b>
 
-The hardware scan code of the key to be translated. The high-order bit of this value is set if the key is up.
+The hardware <a href="/windows/win32/inputdev/about-keyboard-input#scan-codes">scan code</a> of the key to be translated. The high-order bit of this value is set if the key is up.
 
 ### -param lpKeyState [in, optional]
 
 Type: <b>const BYTE*</b>
 
-A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down.
+A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
 
 ### -param pwszBuff [out]
 
 Type: <b>LPWSTR</b>
 
-The buffer that receives the translated Unicode character or characters. However, this buffer may be returned without being null-terminated even though the variable name suggests that it is null-terminated.
+The buffer that receives the translated character or characters as array of UTF-16 code units. This buffer may be returned without being null-terminated even though the variable name suggests that it is null-terminated. You can use the return value of this method to determine how many characters were written.
 
 ### -param cchBuff [in]
 
@@ -114,11 +114,11 @@ The function returns one of the following values.
 <tr>
 <td width="40%">
 <dl>
-<dt>-1</dt>
+<dt><i>value</i> < 0 </dt>
 </dl>
 </td>
 <td width="60%">
-The specified virtual key is a dead-key character (accent or diacritic). This value is returned regardless of the keyboard layout, even if several characters have been typed and are stored in the keyboard state. If possible, even with Unicode keyboard layouts, the function has written a spacing version of the dead-key character to the buffer specified by <i>pwszBuff</i>. For example, the function writes the character SPACING ACUTE (0x00B4), rather than the character NON_SPACING ACUTE (0x0301).
+The specified virtual key is a <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> character (accent or diacritic). This value is returned regardless of the keyboard layout, even if several characters have been typed and are stored in the keyboard state. If possible, even with Unicode keyboard layouts, the function has written a spacing version of the dead-key character to the buffer specified by <i>pwszBuff</i>. For example, the function writes the character ACUTE ACCENT (U+00B4), rather than the character COMBINING ACUTE ACCENT (U+0301).
 
 </td>
 </tr>
@@ -136,22 +136,11 @@ The specified virtual key has no translation for the current state of the keyboa
 <tr>
 <td width="40%">
 <dl>
-<dt>1</dt>
+<dt><i>value</i> > 0 </dt>
 </dl>
 </td>
 <td width="60%">
-One character was written to the buffer specified by <i>pwszBuff</i>.
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt>2 ≤ <i>value</i> </dt>
-</dl>
-</td>
-<td width="60%">
-Two or more characters were written to the buffer specified by <i>pwszBuff</i>. The most common cause for this is that a dead-key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character. However, the buffer may contain more characters than the return value specifies. When this happens, any extra characters are invalid and should be ignored.
+One or more UTF-16 code units were written to the buffer specified by <i>pwszBuff</i>. Returned <i>pwszBuff</i> may contain more characters than the return value specifies. When this happens, any extra characters are invalid and should be ignored.
 
 </td>
 </tr>
@@ -159,9 +148,11 @@ Two or more characters were written to the buffer specified by <i>pwszBuff</i>. 
 
 ## -remarks
 
-The parameters supplied to the <b>ToUnicode</b> function might not be sufficient to translate the virtual-key code because a previous dead key is stored in the keyboard layout.
+Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
-Typically, <b>ToUnicode</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release.
+The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
+
+Typically, <b>ToUnicode</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release (for example for ALT+numpad key entry).
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -72,7 +72,9 @@ The hardware <a href="/windows/win32/inputdev/about-keyboard-input#scan-codes">s
 
 Type: <b>const BYTE*</b>
 
-A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
+A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key.
+
+If the high-order bit of a byte is set, the key is down. The low bit, if set, indicates that the key is toggled on. In this function, only the toggle bit of the CAPS LOCK key is relevant. The toggle state of the NUM LOCK and SCROLL LOCK keys is ignored. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
 
 ### -param pwszBuff [out]
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -150,7 +150,7 @@ One or more UTF-16 code units were written to the buffer specified by <i>pwszBuf
 
 ## -remarks
 
-Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
+Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units (or surrogate pairs) in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
 The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -52,7 +52,6 @@ api_name:
 
 Translates the specified virtual-key code and keyboard state to the corresponding Unicode character or characters.
 
-To specify a handle to the keyboard layout to use to translate the specified code, use the <a href="/windows/desktop/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> function.
 
 ## -parameters
 
@@ -150,7 +149,9 @@ One or more UTF-16 code units were written to the buffer specified by <i>pwszBuf
 
 ## -remarks
 
-Some keyboard layouts may return several characters and/or supplementary characters as <a href="/windows/win32/intl/surrogates-and-supplementary-characters">surrogate pairs</a> in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
+To specify a handle to the keyboard layout to use to translate the specified code, use the <a href="/windows/desktop/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> function.
+
+Some keyboard layouts may return several characters and/or supplementary characters as <a href="/windows/win32/intl/surrogates-and-supplementary-characters">surrogate pairs</a> in <i>pwszBuff</i>. If a dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
 The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -150,7 +150,7 @@ One or more UTF-16 code units were written to the buffer specified by <i>pwszBuf
 
 ## -remarks
 
-Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units (or surrogate pairs) in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
+Some keyboard layouts may return several characters and/or supplementary characters as <a href="/windows/win32/intl/surrogates-and-supplementary-characters">surrogate pairs</a> in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
 The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
@@ -164,7 +164,7 @@ One or more UTF-16 code units were written to the buffer specified by <i>pwszBuf
 
 The input locale identifier is a broader concept than a keyboard layout, since it can also encompass a speech-to-text converter, an Input Method Editor (IME), or any other form of input.
 
-Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
+Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units (or surrogate pairs) in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
 The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
@@ -78,7 +78,9 @@ The hardware <a href="/windows/win32/inputdev/about-keyboard-input#scan-codes">s
 
 Type: <b>const BYTE*</b>
 
-A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
+A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. 
+
+If the high-order bit of a byte is set, the key is down. The low bit, if set, indicates that the key is toggled on. In this function, only the toggle bit of the CAPS LOCK key is relevant. The toggle state of the NUM LOCK and SCROLL LOCK keys is ignored. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
 
 ### -param pwszBuff [out]
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
@@ -164,7 +164,7 @@ One or more UTF-16 code units were written to the buffer specified by <i>pwszBuf
 
 The input locale identifier is a broader concept than a keyboard layout, since it can also encompass a speech-to-text converter, an Input Method Editor (IME), or any other form of input.
 
-Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units (or surrogate pairs) in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
+Some keyboard layouts may return several characters and/or supplementary characters as <a href="/windows/win32/intl/surrogates-and-supplementary-characters">surrogate pairs</a> in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
 The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
@@ -72,19 +72,19 @@ The virtual-key code to be translated. See <a href="/windows/desktop/inputdev/vi
 
 Type: <b>UINT</b>
 
-The hardware scan code of the key to be translated. The high-order bit of this value is set if the key is up.
+The hardware <a href="/windows/win32/inputdev/about-keyboard-input#scan-codes">scan code</a> of the key to be translated. The high-order bit of this value is set if the key is up.
 
 ### -param lpKeyState [in]
 
 Type: <b>const BYTE*</b>
 
-A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down.
+A pointer to a 256-byte array that contains the current keyboard state. Each element (byte) in the array contains the state of one key. If the high-order bit of a byte is set, the key is down. See <a href="/windows/win32/api/winuser/nf-winuser-getkeyboardstate">GetKeyboardState</a> for more info.
 
 ### -param pwszBuff [out]
 
 Type: <b>LPWSTR</b>
 
-The buffer that receives the translated Unicode character or characters. However, this buffer may be returned without being null-terminated even though the variable name suggests that it is null-terminated.
+The buffer that receives the translated character or characters as array of UTF-16 code units. This buffer may be returned without being null-terminated even though the variable name suggests that it is null-terminated. You can use the return value of this method to determine how many characters were written.
 
 ### -param cchBuff [in]
 
@@ -126,11 +126,11 @@ The function returns one of the following values.
 <tr>
 <td width="40%">
 <dl>
-<dt>-1</dt>
+<dt><i>value</i> < 0 </dt>
 </dl>
 </td>
 <td width="60%">
-The specified virtual key is a dead-key character (accent or diacritic). This value is returned regardless of the keyboard layout, even if several characters have been typed and are stored in the keyboard state. If possible, even with Unicode keyboard layouts, the function has written a spacing version of the dead-key character to the buffer specified by <i>pwszBuff</i>. For example, the function writes the character SPACING ACUTE (0x00B4), rather than the character NON_SPACING ACUTE (0x0301).
+The specified virtual key is a <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> character (accent or diacritic). This value is returned regardless of the keyboard layout, even if several characters have been typed and are stored in the keyboard state. If possible, even with Unicode keyboard layouts, the function has written a spacing version of the dead-key character to the buffer specified by <i>pwszBuff</i>. For example, the function writes the character ACUTE ACCENT (U+00B4), rather than the character COMBINING ACUTE ACCENT (U+0301).
 
 </td>
 </tr>
@@ -148,22 +148,11 @@ The specified virtual key has no translation for the current state of the keyboa
 <tr>
 <td width="40%">
 <dl>
-<dt>1</dt>
+<dt><i>value</i> > 0 </dt>
 </dl>
 </td>
 <td width="60%">
-One character was written to the buffer specified by <i>pwszBuff</i>.
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt>2 ≤ <i>value</i> </dt>
-</dl>
-</td>
-<td width="60%">
-Two or more characters were written to the buffer specified by <i>pwszBuff</i>. The most common cause for this is that a dead-key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character. However, the buffer may contain more characters than the return value specifies. When this happens, any extra characters are invalid and should be ignored.
+One or more UTF-16 code units were written to the buffer specified by <i>pwszBuff</i>. Returned <i>pwszBuff</i> may contain more characters than the return value specifies. When this happens, any extra characters are invalid and should be ignored.
 
 </td>
 </tr>
@@ -173,9 +162,11 @@ Two or more characters were written to the buffer specified by <i>pwszBuff</i>. 
 
 The input locale identifier is a broader concept than a keyboard layout, since it can also encompass a speech-to-text converter, an Input Method Editor (IME), or any other form of input.
 
-The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous dead key is stored in the keyboard layout.
+Some keyboard layouts may return ligatures or characters outside Unicode Basic Multilingual Plane - in this case they are encoded as several UTF-16 code units in <i>pwszBuff</i>. If dead key character (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character then the previous entered dead character can be combined with the current character.
 
-Typically, <b>ToUnicodeEx</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release.
+The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficient to translate the virtual-key code because a previous <a href="/windows/win32/inputdev/about-keyboard-input#dead-character-messages">dead key</a> is stored in the keyboard layout.
+
+Typically, <b>ToUnicodeEx</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release (for example for ALT+numpad key entry).
 
 As <b>ToUnicodeEx</b> translates the virtual-key code, it also changes the state of the kernel-mode keyboard buffer. This state-change affects dead keys, ligatures, alt+numpad key entry, and so on. It might also cause undesired side-effects if used in conjunction with <a href="/windows/desktop/api/winuser/nf-winuser-translatemessage">TranslateMessage</a> (which also changes the state of the kernel-mode keyboard buffer).
 


### PR DESCRIPTION
Some corrections:
- Add links to info about scan codes and dead keys.
- Add info about CAPS LOCK/NUM LOCK/SCOLL LOCK toggle keys in **lpKeyState**. Add link to GetKeyboardState method.
- Use proper names for ACUTE ACCENT (U+00B4) and COMBINING ACUTE ACCENT (U+0301) from [Unicode Character Database NamesList.txt](https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt)
- Mention about UTF-16 encoding (some layouts produce non-BMP characters as UTF-16 surrogate pairs - [Gothic layout](https://kbdlayout.info/kbdgthc) for example)
- ALT+numpad key entry uses 15th bit of wScanCode