### PR TITLE
Update ns-d3d12-d3d12_buffer_srv.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_srv.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_buffer_srv.md
@@ -63,7 +63,7 @@ The number of elements in the resource.
 
 ### -field StructureByteStride
 
-The size of each element in the buffer structure (in bytes) when the buffer represents a structured buffer.
+The size of each element in the buffer structure (in bytes) when the buffer represents a structured buffer.  The size must match the struct size declared in shaders that access the view.
 
 ### -field Flags
 


### PR DESCRIPTION
Clarify that structured buffer view stride must match shader struct size.