### PR TITLE
Correct description for flag OFN_NOCHANGEDIR

### DIFF
--- a/sdk-api-src/content/commdlg/ns-commdlg-openfilenamea.md
+++ b/sdk-api-src/content/commdlg/ns-commdlg-openfilenamea.md
@@ -361,8 +361,6 @@ For old-style dialog boxes, this flag causes the dialog box to use long file nam
 <td width="60%">
 Restores the current directory to its original value if the user changed the directory while searching for files.
 
- This flag is ineffective for <a href="/windows/desktop/api/commdlg/nf-commdlg-getopenfilenamea">GetOpenFileName</a>.
-
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
> Restores the current directory to its original value if the user changed the directory while searching for files.
This flag is ineffective for [GetOpenFileName](https://learn.microsoft.com/en-us/windows/desktop/api/commdlg/nf-commdlg-getopenfilenamea).

The original text states that `OFN_NOCHANGEDIR` is ineffective for [GetOpenFileName](https://learn.microsoft.com/zh-cn/windows/win32/api/commdlg/nf-commdlg-getopenfilenamea), but actually it works.

I'm not sure if it is indeed ineffective in some lower Windows versions, but it does work on Win10. Perhaps a more comprehensive description could be considered.

Affected Pages:

- OPENFILENAMEA - https://learn.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea
- OPENFILENAMEW - https://learn.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamew