### PR TITLE
Update nf-winuser-enumdesktopsa.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-enumdesktopsa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-enumdesktopsa.md
@@ -64,7 +64,7 @@ A handle to the window station whose desktops are to be enumerated. This handle 
 <a href="/windows/desktop/api/winuser/nf-winuser-openwindowstationa">OpenWindowStation</a> function, and must have the WINSTA_ENUMDESKTOPS access right. For more information, see 
 <a href="/windows/desktop/winstation/window-station-security-and-access-rights">Window Station Security and Access Rights</a>.
 
-If this parameter is NULL, the current window station is used.
+If this parameter is NULL, the callback function will received all windows station names instead of desktop names.
 
 ### -param lpEnumFunc [in]
 


### PR DESCRIPTION
original doc says that if the first paramater is null, this function use current window station. but in fact if the first parameter is null, the function will return all window station name through callback function