### PR TITLE
IAudioClient3::InitializeSharedAudioStream() returns AUDCLNT_E_INVALID_STREAM_FLAG if any flag other than AUDCLNT_STREAMFLAGS_EVENTCALLBACK is specified

### DIFF
--- a/sdk-api-src/content/audioclient/nf-audioclient-iaudioclient3-initializesharedaudiostream.md
+++ b/sdk-api-src/content/audioclient/nf-audioclient-iaudioclient3-initializesharedaudiostream.md
@@ -61,8 +61,6 @@ Type: <b>DWORD</b>
 Flags to control creation of the stream. The client should set this parameter to 0 or to the bitwise OR of one or more of the supported  <a href="/windows/desktop/CoreAudio/audclnt-streamflags-xxx-constants">AUDCLNT_STREAMFLAGS_XXX Constants</a> or   <a href="/windows/desktop/CoreAudio/audclnt-sessionflags-xxx-constants">AUDCLNT_SESSIONFLAGS_XXX Constants</a>. The supported <a href="/windows/desktop/CoreAudio/audclnt-streamflags-xxx-constants">AUDCLNT_STREAMFLAGS_XXX Constants</a> for this parameter when using this method are: 
 
 - AUDCLNT_STREAMFLAGS_EVENTCALLBACK
-- AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
-- AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY
 
 ### -param PeriodInFrames [in]
 


### PR DESCRIPTION
Related: https://social.msdn.microsoft.com/Forums/en-US/windowspro-audiodevelopment/thread/55b39a3d-0f2a-4f05-ac66-5c5abf32ec64