### PR TITLE
Fix markdown rendering error for local named pipe syntax.

### DIFF
--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-callnamedpipew.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-callnamedpipew.md
@@ -138,7 +138,7 @@ Calling <b>CallNamedPipe</b> is equivalent to calling the <a href="/windows/desk
 
 <b>CallNamedPipe</b> fails if the pipe is a byte-type pipe.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ### Examples
 

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-connectnamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-connectnamedpipe.md
@@ -120,7 +120,7 @@ If the specified pipe handle is in nonblocking mode,
 
 <div class="alert"><b>Note</b>  Nonblocking mode is supported for compatibility with Microsoft LAN Manager version 2.0, and it should not be used to achieve asynchronous input and output (I/O) with named pipes.</div>
 <div> </div>
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-createnamedpipew.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-createnamedpipew.md
@@ -399,7 +399,7 @@ Whenever a pipe write operation occurs, the system first tries to charge the mem
 
 To free resources used by a named pipe, the application should always close handles when they are no longer needed, which is accomplished either by calling the <a href="/windows/desktop/api/handleapi/nf-handleapi-closehandle">CloseHandle</a> function or when the process associated with the instance handles ends. Note that an instance of a named pipe may have more than one handle associated with it. An instance of a named pipe is always deleted when the last handle to the instance of the named pipe is closed.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ### Examples
 

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-disconnectnamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-disconnectnamedpipe.md
@@ -87,7 +87,7 @@ The server process must call
 <b>DisconnectNamedPipe</b> to disconnect a pipe handle from its previous client before the handle can be connected to another client by using the 
 <a href="/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe">ConnectNamedPipe</a> function.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-getnamedpipeclientcomputernamew.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-getnamedpipeclientcomputernamew.md
@@ -82,7 +82,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-getnamedpipehandlestatew.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-getnamedpipehandlestatew.md
@@ -132,7 +132,7 @@ The <b>GetNamedPipeHandleState</b> function returns successfully even if all of 
 To set the pipe handle state, use the 
 <a href="/windows/desktop/api/namedpipeapi/nf-namedpipeapi-setnamedpipehandlestate">SetNamedPipeHandleState</a> function.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-peeknamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-peeknamedpipe.md
@@ -114,7 +114,7 @@ The
 <div> </div>
 If the specified handle is a named pipe handle in byte-read mode, the function reads all available bytes up to the size specified in <i>nBufferSize</i>. For a named pipe handle in message-read mode, the function reads the next message in the pipe. If the message is larger than <i>nBufferSize</i>, the function returns <b>TRUE</b> after reading the specified number of bytes. In this situation, <i>lpBytesLeftThisMessage</i> will receive the number of bytes remaining in the message.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-setnamedpipehandlestate.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-setnamedpipehandlestate.md
@@ -162,7 +162,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-transactnamedpipe.md
@@ -142,7 +142,7 @@ The function cannot be completed successfully until data is written into the buf
 
 The maximum guaranteed size of a named pipe transaction is 64 kilobytes. In some limited cases, transactions beyond 64 kilobytes are possible, depending on OS versions participating in the transaction and dynamic network conditions. However, there is no guarantee that transactions above 64 kilobytes will succeed. Therefore it's recommended that named pipe transactions be limited to 64 kilobytes of data.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-waitnamedpipew.md
+++ b/sdk-api-src/content/namedpipeapi/nf-namedpipeapi-waitnamedpipew.md
@@ -116,7 +116,7 @@ If the time-out interval expires, the <b>WaitNamedPipe</b> function will fail wi
 
 If the function succeeds, the process should use the <a href="/windows/desktop/api/fileapi/nf-fileapi-createfilea">CreateFile</a> function to open a handle to the named pipe. A return value of <b>TRUE</b> indicates that there is at least one instance of the pipe available. A subsequent <b>CreateFile</b> call to the pipe can fail, because the instance was closed by the server or opened by another client.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ### Examples
 

--- a/sdk-api-src/content/winbase/nf-winbase-callnamedpipea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-callnamedpipea.md
@@ -146,7 +146,7 @@ Calling <b>CallNamedPipe</b> is equivalent to calling the <a href="/windows/desk
 
 <b>CallNamedPipe</b> fails if the pipe is a byte-type pipe.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/winbase/nf-winbase-createnamedpipea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createnamedpipea.md
@@ -413,7 +413,7 @@ Whenever a pipe write operation occurs, the system first tries to charge the mem
 
 To free resources used by a named pipe, the application should always close handles when they are no longer needed, which is accomplished either by calling the <a href="/windows/desktop/api/handleapi/nf-handleapi-closehandle">CloseHandle</a> function or when the process associated with the instance handles ends. Note that an instance of a named pipe may have more than one handle associated with it. An instance of a named pipe is always deleted when the last handle to the instance of the named pipe is closed.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientcomputernamea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientcomputernamea.md
@@ -88,7 +88,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientprocessid.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientprocessid.md
@@ -80,7 +80,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientsessionid.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipeclientsessionid.md
@@ -72,7 +72,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipehandlestatea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipehandlestatea.md
@@ -147,7 +147,7 @@ The
 To set the pipe handle state, use the 
 <a href="/windows/desktop/api/namedpipeapi/nf-namedpipeapi-setnamedpipehandlestate">SetNamedPipeHandleState</a> function.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipeserverprocessid.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipeserverprocessid.md
@@ -80,7 +80,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-getnamedpipeserversessionid.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getnamedpipeserversessionid.md
@@ -72,7 +72,7 @@ the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror"
 
 ## -remarks
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 ## -see-also
 

--- a/sdk-api-src/content/winbase/nf-winbase-waitnamedpipea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-waitnamedpipea.md
@@ -125,7 +125,7 @@ If the time-out interval expires, the <b>WaitNamedPipe</b> function will fail wi
 
 If the function succeeds, the process should use the <a href="/windows/desktop/api/fileapi/nf-fileapi-createfilea">CreateFile</a> function to open a handle to the named pipe. A return value of <b>TRUE</b> indicates that there is at least one instance of the pipe available. A subsequent <b>CreateFile</b> call to the pipe can fail, because the instance was closed by the server or opened by another client.
 
-<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax "\\.\pipe\LOCAL\" for the pipe name.
+<b>Windows 10, version 1709:  </b>Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax `\\.\pipe\LOCAL\` for the pipe name.
 
 
 #### Examples


### PR DESCRIPTION
Double quotes don't prevent \\ from being interpretted as an escaped backslash; use backticks instead so that rendered and source markdown are identical.