### PR TITLE
nf-winuser-registerhotkey.md - fixed parameter name

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-registerhotkey.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerhotkey.md
@@ -79,7 +79,7 @@ The identifier of the hot key.  If the <i>hWnd</i> parameter is NULL, then the h
 Type: <b>UINT</b>
 
 The keys that must be pressed in combination with the key specified by the 
-     <i>uVirtKey</i> parameter in order to generate the <a href="/windows/desktop/inputdev/wm-hotkey">WM_HOTKEY</a> message. The <i>fsModifiers</i> parameter can be a combination of the following values.
+     <i>vk</i> parameter in order to generate the <a href="/windows/desktop/inputdev/wm-hotkey">WM_HOTKEY</a> message. The <i>fsModifiers</i> parameter can be a combination of the following values.
 
 <table>
 <tr>


### PR DESCRIPTION
Changing reference to parameter ```uVirtKey``` -> ```vk```...

The documentation references a parameter called ```uVirtKey``` which doesn't exist.

There **is** a parameter called ```vk``` though, which matches the definition in winuser.h:

```c
WINUSERAPI
BOOL
WINAPI
RegisterHotKey(
    _In_opt_ HWND hWnd,
    _In_ int id,
    _In_ UINT fsModifiers,
    _In_ UINT vk);
```