### PR TITLE
Correct the links of ABM_SETAUTOHIDEBAR and ABM_SETSTATE

### DIFF
--- a/sdk-api-src/content/shellapi/ns-shellapi-appbardata.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-appbardata.md
@@ -153,13 +153,13 @@ A message-dependent value. This member is used with these messages:
                         
 <ul>
 <li>
-<a href="/windows/desktop/shell/dialogs-bumper">ABM_SETAUTOHIDEBAR</a>
+<a href="/windows/desktop/shell/abm-setautohidebar">ABM_SETAUTOHIDEBAR</a>
 </li>
 <li>
 <a href="/windows/desktop/shell/abm-setautohidebarex">ABM_SETAUTOHIDEBAREX</a>
 </li>
 <li>
-<a href="/windows/desktop/shell/drag-and-drop-handlers-and-custom-clipboard-format-bumper">ABM_SETSTATE</a>
+<a href="windows/desktop/shell/abm-setstate">ABM_SETSTATE</a>
 </li>
 </ul>
 


### PR DESCRIPTION
Currently the hyperlinks of ABM_SETAUTOHIDEBAR and ABM_SETSTATE lead to "[Dialogs](https://learn.microsoft.com/en-us/windows/win32/shell/dialogs-bumper)" and "[Drag-and-Drop Handlers and Custom Clipboard Format](https://learn.microsoft.com/en-us/windows/win32/shell/drag-and-drop-handlers-and-custom-clipboard-format-bumper)" respectively.

Correct these links to navigate to the correct topic pages.