### PR TITLE
Fix page description for IApplicationAssociationRegistration::QueryCurrentDefault

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-iapplicationassociationregistration-querycurrentdefault.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-iapplicationassociationregistration-querycurrentdefault.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:shobjidl_core.IApplicationAssociationRegistration.QueryCurrentDefault
 title: IApplicationAssociationRegistration::QueryCurrentDefault (shobjidl_core.h)
-description: Determines the default application for a given association type. This is the default application launched by ShellExecute for that type. Not intended for use in Windows 8.
+description: Determines the default application for a given association type. This is the default application launched by ShellExecute for that type.
 helpviewer_keywords: ["IApplicationAssociationRegistration interface [Windows Shell]","QueryCurrentDefault method","IApplicationAssociationRegistration.QueryCurrentDefault","IApplicationAssociationRegistration::QueryCurrentDefault","QueryCurrentDefault","QueryCurrentDefault method [Windows Shell]","QueryCurrentDefault method [Windows Shell]","IApplicationAssociationRegistration interface","_shell_IApplicationAssociationRegistration_QueryCurrentDefault","shell.IApplicationAssociationRegistration_QueryCurrentDefault","shobjidl_core/IApplicationAssociationRegistration::QueryCurrentDefault"]
 old-location: shell\IApplicationAssociationRegistration_QueryCurrentDefault.htm
 tech.root: shell


### PR DESCRIPTION
The page description says this member function is not indented for use in Windows 8, but the actual page doesn't say anything like this. All other methods on the interface say this, however.