### PR TITLE
Clarify sRGB and 2.2 gamma mistake

### DIFF
--- a/sdk-api-src/content/dxgiformat/ne-dxgiformat-dxgi_format.md
+++ b/sdk-api-src/content/dxgiformat/ne-dxgiformat-dxgi_format.md
@@ -774,7 +774,7 @@ Each enumeration value contains a format modifier which describes the data type.
 <td>
 Standard RGB data, which roughly displays colors in a linear ramp of luminosity levels such that an average observer, under average viewing conditions, can view them on an average display.
 
-All 0's maps to 0.0f, and all 1's maps to 1.0f. The sequence of unsigned integer encodings between all 0's and all 1's represent a nonlinear progression in the floating-point interpretation of the numbers between 0.0f to 1.0f. For more detail, see the SRGB color standard, IEC 61996-2-1, at IEC (International Electrotechnical Commission).</p>Conversion to or from sRGB space is automatically done by D3DX10 or D3DX9 texture-load functions. If a format with _SRGB has an A channel, the A channel is stored in Gamma 1.0f data; the R, G, and B channels in the format are stored in Gamma 2.2f data.</td>
+All 0's maps to 0.0f, and all 1's maps to 1.0f. The sequence of unsigned integer encodings between all 0's and all 1's represent a nonlinear progression in the floating-point interpretation of the numbers between 0.0f to 1.0f. For more detail, see the SRGB color standard, IEC 61996-2-1, at IEC (International Electrotechnical Commission).</p>Conversion to or from sRGB space is automatically done by D3DX10 or D3DX9 texture-load functions. If a format with _SRGB has an A channel, the A channel is stored in Gamma 1.0f data; the R, G, and B channels in the format are stored in sRGB Gamma (linear segment + 2.4 power) data.</td>
 </tr>
 <tr>
 <td>_TYPELESS</td>


### PR DESCRIPTION
sRGB gamma and 2.2 power gamma are not the same. sRGB has a linear segment at the beginning and then uses a 2.4 pow curve.
sRGB textures is indeed stored in sRGB on the GPU, not simple 2.2 pow.

This is pretty much the same change I had already made here: https://github.com/MicrosoftDocs/sdk-api/pull/1457