### PR TITLE
Fix max size formula for USN_RECORD_V2

### DIFF
--- a/sdk-api-src/content/winioctl/ns-winioctl-usn_record_v2.md
+++ b/sdk-api-src/content/winioctl/ns-winioctl-usn_record_v2.md
@@ -85,7 +85,7 @@ The size in bytes of any change
 <td>
 <pre>  MaximumChangeJournalRecordSize = 
       ( MaximumComponentLength * sizeof(WCHAR) 
-        + sizeof(USN_RECORD)   - sizeof(WCHAR) );
+        + sizeof(USN_RECORD)   + sizeof(WCHAR) );
 </pre>
 </td>
 </tr>


### PR DESCRIPTION
The result of provided MaximumChangeJournalRecordSize formula is 4 bytes to low. For a 255 max component it gives 572 whereas such file would need a 576 byte long buffer. This is most likely a typo, adding a WCHAR instead of subtracting it fixes this.