### PR TITLE
Update nf-libloaderapi-enumresourcelanguagesexa.md

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcelanguagesexa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcelanguagesexa.md
@@ -92,7 +92,7 @@ The name of the resource for which the language is being enumerated. Alternately
 
 Type: <b>ENUMRESLANGPROC</b>
 
-A pointer to the callback function to be called for each enumerated resource language. For more information, see <a href="https://msdn.microsoft.com/58c1a42d-15d2-4157-8c57-f9b1d389b917">EnumResLangProc</a>.
+A pointer to the callback function to be called for each enumerated resource language. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms648033(v=vs.85)">EnumResLangProc</a>.
 
 ### -param lParam [in]
 
@@ -214,7 +214,7 @@ For an example, see <a href="/windows-hardware/drivers/wdf/creating-a-resource-r
 
 
 
-<a href="https://msdn.microsoft.com/58c1a42d-15d2-4157-8c57-f9b1d389b917">EnumResLangProc</a>
+<a href="/previous-versions/windows/desktop/legacy/ms648033(v=vs.85)">EnumResLangProc</a>
 
 
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcelanguagesexw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcelanguagesexw.md
@@ -92,7 +92,7 @@ The name of the resource for which the language is being enumerated. Alternately
 
 Type: <b>ENUMRESLANGPROC</b>
 
-A pointer to the callback function to be called for each enumerated resource language. For more information, see <a href="https://msdn.microsoft.com/58c1a42d-15d2-4157-8c57-f9b1d389b917">EnumResLangProc</a>.
+A pointer to the callback function to be called for each enumerated resource language. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms648033(v=vs.85)">EnumResLangProc</a>.
 
 ### -param lParam [in]
 
@@ -214,7 +214,7 @@ For an example, see <a href="/windows-hardware/drivers/wdf/creating-a-resource-r
 
 
 
-<a href="https://msdn.microsoft.com/58c1a42d-15d2-4157-8c57-f9b1d389b917">EnumResLangProc</a>
+<a href="/previous-versions/windows/desktop/legacy/ms648033(v=vs.85)">EnumResLangProc</a>
 
 
 


### PR DESCRIPTION
fix link

`<a href="https://msdn.microsoft.com/58c1a42d-15d2-4157-8c57-f9b1d389b917">EnumResLangProc</a>` -> `<a href="/previous-versions/windows/desktop/legacy/ms648033(v=vs.85)">EnumResLangProc</a>`

Actually `EnumResLangProc` page should be copied to `sdk-api-src/content/libloaderapi/` folder from `/previous-versions/` part of the docs. Like already done with `EnumResTypeProc` and `EnumResNameProc` docs.