### PR TITLE
ns-verrsrc-vs_fixedfileinfo.md: dwFileDateMS/dwFileDateLS

### DIFF
--- a/sdk-api-src/content/verrsrc/ns-verrsrc-vs_fixedfileinfo.md
+++ b/sdk-api-src/content/verrsrc/ns-verrsrc-vs_fixedfileinfo.md
@@ -686,11 +686,15 @@ Type: <b>DWORD</b>
 
 The most significant 32 bits of the file's 64-bit binary creation date and time stamp.
 
+This field is not used and should be zero.
+
 ### -field dwFileDateLS
 
 Type: <b>DWORD</b>
 
 The least significant 32 bits of the file's 64-bit binary creation date and time stamp.
+
+This field is not used and should be zero.
 
 ## -see-also
 


### PR DESCRIPTION
In practice, `dwFileDateMS` and `dwFileDateLS` are almost never used and are expected to be zero.

From what I can gather, Microsoft's own build tools have never set them to a non-zero value, going back to Windows 3.x. It appears very few third party tools do so either. While executables having non-zero values for this field reputedly exist, nobody seems to be able to produce an example of one.

And yet, the documentation doesn't mention this significant fact–I think it should.