### PR TITLE
DXGI_SWAP_EFFECT_FLIP_DISCARD iBuffer must be Zero on D3D11.

### DIFF
--- a/sdk-api-src/content/dxgi/ne-dxgi-dxgi_swap_effect.md
+++ b/sdk-api-src/content/dxgi/ne-dxgi-dxgi_swap_effect.md
@@ -96,7 +96,7 @@ Use this flag to specify the flip presentation model and to specify that DXGI di
             
 
 <b>Direct3D 11:  </b>This enumeration value is supported starting with Windows 10. 
-This flag is valid for a swap chain with more than one back buffer, although, applications only have read and write access to buffer 0.
+This flag is valid for a swap chain with more than one back buffer; although applications have read and write access only to buffer 0.
               
 
 <div class="alert"><b>Note</b>  Windows Store apps must use <b>DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</b> or <b>DXGI_SWAP_EFFECT_FLIP_DISCARD</b>.

--- a/sdk-api-src/content/dxgi/ne-dxgi-dxgi_swap_effect.md
+++ b/sdk-api-src/content/dxgi/ne-dxgi-dxgi_swap_effect.md
@@ -95,7 +95,8 @@ Use this flag to specify the flip presentation model and to specify that DXGI di
               See <a href="/windows/win32/direct3ddxgi/dxgi-1-4-improvements">DXGI 1.4 Improvements</a>.
             
 
-<b>Direct3D 11:  </b>This enumeration value is supported starting with Windows 10.
+<b>Direct3D 11:  </b>This enumeration value is supported starting with Windows 10. 
+This flag is valid for a swap chain with more than one back buffer, although, applications only have read and write access to buffer 0.
               
 
 <div class="alert"><b>Note</b>  Windows Store apps must use <b>DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</b> or <b>DXGI_SWAP_EFFECT_FLIP_DISCARD</b>.


### PR DESCRIPTION
When using D3D11, DXGI_SWAP_EFFECT_FLIP_DISCARD has the same buffer access concerns as DXGI_SWAP_EFFECT_DISCARD

The user will hit the Warning/Error ```iBuffer must be zero if swap effect is DXGI_SWAP_EFFECT_FLIP_DISCARD``` if they try to use a D3D12 compatible iBuffer configuration.

https://github.com/baldurk/renderdoc/issues/2055
https://github.com/baldurk/renderdoc/commit/92040f4636c8a65c17cc8dbd8e664c9409ed3cb3


>Jessie Natalie:
> D3D11 supports automatic "rotation" of buffers, meaning even if you have more than one you can pretend that you just have one, and always render to buffer 0. D3D12 can't do that due to the way descriptors work
