### PR TITLE
Fix file encoding and remove pre-Vista comments

### DIFF
--- a/sdk-api-src/content/evntrace/nf-evntrace-starttracea.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-starttracea.md
@@ -26,8 +26,8 @@ ms.keywords:
 req.header: evntrace.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows 2000 Server [desktop apps \| UWP apps]
+req.target-min-winverclnt: WindowsÂ Vista [desktop apps \| UWP apps]
+req.target-min-winversvr: WindowsÂ Server 2008 [desktop apps \| UWP apps]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:
@@ -38,13 +38,13 @@ req.namespace:
 req.assembly:
 req.type-library:
 req.lib:
-  Sechost.lib on Windows 8.1 and Windows Server 2012 R2; Advapi32.lib on
-  Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Sechost.lib on WindowsÂ 8.1 and Windows ServerÂ 2012Â R2; Advapi32.lib on
+  WindowsÂ 8, Windows ServerÂ 2012, WindowsÂ 7, Windows ServerÂ 2008Â R2, Windows
+  ServerÂ 2008, WindowsÂ Vista
 req.dll:
-  Sechost.dll on Windows 8.1 and Windows Server 2012 R2; Advapi32.dll on
-  Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Sechost.dll on WindowsÂ 8.1 and Windows ServerÂ 2012Â R2; Advapi32.dll on
+  WindowsÂ 8, Windows ServerÂ 2012, WindowsÂ 7, Windows ServerÂ 2008Â R2, Windows
+  ServerÂ 2008, WindowsÂ Vista
 req.irql:
 targetos: Windows
 req.typenames:
@@ -108,10 +108,6 @@ Null-terminated string that contains the name of the event tracing session. The
 session name is limited to 1,024 characters, is case-insensitive, and must be
 unique.
 
-**Windows 2000:** Session names are case-sensitive. As a result, duplicate
-session names are allowed. However, to reduce confusion, you should make sure
-your session names are unique.
-
 > [!Important]
 > Use a descriptive name for your session so that the session's
 > ownership and usage can be determined from the session name. Do not use a GUID
@@ -145,7 +141,7 @@ specify a value for **MaximumFileSize**. See the Remarks section for more
 information on setting the _Properties_ parameter and the behavior of the
 session.
 
-**Starting with Windows 10, version 1703:** For better performance in cross
+**Starting with WindowsÂ 10, version 1703:** For better performance in cross
 process scenarios, you can now pass filtering in to **StartTrace** when starting
 system wide private loggers. You will need to pass in the new
 [EVENT_TRACE_PROPERTIES_V2](/windows/win32/api/evntrace/ns-evntrace-event_trace_properties_v2)
@@ -180,8 +176,7 @@ are some common errors and their causes.
   - The **LogFileMode** member of _Properties_ specifies a combination of flags
     that is not valid.
   - The **Wnode.Guid** member is **SystemTraceControlGuid**, but the
-    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**. **Windows 2000:**
-    This case does not return an error.
+    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**.
 
 - **ERROR_ALREADY_EXISTS**
 
@@ -207,8 +202,6 @@ are some common errors and their causes.
   Choose a drive with more space, or decrease the size specified in
   **MaximumFileSize** (if used).
 
-  **Windows 2000:** Does not require an additional 200 MB available disk space.
-
 - **ERROR_ACCESS_DENIED**
 
   Only users with administrative privileges, users in the Performance Log Users
@@ -217,8 +210,6 @@ are some common errors and their causes.
   control trace sessions, add them to the Performance Log Users group. Only
   users with administrative privileges and services running as LocalSystem can
   control an NT Kernel Logger session.
-
-  **Windows XP and Windows 2000:** Anyone can control a trace session.
 
   If the user is a member of the Performance Log Users group, they may not have
   permission to create the log file in the specified folder.
@@ -249,7 +240,7 @@ are some common errors and their causes.
     > administrator to enable specific scenarios. The EtwMaxLoggers setting must
     > not be automatically modified by a program or driver.
 
-    Prior to Windows 10, version 1709, this is a fixed cap of 64 loggers for
+    Prior to WindowsÂ 10, version 1709, this is a fixed cap of 64 loggers for
     non-private loggers.
 
 ## -remarks
@@ -266,9 +257,6 @@ You cannot start more than one session with the same session GUID (as specified
 by `Properties.Wnode.Guid`). In most cases, you will set `Properties.Wnode.Guid`
 to all-zero (i.e. **GUID_NULL**) to allow the ETW system to generate a new GUID
 for the session.
-
-**Windows Server 2003:** You can start more than one session with the same
-session GUID.
 
 To specify a private logger session, set **Wnode.Guid** member of _Properties_
 to the provider's control GUID, not the private logger session's control GUID.
@@ -295,7 +283,7 @@ following must be true:
   to use this name).
 
 > [!NOTE]
-> A system logger must set the **EnableFlags** member of the
+>Â A system logger must set the **EnableFlags** member of the
 > [EVENT_TRACE_PROPERTIES](/windows/win32/api/evntrace/ns-evntrace-event_trace_properties)
 > structure to indicate which
 > [SystemTraceProvider](/windows/win32/etw/configuring-and-starting-a-systemtraceprovider-session)
@@ -307,7 +295,7 @@ additional restrictions:
 - There can be no more than 8 system loggers active on the same system.
 - System loggers cannot be created within a Windows Server container.
 - System loggers cannot use the **EVENT_TRACE_USE_PAGED_MEMORY** flag.
-- Prior to Windows 10, version 1703, no more than 2 distinct clock types can be
+- Prior to WindowsÂ 10, version 1703, no more than 2 distinct clock types can be
   used simultaneously by any system loggers. For example, if one active system
   logger is using the "CPU cycle counter" clock type, and another active system
   logger is using the "Query performance counter" clock type, then any attempt
@@ -315,7 +303,7 @@ additional restrictions:
   it would require the activation of a third clock type. Because of this
   limitation, Microsoft strongly recommends that system loggers do not use the
   "System time" clock type.
-- Starting with Windows 10, version 1703, the clock type restriction has been
+- Starting with WindowsÂ 10, version 1703, the clock type restriction has been
   removed. All three clock types can now be used simultaneously by system
   loggers.
 
@@ -324,9 +312,6 @@ To specify an NT Kernel Logger session (deprecated), set _InstanceName_ to
 **SystemTraceControlGuid**. If you do not specify the GUID as
 **SystemTraceControlGuid**, ETW will override the GUID value and set it to
 **SystemTraceControlGuid**.
-
-**Windows 2000:** To start the kernel session, the session name must be
-**KERNEL_LOGGER_NAME** and the GUID must be **SystemTraceControlGuid**.
 
 ### Examples
 

--- a/sdk-api-src/content/evntrace/nf-evntrace-starttracew.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-starttracew.md
@@ -26,8 +26,8 @@ ms.keywords:
 req.header: evntrace.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows 2000 Server [desktop apps \| UWP apps]
+req.target-min-winverclnt: WindowsÂ 2000 Professional [desktop apps \| UWP apps]
+req.target-min-winversvr: WindowsÂ 2000 Server [desktop apps \| UWP apps]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:
@@ -38,13 +38,13 @@ req.namespace:
 req.assembly:
 req.type-library:
 req.lib:
-  Sechost.lib on Windows 8.1 and Windows Server 2012 R2; Advapi32.lib on
-  Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Sechost.lib on WindowsÂ 8.1 and Windows ServerÂ 2012Â R2; Advapi32.lib on
+  WindowsÂ 8, Windows ServerÂ 2012, WindowsÂ 7, Windows ServerÂ 2008Â R2, Windows
+  ServerÂ 2008, WindowsÂ Vista and WindowsÂ XP
 req.dll:
-  Sechost.dll on Windows 8.1 and Windows Server 2012 R2; Advapi32.dll on
-  Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Sechost.dll on WindowsÂ 8.1 and Windows ServerÂ 2012Â R2; Advapi32.dll on
+  WindowsÂ 8, Windows ServerÂ 2012, WindowsÂ 7, Windows ServerÂ 2008Â R2, Windows
+  ServerÂ 2008, WindowsÂ Vista and WindowsÂ XP
 req.irql:
 targetos: Windows
 req.typenames:
@@ -108,10 +108,6 @@ Null-terminated string that contains the name of the event tracing session. The
 session name is limited to 1,024 characters, is case-insensitive, and must be
 unique.
 
-**Windows 2000:** Session names are case-sensitive. As a result, duplicate
-session names are allowed. However, to reduce confusion, you should make sure
-your session names are unique.
-
 > [!Important]
 > Use a descriptive name for your session so that the session's
 > ownership and usage can be determined from the session name. Do not use a GUID
@@ -145,7 +141,7 @@ specify a value for **MaximumFileSize**. See the Remarks section for more
 information on setting the _Properties_ parameter and the behavior of the
 session.
 
-**Starting with Windows 10, version 1703:** For better performance in cross
+**Starting with WindowsÂ 10, version 1703:** For better performance in cross
 process scenarios, you can now pass filtering in to **StartTrace** when starting
 system wide private loggers. You will need to pass in the new
 [EVENT_TRACE_PROPERTIES_V2](/windows/win32/api/evntrace/ns-evntrace-event_trace_properties_v2)
@@ -180,7 +176,7 @@ are some common errors and their causes.
   - The **LogFileMode** member of _Properties_ specifies a combination of flags
     that is not valid.
   - The **Wnode.Guid** member is **SystemTraceControlGuid**, but the
-    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**. **Windows 2000:**
+    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**. **WindowsÂ 2000:**
     This case does not return an error.
 
 - **ERROR_ALREADY_EXISTS**
@@ -207,8 +203,6 @@ are some common errors and their causes.
   Choose a drive with more space, or decrease the size specified in
   **MaximumFileSize** (if used).
 
-  **Windows 2000:** Does not require an additional 200 MB available disk space.
-
 - **ERROR_ACCESS_DENIED**
 
   Only users with administrative privileges, users in the Performance Log Users
@@ -217,8 +211,6 @@ are some common errors and their causes.
   control trace sessions, add them to the Performance Log Users group. Only
   users with administrative privileges and services running as LocalSystem can
   control an NT Kernel Logger session.
-
-  **Windows XP and Windows 2000:** Anyone can control a trace session.
 
   If the user is a member of the Performance Log Users group, they may not have
   permission to create the log file in the specified folder.
@@ -249,7 +241,7 @@ are some common errors and their causes.
     > administrator to enable specific scenarios. The EtwMaxLoggers setting must
     > not be automatically modified by a program or driver.
 
-    Prior to Windows 10, version 1709, this is a fixed cap of 64 loggers for
+    Prior to WindowsÂ 10, version 1709, this is a fixed cap of 64 loggers for
     non-private loggers.
 
 ## -remarks
@@ -266,9 +258,6 @@ You cannot start more than one session with the same session GUID (as specified
 by `Properties.Wnode.Guid`). In most cases, you will set `Properties.Wnode.Guid`
 to all-zero (i.e. **GUID_NULL**) to allow the ETW system to generate a new GUID
 for the session.
-
-**Windows Server 2003:** You can start more than one session with the same
-session GUID.
 
 To specify a private logger session, set **Wnode.Guid** member of _Properties_
 to the provider's control GUID, not the private logger session's control GUID.
@@ -295,7 +284,7 @@ following must be true:
   to use this name).
 
 > [!NOTE]
-> A system logger must set the **EnableFlags** member of the
+>Â A system logger must set the **EnableFlags** member of the
 > [EVENT_TRACE_PROPERTIES](/windows/win32/api/evntrace/ns-evntrace-event_trace_properties)
 > structure to indicate which
 > [SystemTraceProvider](/windows/win32/etw/configuring-and-starting-a-systemtraceprovider-session)
@@ -307,7 +296,7 @@ additional restrictions:
 - There can be no more than 8 system loggers active on the same system.
 - System loggers cannot be created within a Windows Server container.
 - System loggers cannot use the **EVENT_TRACE_USE_PAGED_MEMORY** flag.
-- Prior to Windows 10, version 1703, no more than 2 distinct clock types can be
+- Prior to WindowsÂ 10, version 1703, no more than 2 distinct clock types can be
   used simultaneously by any system loggers. For example, if one active system
   logger is using the "CPU cycle counter" clock type, and another active system
   logger is using the "Query performance counter" clock type, then any attempt
@@ -315,7 +304,7 @@ additional restrictions:
   it would require the activation of a third clock type. Because of this
   limitation, Microsoft strongly recommends that system loggers do not use the
   "System time" clock type.
-- Starting with Windows 10, version 1703, the clock type restriction has been
+- Starting with WindowsÂ 10, version 1703, the clock type restriction has been
   removed. All three clock types can now be used simultaneously by system
   loggers.
 
@@ -324,9 +313,6 @@ To specify an NT Kernel Logger session (deprecated), set _InstanceName_ to
 **SystemTraceControlGuid**. If you do not specify the GUID as
 **SystemTraceControlGuid**, ETW will override the GUID value and set it to
 **SystemTraceControlGuid**.
-
-**Windows 2000:** To start the kernel session, the session name must be
-**KERNEL_LOGGER_NAME** and the GUID must be **SystemTraceControlGuid**.
 
 ### Examples
 

--- a/sdk-api-src/content/evntrace/nf-evntrace-starttracew.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-starttracew.md
@@ -26,8 +26,8 @@ ms.keywords:
 req.header: evntrace.h
 req.include-header:
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows 2000 Server [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]
 req.kmdf-ver:
 req.umdf-ver:
 req.ddi-compliance:
@@ -40,11 +40,11 @@ req.type-library:
 req.lib:
   Sechost.lib on Windows 8.1 and Windows Server 2012 R2; Advapi32.lib on
   Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Server 2008, Windows Vista
 req.dll:
   Sechost.dll on Windows 8.1 and Windows Server 2012 R2; Advapi32.dll on
   Windows 8, Windows Server 2012, Windows 7, Windows Server 2008 R2, Windows
-  Server 2008, Windows Vista and Windows XP
+  Server 2008, Windows Vista
 req.irql:
 targetos: Windows
 req.typenames:
@@ -176,8 +176,7 @@ are some common errors and their causes.
   - The **LogFileMode** member of _Properties_ specifies a combination of flags
     that is not valid.
   - The **Wnode.Guid** member is **SystemTraceControlGuid**, but the
-    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**. **Windows 2000:**
-    This case does not return an error.
+    _InstanceName_ parameter is not **KERNEL_LOGGER_NAME**.
 
 - **ERROR_ALREADY_EXISTS**
 


### PR DESCRIPTION
ETW changed drastically in Windows Vista, and comments about  pre-Vista behaviors are no longer helpful and may be adding confusion.

Also, the page had a bad character encoding after each instance of the word "Windows", which shows up on MSDN and in VSCode, but not viewing the file on Github. Saving the file fixed that.