### PR TITLE
Change parameter value to avoid data type warning

### DIFF
--- a/sdk-api-src/content/wincrypt/nf-wincrypt-certopensystemstorea.md
+++ b/sdk-api-src/content/wincrypt/nf-wincrypt-certopensystemstorea.md
@@ -58,9 +58,9 @@ The <b>CertOpenSystemStore</b> function is a simplified function that opens the 
 
 ### -param hProv [in]
 
-This parameter is not used and should be set to <b>NULL</b>.
+This parameter is not used and should be set to <b>0</b>.
 
-<b>Windows Server 2003 and Windows XP:  </b>A handle of a <a href="/windows/desktop/SecGloss/c-gly">cryptographic service provider</a> (CSP). Set <i>hProv</i> to <b>NULL</b> to use the default CSP. If <i>hProv</i> is not <b>NULL</b>, it must be a CSP handle created by using the <a href="/windows/desktop/api/wincrypt/nf-wincrypt-cryptacquirecontexta">CryptAcquireContext</a> function.This parameter's data type is <b>HCRYPTPROV</b>.
+<b>Windows Server 2003 and Windows XP:  </b>A handle of a <a href="/windows/desktop/SecGloss/c-gly">cryptographic service provider</a> (CSP). Set <i>hProv</i> to <b>0</b> to use the default CSP. If <i>hProv</i> is not <b>0</b>, it must be a CSP handle created by using the <a href="/windows/desktop/api/wincrypt/nf-wincrypt-cryptacquirecontexta">CryptAcquireContext</a> function.This parameter's data type is <b>HCRYPTPROV</b>.
 
 ### -param szSubsystemProtocol [in]
 

--- a/sdk-api-src/content/wincrypt/nf-wincrypt-certopensystemstorew.md
+++ b/sdk-api-src/content/wincrypt/nf-wincrypt-certopensystemstorew.md
@@ -58,9 +58,9 @@ The <b>CertOpenSystemStore</b> function is a simplified function that opens the 
 
 ### -param hProv [in]
 
-This parameter is not used and should be set to <b>NULL</b>.
+This parameter is not used and should be set to <b>0</b>.
 
-<b>Windows Server 2003 and Windows XP:  </b>A handle of a <a href="/windows/desktop/SecGloss/c-gly">cryptographic service provider</a> (CSP). Set <i>hProv</i> to <b>NULL</b> to use the default CSP. If <i>hProv</i> is not <b>NULL</b>, it must be a CSP handle created by using the <a href="/windows/desktop/api/wincrypt/nf-wincrypt-cryptacquirecontexta">CryptAcquireContext</a> function.This parameter's data type is <b>HCRYPTPROV</b>.
+<b>Windows Server 2003 and Windows XP:  </b>A handle of a <a href="/windows/desktop/SecGloss/c-gly">cryptographic service provider</a> (CSP). Set <i>hProv</i> to <b>0</b> to use the default CSP. If <i>hProv</i> is not <b>0</b>, it must be a CSP handle created by using the <a href="/windows/desktop/api/wincrypt/nf-wincrypt-cryptacquirecontexta">CryptAcquireContext</a> function.This parameter's data type is <b>HCRYPTPROV</b>.
 
 ### -param szSubsystemProtocol [in]
 


### PR DESCRIPTION
The parameter `hProv` is of data type `HCRYPTPROV_LEGACY` which is `ULONG_PTR` which is `unsigned long long`. Thus when passing `NULL` as `hProv` to `CertOpenSystemStoreA` or `CertOpenSystemStoreW`, this will create a warning regarding incompatible pointer to integer conversion. Since `NULL` is just zero casted to `void *`, passing zero is an acceptable substitution.