### PR TITLE
Update nf-winuser-toasciiex.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-toascii.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toascii.md
@@ -56,6 +56,9 @@ Translates the specified virtual-key code and keyboard state to the correspondin
 
 To specify a handle to the keyboard layout to use to translate the specified code, use the <a href="/windows/desktop/api/winuser/nf-winuser-toasciiex">ToAsciiEx</a> function.
 
+> [!NOTE]
+> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> may emit several characters and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
+
 ## -parameters
 
 ### -param uVirtKey [in]

--- a/sdk-api-src/content/winuser/nf-winuser-toascii.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toascii.md
@@ -97,7 +97,7 @@ This parameter must be 1 if a menu is active, or 0 otherwise.
 
 Type: <b>int</b>
 
-If the specified key is a dead key, the return value is negative. Otherwise, it is one of the following values.
+The return value is one of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/winuser/nf-winuser-toascii.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toascii.md
@@ -85,7 +85,7 @@ The low bit, if set, indicates that the key is toggled on. In this function, onl
 
 Type: <b>LPWORD</b>
 
-The buffer that receives the translated character or characters.
+The buffer that receives the translated character or characters. The low-order byte contains first character and the high-order byte contains second character, if present.
 
 ### -param uFlags [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-toascii.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toascii.md
@@ -57,7 +57,7 @@ Translates the specified virtual-key code and keyboard state to the correspondin
 To specify a handle to the keyboard layout to use to translate the specified code, use the <a href="/windows/desktop/api/winuser/nf-winuser-toasciiex">ToAsciiEx</a> function.
 
 > [!NOTE]
-> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> may emit several characters and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
+> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
 
 ## -parameters
 

--- a/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
@@ -85,7 +85,7 @@ The low bit, if set, indicates that the key is toggled on. In this function, onl
 
 Type: <b>LPWORD</b>
 
-A pointer to the buffer that receives the translated character or characters.
+A pointer to the buffer that receives the translated character or characters. The low-order byte contains first character and the high-order byte contains second character, if present.
 
 ### -param uFlags [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
@@ -57,7 +57,7 @@ api_name:
 Translates the specified virtual-key code and keyboard state to the corresponding character or characters. The function translates the code using the input language and physical keyboard layout identified by the input locale identifier.
 
 > [!NOTE]
-> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> may emit several characters and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
+> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
 
 ## -parameters
 

--- a/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
@@ -56,6 +56,9 @@ api_name:
 
 Translates the specified virtual-key code and keyboard state to the corresponding character or characters. The function translates the code using the input language and physical keyboard layout identified by the input locale identifier.
 
+> [!NOTE]
+> This method may not work properly with some <a href="/globalization/windows-keyboard-layouts">keyboard layouts</a> may emit several characters and/or supplementary Unicode characters on a single key press. It is highly recommended to use the <a href="/windows/win32/api/winuser/nf-winuser-tounicode">ToUnicode</a> or <a href="/windows/win32/api/winuser/nf-winuser-tounicodeex">ToUnicodeEx</a> methods that handles such cases properly.
+
 ## -parameters
 
 ### -param uVirtKey [in]
@@ -82,7 +85,7 @@ The low bit, if set, indicates that the key is toggled on. In this function, onl
 
 Type: <b>LPWORD</b>
 
-A pointer to the buffer that receives the translated character or characters.
+A pointer to the buffer that receives the translated character or characters. 
 
 ### -param uFlags [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
@@ -85,7 +85,7 @@ The low bit, if set, indicates that the key is toggled on. In this function, onl
 
 Type: <b>LPWORD</b>
 
-A pointer to the buffer that receives the translated character or characters. 
+A pointer to the buffer that receives the translated character or characters.
 
 ### -param uFlags [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-toasciiex.md
@@ -103,7 +103,7 @@ Input locale identifier to use to translate the code. This parameter can be any 
 
 Type: <b>int</b>
 
-If the specified key is a dead key, the return value is negative. Otherwise, it is one of the following values.
+The return value is one of the following values.
 
 <table>
 <tr>


### PR DESCRIPTION
Seems ToAscii never returns negative value.
Add a note to use ToUnicode instead - it supports ligatures, dead chars and supplementary Unicode characters.
Clarify `lpChar` param - that it only contains two character bytes packed into **single** `WORD` value.