### PR TITLE
Update links that reference SFGAO to point to the correct page

### DIFF
--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetattributesfromdataobject.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetattributesfromdataobject.md
@@ -66,13 +66,13 @@ The data object from which to retrieve the information.
 
 Type: <b>DWORD</b>
 
-One or more of the <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">SFGAO</a> flags that indicate which pieces of information the calling application wants to retrieve.
+One or more of the <a href="/windows/desktop/shell/sfgao">SFGAO</a> flags that indicate which pieces of information the calling application wants to retrieve.
 
 ### -param pdwAttributes [out, optional]
 
 Type: <b>DWORD*</b>
 
-A pointer to a <b>DWORD</b> value that, when this function returns successfully, receives one or more <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">SFGAO</a> flags that indicate the attributes, among those requested, that are common to all items in <i>pdo</i>. This pointer can be <b>NULL</b> if this information is not needed.
+A pointer to a <b>DWORD</b> value that, when this function returns successfully, receives one or more <a href="/windows/desktop/shell/sfgao">SFGAO</a> flags that indicate the attributes, among those requested, that are common to all items in <i>pdo</i>. This pointer can be <b>NULL</b> if this information is not needed.
 
 ### -param pcItems [out, optional]
 

--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetattributesfromdataobject.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shgetattributesfromdataobject.md
@@ -66,13 +66,13 @@ The data object from which to retrieve the information.
 
 Type: <b>DWORD</b>
 
-One or more of the <a href="/windows/desktop/shell/sfgao">SFGAO</a> flags that indicate which pieces of information the calling application wants to retrieve.
+One or more of the <a href="/windows/win32/shell/sfgao">SFGAO</a> flags that indicate which pieces of information the calling application wants to retrieve.
 
 ### -param pdwAttributes [out, optional]
 
 Type: <b>DWORD*</b>
 
-A pointer to a <b>DWORD</b> value that, when this function returns successfully, receives one or more <a href="/windows/desktop/shell/sfgao">SFGAO</a> flags that indicate the attributes, among those requested, that are common to all items in <i>pdo</i>. This pointer can be <b>NULL</b> if this information is not needed.
+A pointer to a <b>DWORD</b> value that, when this function returns successfully, receives one or more <a href="/windows/win32/shell/sfgao">SFGAO</a> flags that indicate the attributes, among those requested, that are common to all items in <i>pdo</i>. This pointer can be <b>NULL</b> if this information is not needed.
 
 ### -param pcItems [out, optional]
 

--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shparsedisplayname.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shparsedisplayname.md
@@ -80,13 +80,13 @@ The address of a pointer to a variable of type <a href="/windows/desktop/api/sht
 
 Type: <b>SFGAOF</b>
 
-A <b>ULONG</b> value that specifies the attributes to query. To query for one or more attributes, initialize this parameter with the flags that represent the attributes of interest. For a list of available SFGAO flags, see <a href="/windows/desktop/shell/sfgao">SFGAO</a>.
+A <b>ULONG</b> value that specifies the attributes to query. To query for one or more attributes, initialize this parameter with the flags that represent the attributes of interest. For a list of available SFGAO flags, see <a href="/windows/win32/shell/sfgao">SFGAO</a>.
 
 ### -param psfgaoOut [out, optional]
 
 Type: <b>SFGAOF*</b>
 
-A pointer to a <b>ULONG</b>. On return, those attributes that are true for the object and were requested in <i>sfgaoIn</i> are set. An object's attribute flags can be zero or a combination of SFGAO flags. For a list of available SFGAO flags, see <a href="/windows/desktop/shell/sfgao">SFGAO</a>.
+A pointer to a <b>ULONG</b>. On return, those attributes that are true for the object and were requested in <i>sfgaoIn</i> are set. An object's attribute flags can be zero or a combination of SFGAO flags. For a list of available SFGAO flags, see <a href="/windows/win32/shell/sfgao">SFGAO</a>.
 
 ## -returns
 

--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-shparsedisplayname.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-shparsedisplayname.md
@@ -80,13 +80,13 @@ The address of a pointer to a variable of type <a href="/windows/desktop/api/sht
 
 Type: <b>SFGAOF</b>
 
-A <b>ULONG</b> value that specifies the attributes to query. To query for one or more attributes, initialize this parameter with the flags that represent the attributes of interest. For a list of available SFGAO flags, see <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">IShellFolder::GetAttributesOf</a>.
+A <b>ULONG</b> value that specifies the attributes to query. To query for one or more attributes, initialize this parameter with the flags that represent the attributes of interest. For a list of available SFGAO flags, see <a href="/windows/desktop/shell/sfgao">SFGAO</a>.
 
 ### -param psfgaoOut [out, optional]
 
 Type: <b>SFGAOF*</b>
 
-A pointer to a <b>ULONG</b>. On return, those attributes that are true for the object and were requested in <i>sfgaoIn</i> are set. An object's attribute flags can be zero or a combination of SFGAO flags. For a list of available SFGAO flags, see <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">IShellFolder::GetAttributesOf</a>.
+A pointer to a <b>ULONG</b>. On return, those attributes that are true for the object and were requested in <i>sfgaoIn</i> are set. An object's attribute flags can be zero or a combination of SFGAO flags. For a list of available SFGAO flags, see <a href="/windows/desktop/shell/sfgao">SFGAO</a>.
 
 ## -returns
 

--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellitem-bindtohandler.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellitem-bindtohandler.md
@@ -100,7 +100,7 @@ Restricts usage to <a href="/windows/desktop/api/objidl/nn-objidl-istream">IStre
 
 #### BHID_LinkTargetItem
 
-CLSID_ShellItem is initialized with the target of this item (can only be SFGAO_LINK). See <a href="/windows/desktop/shell/sfgao">SFGAO</a> for a description of SFGAO_LINK.
+CLSID_ShellItem is initialized with the target of this item (can only be SFGAO_LINK). See <a href="/windows/win32/shell/sfgao">SFGAO</a> for a description of SFGAO_LINK.
 
 
 

--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellitem-bindtohandler.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellitem-bindtohandler.md
@@ -100,7 +100,7 @@ Restricts usage to <a href="/windows/desktop/api/objidl/nn-objidl-istream">IStre
 
 #### BHID_LinkTargetItem
 
-CLSID_ShellItem is initialized with the target of this item (can only be SFGAO_LINK). See <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">GetAttributesOf</a> for a description of SFGAO_LINK.
+CLSID_ShellItem is initialized with the target of this item (can only be SFGAO_LINK). See <a href="/windows/desktop/shell/sfgao">SFGAO</a> for a description of SFGAO_LINK.
 
 
 


### PR DESCRIPTION
Currently, a few pages indicate that [IShellFolder::GetAttributesOf](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof) is the source of truth re: the SFGAO bitfields, but no information is provided on that page. I updated these pages to point to [SFGAO](https://learn.microsoft.com/en-us/windows/win32/shell/sfgao) page instead.