### PR TITLE
Mark UWP API's allowed in Windows 10240

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-createsemaphorea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createsemaphorea.md
@@ -11,8 +11,8 @@ ms.keywords: CreateSemaphoreA, CreateSemaphoreA function, CreateSemaphoreW, base
 req.header: winbase.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows XP [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2003 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/winbase/nf-winbase-createsemaphorea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createsemaphorea.md
@@ -11,8 +11,8 @@ ms.keywords: CreateSemaphoreA, CreateSemaphoreA function, CreateSemaphoreW, base
 req.header: winbase.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows XP [desktop apps only]
-req.target-min-winversvr: Windows Server 2003 [desktop apps only]
+req.target-min-winverclnt: Windows XP [desktop apps | UWP apps]
+req.target-min-winversvr: Windows Server 2003 [desktop apps | UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/winbase/nf-winbase-createsemaphoreexa.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createsemaphoreexa.md
@@ -11,8 +11,8 @@ ms.keywords: CreateSemaphoreExA, CreateSemaphoreExA function, CreateSemaphoreExW
 req.header: winbase.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2008 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/winbase/nf-winbase-createsemaphoreexa.md
+++ b/sdk-api-src/content/winbase/nf-winbase-createsemaphoreexa.md
@@ -11,8 +11,8 @@ ms.keywords: CreateSemaphoreExA, CreateSemaphoreExA function, CreateSemaphoreExW
 req.header: winbase.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista [desktop apps only]
-req.target-min-winversvr: Windows Server 2008 [desktop apps only]
+req.target-min-winverclnt: Windows Vista [desktop apps | UWP apps]
+req.target-min-winversvr: Windows Server 2008 [desktop apps | UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
These API's are allowed in UWP since the first Windows 10 build.