### PR TITLE
Fix base interface for IClosable

### DIFF
--- a/sdk-api-src/content/windows.foundation/nn-windows-foundation-iclosable.md
+++ b/sdk-api-src/content/windows.foundation/nn-windows-foundation-iclosable.md
@@ -54,7 +54,7 @@ Defines a method to release allocated resources.
 
 ## -inheritance
 
-The <b>IClosable</b> interface inherits from the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> interface. <b>IClosable</b> also has these types of members:
+The <b>IClosable</b> interface inherits from the <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a> interface. <b>IClosable</b> also has these types of members:
 
 ## -remarks
 


### PR DESCRIPTION
This PR fixes the base interface for `IClosable`, which is `IInspectable`, not `IUnknown`:

![](https://user-images.githubusercontent.com/10199417/216424651-7c1e2b30-7866-4dc1-a7d1-6f18f38cec56.png)