### PR TITLE
Mark GetColorDirectoryA and GetColorDirectoryW as deprecated

### DIFF
--- a/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
@@ -44,7 +44,7 @@ dev_langs:
 ## -description
 
 > [!NOTE] 
-> This API is being deprecated as part of ongoing security and reliability efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+> This API is being deprecated as part of ongoing modernization efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
 >
 >| Scenario | Mechanism |
 >| :------: | :------: |

--- a/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:icm.GetColorDirectoryA
 title: GetColorDirectoryA
-description: Retrieves the path of the Windows COLOR directory on a specified machine.
+description: Retrieves the path of the Windows COLOR directory on a specified machine. (ANSI)
 tech.root: wcs
 ms.date: 02/01/2021
 targetos: Windows
@@ -42,6 +42,17 @@ dev_langs:
 ---
 
 ## -description
+
+> [!NOTE] 
+> This API is being deprecated as part of ongoing security and reliability efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+>
+>| Scenario | Mechanism |
+>| :------: | :------: |
+>|   Enumerating all installed profiles  |   Use [**WcsEnumColorProfilesSize**](/windows/win32/api/icm/nf-icm-wcsenumcolorprofilessize) and [**WcsEnumColorProfiles**](/windows/win32/api/icm/nf-icm-wcsenumcolorprofiles), or [**EnumColorProfilesA**](/windows/win32/api/icm/nf-icm-EnumColorProfilesA)  |
+>|   Installing/Uninstalling color profiles  |   Use [**InstallColorProfileA**](/windows/win32/api/icm/nf-icm-InstallColorProfileA)/[**UninstallColorProfileA**](/windows/win32/api/icm/nf-icm-UninstallColorProfileA)  |
+>|   Opening a color profile file directly  |   Use [**OpenColorProfileA**](/windows/win32/api/icm/nf-icm-OpenColorProfileA) with dwType=PROFILE_FILENAME in the PROFILE struct parameter.<br/> Or use [**WcsOpenColorProfileA**](/windows/win32/api/icm/nf-icm-WcsOpenColorProfileA). [**Icm.h**](/windows/win32/api/icm) contains many APIs that accept the returned HPROFILE for color profile manipulation  |
+
+<br/>
 
 Retrieves the path of the Windows COLOR directory on a specified machine.
 

--- a/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectorya.md
@@ -44,7 +44,7 @@ dev_langs:
 ## -description
 
 > [!NOTE] 
-> This API is being deprecated as part of ongoing modernization efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+> This API may be unavailable in future releases. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
 >
 >| Scenario | Mechanism |
 >| :------: | :------: |

--- a/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
@@ -44,7 +44,7 @@ dev_langs:
 ## -description
 
 > [!NOTE] 
-> This API is being deprecated as part of ongoing security and reliability efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+> This API is being deprecated as part of ongoing modernization efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
 >
 >| Scenario | Mechanism |
 >| :------: | :------: |

--- a/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:icm.GetColorDirectoryW
 title: GetColorDirectoryW
-description: Retrieves the path of the Windows COLOR directory on a specified machine.
+description: Retrieves the path of the Windows COLOR directory on a specified machine. (Unicode)
 tech.root: wcs
 ms.date: 02/01/2021
 targetos: Windows
@@ -42,6 +42,17 @@ dev_langs:
 ---
 
 ## -description
+
+> [!NOTE] 
+> This API is being deprecated as part of ongoing security and reliability efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+>
+>| Scenario | Mechanism |
+>| :------: | :------: |
+>|   Enumerating all installed profiles  |   Use [**WcsEnumColorProfilesSize**](/windows/win32/api/icm/nf-icm-wcsenumcolorprofilessize) and [**WcsEnumColorProfiles**](/windows/win32/api/icm/nf-icm-wcsenumcolorprofiles), or [**EnumColorProfilesW**](/windows/win32/api/icm/nf-icm-EnumColorProfilesW)  |
+>|   Installing/Uninstalling color profiles  |   Use [**InstallColorProfileW**](/windows/win32/api/icm/nf-icm-InstallColorProfileW)/[**UninstallColorProfileW**](/windows/win32/api/icm/nf-icm-UninstallColorProfileW)  |
+>|   Opening a color profile file directly  |   Use [**OpenColorProfileW**](/windows/win32/api/icm/nf-icm-OpenColorProfileW) with dwType=PROFILE_FILENAME in the PROFILE struct parameter.<br/> Or use [**WcsOpenColorProfileW**](/windows/win32/api/icm/nf-icm-WcsOpenColorProfileW). [**Icm.h**](/windows/win32/api/icm) contains many APIs that accept the returned HPROFILE for color profile manipulation  |
+
+<br/>
 
 Retrieves the path of the Windows COLOR directory on a specified machine.
 

--- a/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
+++ b/sdk-api-src/content/icm/nf-icm-getcolordirectoryw.md
@@ -44,7 +44,7 @@ dev_langs:
 ## -description
 
 > [!NOTE] 
-> This API is being deprecated as part of ongoing modernization efforts in Windows. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
+> This API may be unavailable in future releases. We encourage new and existing software to use other APIs for color profile interactions. Please refer to the below table for some examples.
 >
 >| Scenario | Mechanism |
 >| :------: | :------: |


### PR DESCRIPTION
These APIs need to be deprecated to address ongoing security and reliability efforts in Windows.