### PR TITLE
Update ni-winioctl-fsctl_enum_usn_data.md

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_enum_usn_data.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_enum_usn_data.md
@@ -119,7 +119,7 @@ To retrieve a handle to a volume, call
      <a href="/windows/desktop/api/fileapi/nf-fileapi-createfilea">CreateFile</a> with the 
      <i>lpFileName</i> parameter set to a string in the following form:
 
-\\.&#92;<i>X</i>:
+\\\\.&#92;<i>X</i>:
 
 In the preceding string, <i>X</i> is the letter identifying the drive on which the volume 
      appears. The volume must be NTFS.


### PR DESCRIPTION
Backslash was escaped, so only 1 appeared
![image](https://github.com/MicrosoftDocs/sdk-api/assets/69343917/d3447a4e-e121-46b9-95d8-97984fc1a27e)
