### PR TITLE
Update Arm64 processor features detection

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
@@ -464,15 +464,37 @@ This Arm processor implements the Arm v8 extra CRC32 instructions.
 This Arm processor implements the Arm v8.1 atomic instructions (e.g. CAS, SWP).
 </td>
 </tr>
-
- <tr>
-<td width="40%"><a id="PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE"></a><a id="pf_arm_v83_lrcpc_instructions_available"></a><dl>
-<dt><b>PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE</b></dt>
-<dt>34</dt>
+ 
+<tr>
+<td width="40%"><a id="PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE"></a><a id="pf_arm_v82_dp_instructions_available"></a><dl>
+<dt><b>PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE</b></dt>
+<dt>43</dt>
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8.3 LRCPC instructions (e.g. ldapr). Note that certain Arm v8.2 CPUs may optionally support the LRCPC instructions.
+This Arm processor implements the Arm v8.2 DP instructions (e.g. SDOT, UDOT). This feature is optional in Arm v8.2 implementations and mandatory in Arm v8.4 implementations.
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE"></a><a id="pf_arm_v83_jscvt_instructions_available"></a><dl>
+<dt><b>PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE</b></dt>
+<dt>44</dt>
+</dl>
+</td>
+<td width="60%">
+This Arm processor implements the Arm v8.3 JSCVT instructions (e.g. FJCVTZS).
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE"></a><a id="pf_arm_v83_lrcpc_instructions_available"></a><dl>
+<dt><b>PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE</b></dt>
+<dt>45</dt>
+</dl>
+</td>
+<td width="60%">
+This Arm processor implements the Arm v8.3 LRCPC instructions (e.g. LDAPR). Note that certain Arm v8.2 CPUs may optionally support the LRCPC instructions.
 </td>
 </tr>
  

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent.md
@@ -439,7 +439,7 @@ This Arm processor implements the Arm v8 instructions set.
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8 extra cryptographic instructions (i.e. AES, SHA1 and SHA2).
+This Arm processor implements the Arm v8 extra cryptographic instructions (for example, AES, SHA1 and SHA2).
 </td>
 </tr>
 
@@ -461,7 +461,7 @@ This Arm processor implements the Arm v8 extra CRC32 instructions.
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8.1 atomic instructions (e.g. CAS, SWP).
+This Arm processor implements the Arm v8.1 atomic instructions (for example, CAS, SWP).
 </td>
 </tr>
  
@@ -472,7 +472,7 @@ This Arm processor implements the Arm v8.1 atomic instructions (e.g. CAS, SWP).
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8.2 DP instructions (e.g. SDOT, UDOT). This feature is optional in Arm v8.2 implementations and mandatory in Arm v8.4 implementations.
+This Arm processor implements the Arm v8.2 DP instructions (for example, SDOT, UDOT). This feature is optional in Arm v8.2 implementations and mandatory in Arm v8.4 implementations.
 </td>
 </tr>
 
@@ -483,7 +483,7 @@ This Arm processor implements the Arm v8.2 DP instructions (e.g. SDOT, UDOT). Th
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8.3 JSCVT instructions (e.g. FJCVTZS).
+This Arm processor implements the Arm v8.3 JSCVT instructions (for example, FJCVTZS).
 </td>
 </tr>
 
@@ -494,7 +494,7 @@ This Arm processor implements the Arm v8.3 JSCVT instructions (e.g. FJCVTZS).
 </dl>
 </td>
 <td width="60%">
-This Arm processor implements the Arm v8.3 LRCPC instructions (e.g. LDAPR). Note that certain Arm v8.2 CPUs may optionally support the LRCPC instructions.
+This Arm processor implements the Arm v8.3 LRCPC instructions (for example, LDAPR). Note that certain Arm v8.2 CPUs may optionally support the LRCPC instructions.
 </td>
 </tr>
  


### PR DESCRIPTION
Updated Arm64 processor features accordingly to the Windows 11 SDK (10.0.22621.0). I noticed that `PF_ARM_V83_LRCPC_INSTRUCTIONS_AVAILABLE` has the same value as `PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE` (34), so updated it to 45 and changed examples of instructions in meaning to uppercase to be consistent with other descriptions, and added `PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE` and `PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE`

Refs: #1350