### PR TITLE
Use actual space in the windows version value

### DIFF
--- a/sdk-api-src/content/ioapiset/nf-ioapiset-deviceiocontrol.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-deviceiocontrol.md
@@ -10,8 +10,8 @@ ms.keywords: DeviceIoControl, DeviceIoControl function, _win32_deviceiocontrol, 
 req.header: ioapiset.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows XP
-req.target-min-winversvr: Windows Server 2003
+req.target-min-winverclnt: Windows XP
+req.target-min-winversvr: Windows Server 2003
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-processidtosessionid.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-processidtosessionid.md
@@ -11,8 +11,8 @@ ms.keywords: ProcessIdToSessionId, ProcessIdToSessionId function [Remote Desktop
 req.header: processthreadsapi.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista
-req.target-min-winversvr: Windows Server 2008
+req.target-min-winverclnt: Windows Vista
+req.target-min-winversvr: Windows Server 2008
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
It seems to be using `0xA0` (non breaking space) which makes it slighty harder to parse and compare.