### PR TITLE
Fix typo `&amp;` to `&` in ne-mftransform-_mft_output_data_buffer_flags.md

### DIFF
--- a/sdk-api-src/content/mftransform/ne-mftransform-_mft_output_data_buffer_flags.md
+++ b/sdk-api-src/content/mftransform/ne-mftransform-_mft_output_data_buffer_flags.md
@@ -91,7 +91,7 @@ if (Buffer.dwStatus == MFT_OUTPUT_DATA_BUFFER_STREAM_END)
 }
 
 // Incorrect.
-if ((Buffer.dwStatus &amp; MFT_OUTPUT_DATA_BUFFER_STREAM_END) != 0)
+if ((Buffer.dwStatus & MFT_OUTPUT_DATA_BUFFER_STREAM_END) != 0)
 {
     ...
 }


### PR DESCRIPTION
Changed `&amp;` to `&` in the sample code.