### PR TITLE
Update ns-richedit-nmhdr.md

### DIFF
--- a/sdk-api-src/content/richedit/ns-richedit-nmhdr.md
+++ b/sdk-api-src/content/richedit/ns-richedit-nmhdr.md
@@ -64,7 +64,7 @@ A window handle to the control sending the message.
 
 ### -field idFrom
 
-Type: <b><a href="/windows/desktop/WinProg/windows-data-types">UINT</a></b>
+Type: <b><a href="/windows/desktop/WinProg/windows-data-types">UINT_PTR</a></b>
 
 An identifier of the control sending the message.
 


### PR DESCRIPTION
Changed `idFrom` type to accurately reflect other references to the same member of the `NMHDR` structure. See [NMHDR structure (winuser.h)](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-nmhdr).