### PR TITLE
Revert "Fix params naming in GetObject"

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-getobject.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-getobject.md
@@ -60,15 +60,15 @@ The <b>GetObject</b> function retrieves information for the specified graphics o
 
 ## -parameters
 
-### -param hgdiobj [in]
+### -param h [in]
 
 A handle to the graphics object of interest. This can be a handle to one of the following: a logical bitmap, a brush, a font, a palette, a pen, or a device independent bitmap created by calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-createdibsection">CreateDIBSection</a> function.
 
-### -param cbBuffer [in]
+### -param c [in]
 
 The number of bytes of information to be written to the buffer.
 
-### -param lpvObject [out]
+### -param pv [out]
 
 A pointer to a buffer that receives the information about the specified graphics object.
 


### PR DESCRIPTION
Reverts MicrosoftDocs/sdk-api#1093

Unfortunately the current system doesn't like parameter names that aren't exactly the same as those in the method stub.