### PR TITLE
Return description for async call

### DIFF
--- a/sdk-api-src/content/icmpapi/nf-icmpapi-icmpsendecho2.md
+++ b/sdk-api-src/content/icmpapi/nf-icmpapi-icmpsendecho2.md
@@ -120,7 +120,7 @@ The time, in milliseconds, to wait for replies.
 When called synchronously, the <b>IcmpSendEcho2</b> function returns the number of replies received and stored in <i>ReplyBuffer</i>. If the return value is zero, call 
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
 
-When called asynchronously, the <b>IcmpSendEcho2</b> function returns ERROR_IO_PENDING to indicate the operation is in progress. The results can be retrieved later when the event specified in the <i>Event</i> parameter signals or the callback function in the <i>ApcRoutine</i> parameter is called.
+When called asynchronously, the <b>IcmpSendEcho2</b> function returns zero, with a subsequent call to <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returning extended error code ERROR_IO_PENDING to indicate the operation is in progress. The results can be retrieved later when the event specified in the <i>Event</i> parameter signals or the callback function in the <i>ApcRoutine</i> parameter is called.
 
 If the return value is zero, call 
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.


### PR DESCRIPTION
When called asynchronously IcmpSendEcho2 returns 0, and the GetLastError() returns ERROR_IO_PENDING. The current description indicates that IcmpSendEcho2  returns ERROR_IO_PENDING directly, which it does not.