### PR TITLE
Fixed SHCOLSTATE_TYPEMASK field description.

### DIFF
--- a/sdk-api-src/content/shtypes/ne-shtypes-shcolstate.md
+++ b/sdk-api-src/content/shtypes/ne-shtypes-shcolstate.md
@@ -74,7 +74,7 @@ The value is displayed as a date/time.
 
 ### -field SHCOLSTATE_TYPEMASK:0xf
 
-A mask for display type values SHCOLSTATE_TYPE_STR, SHCOLSTATE_TYPE_STR, and SHCOLSTATE_TYPE_DATE.
+A mask for display type values SHCOLSTATE_TYPE_STR, SHCOLSTATE_TYPE_INT, and SHCOLSTATE_TYPE_DATE.
 
 ### -field SHCOLSTATE_ONBYDEFAULT:0x10
 


### PR DESCRIPTION
Updated the description of field '**SHCOLSTATE_TYPEMASK**' within [ne-shtypes-shcolstate.md](https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/shtypes/ne-shtypes-shcolstate.md)
- Added missing `SHCOLSTATE_TYPE_INT` value.
- Removed duplicate `SHCOLSTATE_TYPE_STR` value.