### PR TITLE
param pProps is [out]

### DIFF
--- a/sdk-api-src/content/strmif/nf-strmif-imeminputpin-getallocatorrequirements.md
+++ b/sdk-api-src/content/strmif/nf-strmif-imeminputpin-getallocatorrequirements.md
@@ -55,7 +55,7 @@ The <code>GetAllocatorRequirements</code> method retrieves the allocator propert
 
 ## -parameters
 
-### -param pProps [in]
+### -param pProps [out]
 
 Pointer to an [ALLOCATOR_PROPERTIES](/windows/desktop/api/strmif/ns-strmif-allocator_properties), structure which is filled in with the requirements.
 


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/4289847/217670661-70062ae6-5c80-4037-8503-fdf13a21e9fb.png)

I didn't change `<a href="/windows/desktop/api/strmif/nn-strmif-imeminputpin">IMemInputPin Interface</a>`. I don't know why it's shown :(

Also I didn't find where I can change `Syntax`: https://learn.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-imeminputpin-getallocatorrequirements#syntax