### PR TITLE
Link directly to Window Class Styles page

### DIFF
--- a/sdk-api-src/content/winuser/ns-winuser-wndclassexa.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassexa.md
@@ -73,7 +73,7 @@ The size, in bytes, of this structure. Set this member to <code>sizeof(WNDCLASSE
 
 Type: <b>UINT</b>
 
-The class style(s). This member can be any combination of the <a href="/windows/desktop/winmsg/about-window-classes">Class Styles</a>.
+The class style(s). This member can be any combination of the <a href="/windows/win32/winmsg/window-class-styles">Class Styles</a>.
 
 ### -field lpfnWndProc
 


### PR DESCRIPTION
Cut out the middleman and directly link to the page with the list of styles.