### PR TITLE
Update nf-winbase-getfirmwaretype.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-getfirmwaretype.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getfirmwaretype.md
@@ -60,7 +60,7 @@ Retrieves the firmware type of the local computer.
 
 ## -parameters
 
-### -param FirmwareType [in, out]
+### -param FirmwareType [out]
 
 A pointer to a <a href="/windows/desktop/api/winnt/ne-winnt-firmware_type">FIRMWARE_TYPE</a> enumeration.
 


### PR DESCRIPTION
`FirmwareType` is an output parameter to retrieves the result, right?