### PR TITLE
Update ns-commctrl-nmtreevieww.md

### DIFF
--- a/sdk-api-src/content/commctrl/ns-commctrl-nmtreevieww.md
+++ b/sdk-api-src/content/commctrl/ns-commctrl-nmtreevieww.md
@@ -92,17 +92,17 @@ For the possible action flag values, see <a href="/windows/desktop/Controls/tvm-
 
 ### -field itemOld
 
-Type: <b><a href="/windows/desktop/api/commctrl/ns-commctrl-tvitema">TVITEM</a></b>
+Type: <b><a href="/windows/desktop/api/commctrl/ns-commctrl-tvitemw">TVITEM</a></b>
 
 
-<a href="/windows/desktop/api/commctrl/ns-commctrl-tvitema">TVITEM</a> structure that contains information about the old item state. This member is zero for notification messages that do not use it.
+<a href="/windows/desktop/api/commctrl/ns-commctrl-tvitemw">TVITEM</a> structure that contains information about the old item state. This member is zero for notification messages that do not use it.
 
 ### -field itemNew
 
-Type: <b><a href="/windows/desktop/api/commctrl/ns-commctrl-tvitema">TVITEM</a></b>
+Type: <b><a href="/windows/desktop/api/commctrl/ns-commctrl-tvitemw">TVITEM</a></b>
 
 
-<a href="/windows/desktop/api/commctrl/ns-commctrl-tvitema">TVITEM</a> structure that contains information about the new item state. This member is zero for notification messages that do not use it.
+<a href="/windows/desktop/api/commctrl/ns-commctrl-tvitemw">TVITEM</a> structure that contains information about the new item state. This member is zero for notification messages that do not use it.
 
 ### -field ptDrag
 

--- a/sdk-api-src/content/commctrl/ns-commctrl-nmtreevieww.md
+++ b/sdk-api-src/content/commctrl/ns-commctrl-nmtreevieww.md
@@ -63,10 +63,10 @@ Contains information about a tree-view notification message. This structure is i
 
 ### -field hdr
 
-Type: <b><a href="/windows/desktop/api/richedit/ns-richedit-nmhdr">NMHDR</a></b>
+Type: <b><a href="/windows/win32/api/winuser/ns-winuser-nmhdr">NMHDR</a></b>
 
 
-<a href="/windows/desktop/api/richedit/ns-richedit-nmhdr">NMHDR</a> structure that contains information about this notification message.
+<a href="/windows/win32/api/winuser/ns-winuser-nmhdr">NMHDR</a> structure that contains information about this notification message.
 
 ### -field action
 


### PR DESCRIPTION
Changed link to NMHDR and TVITEM structures to reflect Unicode versions.