### PR TITLE
Descriptions for D3D12_SAMPLER_FEEDBACK_TIER

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_sampler_feedback_tier.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_sampler_feedback_tier.md
@@ -54,8 +54,8 @@ Specifies that sampler feedback is not supported. Attempts at calling sampler fe
 Specifies that sampler feedback is supported to tier 0.9. This indicates the following:
 
 Sampler feedback is supported for samplers with these texture addressing modes:
- * D3D12_TEXTURE_ADDRESS_MODE_WRAP
- * D3D12_TEXTURE_ADDRESS_MODE_CLAMP
+* D3D12_TEXTURE_ADDRESS_MODE_WRAP
+* D3D12_TEXTURE_ADDRESS_MODE_CLAMP
 
 The Texture2D shader resource view passed in to feedback-writing HLSL methods has these restrictions:
 * The MostDetailedMip field must be 0.

--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_sampler_feedback_tier.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_sampler_feedback_tier.md
@@ -47,15 +47,30 @@ Defines constants that specify sampler feedback support.
 
 ### -field D3D12_SAMPLER_FEEDBACK_TIER_NOT_SUPPORTED:0
 
-Specifies that mesh and amplification shaders are not supported.
+Specifies that sampler feedback is not supported. Attempts at calling sampler feedback APIs represent an error.
 
 ### -field D3D12_SAMPLER_FEEDBACK_TIER_0_9:90
 
-Specifies that mesh and amplification shaders are supported to tier 0.9.
+Specifies that sampler feedback is supported to tier 0.9. This indicates the following:
+
+Sampler feedback is supported for samplers with these texture addressing modes:
+ * D3D12_TEXTURE_ADDRESS_MODE_WRAP
+ * D3D12_TEXTURE_ADDRESS_MODE_CLAMP
+
+The Texture2D shader resource view passed in to feedback-writing HLSL methods has these restrictions:
+* The MostDetailedMip field must be 0.
+* The MipLevels count must span the full mip count of the resource.
+* The PlaneSlice field must be 0.
+* The ResourceMinLODClamp field must be 0.
+
+The Texture2DArray shader resource view passed in to feedback-writing HLSL methods has these restrictions:
+* All the limitations as in Texture2D above, and
+* The FirstArraySlice field must be 0.
+* The ArraySize field must span the full array element count of the resource.
 
 ### -field D3D12_SAMPLER_FEEDBACK_TIER_1_0:100
 
-Specifies that mesh and amplification shaders are supported to tier 1.0.
+Specifies sample feedback is supported to tier 1.0. This indicates that sampler feedback is supported for all texture addressing modes, and feedback-writing methods are supported irrespective of the passed-in shader resource view.
 
 ### -field D3D12_MESH_SHADER_TIER_NOT_SUPPORTED:0
 


### PR DESCRIPTION
The current descriptions for the D3D12_SAMPLER_FEEDBACK_TIER enum values are wrong, and appear to be copy-pasted from D3D12_MESH_SHADER_TIER. I updated the descriptions with information that was taken from sampler feedback spec: https://microsoft.github.io/DirectX-Specs/d3d/SamplerFeedback.html