### PR TITLE
Added return value from ImageList_ReplaceIcon

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-imagelist_addicon.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-imagelist_addicon.md
@@ -66,6 +66,12 @@ Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HICON</a></b>
 
 A handle to the icon or cursor that contains the bitmap and mask for the new image.
 
+## -returns
+
+Type: <b>int</b>
+
+Returns the index of the image if successful, or -1 otherwise.
+
 ## -remarks
 
 Because the system does not save 


### PR DESCRIPTION
This macro directly calls the ImageList_ReplaceIcon macro so its return value is the same.