### PR TITLE
Fixed spelling error in WAVEHDR structure

### DIFF
--- a/sdk-api-src/content/mmeapi/ns-mmeapi-wavehdr.md
+++ b/sdk-api-src/content/mmeapi/ns-mmeapi-wavehdr.md
@@ -76,7 +76,7 @@ User data.
 
 ### -field dwFlags
 
-A bitwise <b>OR</b> of zero of more flags. The following flags are defined:
+A bitwise <b>OR</b> of zero or more flags. The following flags are defined:
 
 <table>
 <tr>


### PR DESCRIPTION
Changed:
A bitwise OR of zero of more flags. The following flags are defined:

To:
A bitwise OR of zero *or* more flags. The following flags are defined: