### PR TITLE
fix formatting of [in]/[out] specifier for `IMetaDataDispenser::Defin…

### DIFF
--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadatadispenser-openscope.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadatadispenser-openscope.md
@@ -51,21 +51,21 @@ Opens an existing file from disk, and maps its metadata into memory for importin
 
 ## -parameters
 
-### -param szScope [in]
+### -param [in] szScope 
 
 The name of the file to be opened. The file must contain common language runtime (CLR) metadata.
 
-### -param dwOpenFlags [in]
+### -param [in] dwOpenFlags 
 
 Specifies the mode (read, and so on) for opening. This is a value of the <a href="/dotnet/framework/unmanaged-api/metadata/coropenflags-enumeration">CorOpenFlags</a> enumeration. You can only import (read) from the file, not emit (write) to it.
 
-### -param riid [in]
+### -param [in] riid 
 
 The IID of the desired metadata interface to be returned; the caller will use the interface to import (read) metadata.
 
 Valid values for *riid* include **IID_IUnknown**, **IID_IMetaDataImport**, **IID_IMetaDataImport2**, **IID_IMetaDataAssemblyImport**, **IID_IMetaDataTables**, and **IID_IMetaDataTables2**.
 
-### -param ppIUnk [out]
+### -param [out] ppIUnk 
 
 The pointer to the returned interface.
 

--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadatadispenser-openscope.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadatadispenser-openscope.md
@@ -51,29 +51,21 @@ Opens an existing file from disk, and maps its metadata into memory for importin
 
 ## -parameters
 
-### -param szScope
-
-`[in]`
+### -param szScope [in]
 
 The name of the file to be opened. The file must contain common language runtime (CLR) metadata.
 
-### -param dwOpenFlags
-
-`[in]`
+### -param dwOpenFlags [in]
 
 Specifies the mode (read, and so on) for opening. This is a value of the <a href="/dotnet/framework/unmanaged-api/metadata/coropenflags-enumeration">CorOpenFlags</a> enumeration. You can only import (read) from the file, not emit (write) to it.
 
-### -param riid
-
-`[in]`
+### -param riid [in]
 
 The IID of the desired metadata interface to be returned; the caller will use the interface to import (read) metadata.
 
 Valid values for *riid* include **IID_IUnknown**, **IID_IMetaDataImport**, **IID_IMetaDataImport2**, **IID_IMetaDataAssemblyImport**, **IID_IMetaDataTables**, and **IID_IMetaDataTables2**.
 
-### -param ppIUnk
-
-`[out]`
+### -param ppIUnk [out]
 
 The pointer to the returned interface.
 


### PR DESCRIPTION
…eScope`'s parameters

The `[in]` and `[out]` specifiers are now on the same line as the parameter name, and not below