### PR TITLE
Update nf-winuser-createiconfromresource.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -74,7 +74,9 @@ The size, in bytes, of the set of bits pointed to by the <i>presbits</i> paramet
 
 Type: <b>BOOL</b>
 
-Indicates whether an icon or a cursor is to be created. If this parameter is <b>TRUE</b>, an icon is to be created. If it is <b>FALSE</b>, a cursor is to be created.
+Indicates whether an icon or a cursor is to be created. If this parameter is <b>TRUE</b>, an icon is to be created. If it is <b>FALSE</b>, a cursor is to be created. 
+
+The <a href="/windows/win32/menurc/localheader">LOCALHEADER</a> structure defines cursor hotspot and is the first data read from the cursor resource bits.
 
 ### -param dwVer [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -60,7 +60,7 @@ To specify a desired height or width, use the <a href="/windows/desktop/api/winu
 
 Type: <b>PBYTE</b>
 
-The buffer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions. If you provide a value in any other way, make sure that the pointer value is DWORD-aligned.
+The DWORD-aligned buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
 ### -param dwResSize [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -60,7 +60,7 @@ To specify a desired height or width, use the <a href="/windows/desktop/api/winu
 
 Type: <b>PBYTE</b>
 
-The buffer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The buffer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions. If you provide a value in any other way, make sure that the pointer value is DWORD-aligned.
 
 ### -param dwResSize [in]
 
@@ -90,7 +90,7 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 ## -remarks
 
-The <b>CreateIconFromResource</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system. 
+The <b>CreateIconFromResource</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system.
 
 The <b>CreateIconFromResource</b> function calls <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a> passing <code>LR_DEFAULTSIZE|LR_SHARED</code> as flags.
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -90,7 +90,7 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 ## -remarks
 
-The <b>CreateIconFromResource</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system.
+The <b>CreateIconFromResource</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system. 
 
 The <b>CreateIconFromResource</b> function calls <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a> passing <code>LR_DEFAULTSIZE|LR_SHARED</code> as flags.
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -62,6 +62,8 @@ Type: <b>PBYTE</b>
 
 The DWORD-aligned buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
+See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
+
 ### -param dwResSize [in]
 
 Type: <b>DWORD</b>

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -74,6 +74,8 @@ Type: <b>BOOL</b>
 
 Indicates whether an icon or a cursor is to be created. If this parameter is <b>TRUE</b>, an icon is to be created. If it is <b>FALSE</b>, a cursor is to be created.
 
+The <a href="/windows/win32/menurc/localheader">LOCALHEADER</a> structure defines cursor hotspot and is the first data read from the cursor resource bits.
+
 ### -param dwVer [in]
 
 Type: <b>DWORD</b>

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -58,7 +58,7 @@ Creates an icon or cursor from resource bits describing the icon.
 
 Type: <b>PBYTE</b>
 
-The icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions. If you provide a value in any other way, make sure that the pointer value is DWORD-aligned.
+The DWORD-aligned buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
 ### -param dwResSize [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -60,6 +60,8 @@ Type: <b>PBYTE</b>
 
 The DWORD-aligned buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
+See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
+
 ### -param dwResSize [in]
 
 Type: <b>DWORD</b>

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -58,7 +58,7 @@ Creates an icon or cursor from resource bits describing the icon.
 
 Type: <b>PBYTE</b>
 
-The icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions. If you provide a value in any other way, make sure that the pointer value is DWORD-aligned.
 
 ### -param dwResSize [in]
 


### PR DESCRIPTION
Mention that `presbits` pointer should be DWORD-aligned.

Reference:
>A resource header is DWORD-aligned in the file

https://learn.microsoft.com/en-us/windows/win32/menurc/resource-file-formats

Also:
https://github.com/dotnet/winforms/blob/923620f28a1b16c057dd21a05fe7354811d2e667/src/System.Drawing.Common/src/System/Drawing/Icon.cs#L613-L624