### PR TITLE
Update ns-d3d12-d3d12_feature_data_d3d12_options9.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options9.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options9.md
@@ -63,7 +63,7 @@ Indicates whether or not typed resource 64-bit integer atomics are supported. `t
 
 Type: \_Out\_ **[BOOL](/windows/desktop/winprog/windows-data-types)**
 
-Indicates whether or not typed resource 64-bit integer atomics are supported. `true` if supported, otherwise `false`.
+Indicates whether or not 64-bit integer atomics are supported on `groupshared` variables. `true` if supported, otherwise `false`.
 
 ### -field DerivativesInMeshAndAmplificationShadersSupported
 


### PR DESCRIPTION
Fixed the copy-paste error from the line above. AtomicInt64OnGroupSharedSupported has nothing to do with Typed Resources.