### PR TITLE
Update ns-winnt-system_logical_processor_information_ex.md

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-system_logical_processor_information_ex.md
+++ b/sdk-api-src/content/winnt/ns-winnt-system_logical_processor_information_ex.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["*PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX","PSYSTEM_LOGIC
 old-location: base\system_logical_processor_information_ex.htm
 tech.root: backup
 ms.assetid: 6ff16cda-c1dc-4d5c-ac60-756653cd6b07
-ms.date: 12/05/2018
+ms.date: 27/02/2023
 ms.keywords: '*PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure pointer, RelationCache, RelationGroup, RelationNumaNode, RelationProcessorCore, RelationProcessorPackage, RelationProcessorModule, RelationProcessorDie, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure, _SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, base.system_logical_processor_information_ex, winnt/PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, winnt/SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX'
 req.header: winnt.h
 req.include-header: 

--- a/sdk-api-src/content/winnt/ns-winnt-system_logical_processor_information_ex.md
+++ b/sdk-api-src/content/winnt/ns-winnt-system_logical_processor_information_ex.md
@@ -7,7 +7,7 @@ old-location: base\system_logical_processor_information_ex.htm
 tech.root: backup
 ms.assetid: 6ff16cda-c1dc-4d5c-ac60-756653cd6b07
 ms.date: 12/05/2018
-ms.keywords: '*PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure pointer, RelationCache, RelationGroup, RelationNumaNode, RelationProcessorCore, RelationProcessorPackage, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure, _SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, base.system_logical_processor_information_ex, winnt/PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, winnt/SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX'
+ms.keywords: '*PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure pointer, RelationCache, RelationGroup, RelationNumaNode, RelationProcessorCore, RelationProcessorPackage, RelationProcessorModule, RelationProcessorDie, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX structure, _SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, base.system_logical_processor_information_ex, winnt/PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, winnt/SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX'
 req.header: winnt.h
 req.include-header: 
 req.target-type: Windows
@@ -60,69 +60,7 @@ Contains information about the relationships of logical processors and related h
 
 ### -field Relationship
 
-The type of relationship between the logical processors. This parameter can be one of the following <a href="/windows/desktop/api/winnt/ne-winnt-logical_processor_relationship">LOGICAL_PROCESSOR_RELATIONSHIP</a> values.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="RelationCache"></a><a id="relationcache"></a><a id="RELATIONCACHE"></a><dl>
-<dt><b>RelationCache</b></dt>
-<dt>2</dt>
-</dl>
-</td>
-<td width="60%">
-The specified logical processors  share a cache. The <b>Cache</b> member contains additional information.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="RelationGroup"></a><a id="relationgroup"></a><a id="RELATIONGROUP"></a><dl>
-<dt><b>RelationGroup</b></dt>
-<dt>4</dt>
-</dl>
-</td>
-<td width="60%">
-The specified logical processors share a processor group. The <b>Group</b> member contains additional information.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="RelationNumaNode"></a><a id="relationnumanode"></a><a id="RELATIONNUMANODE"></a><dl>
-<dt><b>RelationNumaNode</b></dt>
-<dt>1</dt>
-</dl>
-</td>
-<td width="60%">
-The specified logical processors  are part of the same NUMA node. The <b>NumaNode</b> member  contains additional information.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="RelationProcessorCore"></a><a id="relationprocessorcore"></a><a id="RELATIONPROCESSORCORE"></a><dl>
-<dt><b>RelationProcessorCore</b></dt>
-<dt>0</dt>
-</dl>
-</td>
-<td width="60%">
-The specified logical processors share a single processor core. The <b>Processor</b> member contains additional information.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="RelationProcessorPackage"></a><a id="relationprocessorpackage"></a><a id="RELATIONPROCESSORPACKAGE"></a><dl>
-<dt><b>RelationProcessorPackage</b></dt>
-<dt>3</dt>
-</dl>
-</td>
-<td width="60%">
-The specified logical processors share a physical package. The <b>Processor</b> member contains additional information.
-
-</td>
-</tr>
-</table>
+The type of relationship between the logical processors. This parameter can be one of the <a href="/windows/desktop/api/winnt/ne-winnt-logical_processor_relationship">LOGICAL_PROCESSOR_RELATIONSHIP</a> enumeration values.
 
 ### -field Size
 
@@ -132,11 +70,11 @@ The size of the structure.
 
 ### -field DUMMYUNIONNAME.Processor
 
-A <a href="/windows/desktop/api/winnt/ns-winnt-processor_relationship">PROCESSOR_RELATIONSHIP</a> structure that describes processor affinity. This structure contains valid data only if the <b>Relationship</b> member is <b>RelationProcessorCore</b> or <b>RelationProcessorPackage</b>.
+A <a href="/windows/desktop/api/winnt/ns-winnt-processor_relationship">PROCESSOR_RELATIONSHIP</a> structure that describes processor affinity. This structure contains valid data only if the <b>Relationship</b> member is <b>RelationProcessorCore</b>, <b>RelationProcessorDie</b>, <b>RelationProcessorModule</b> or <b>RelationProcessorPackage</b>.
 
 ### -field DUMMYUNIONNAME.NumaNode
 
-A <a href="/windows/desktop/api/winnt/ns-winnt-numa_node_relationship">NUMA_NODE_RELATIONSHIP</a> structure that describes a NUMA node. This structure contains valid data only if the <b>Relationship</b> member is <b>RelationNumaNode</b>.
+A <a href="/windows/desktop/api/winnt/ns-winnt-numa_node_relationship">NUMA_NODE_RELATIONSHIP</a> structure that describes a NUMA node. This structure contains valid data only if the <b>Relationship</b> member is <b>RelationNumaNode</b> or <b>RelationNumaNodeEx</b>.
 
 ### -field DUMMYUNIONNAME.Cache
 


### PR DESCRIPTION
Add RelationProcessorDie and RelationProcessorModule references. Remove the table for the LOGICAL_PROCESSOR_RELATIONSHIP enum, as it is incomplete and we should not duplicate that here anyway, but just refer to the LOGICAL_PROCESSOR_RELATIONSHIP enumeration page itself.