### PR TITLE
Update icon and cursor API docs

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param lims [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
@@ -58,40 +58,19 @@ Loads a specified icon resource with a client-specified system metric.
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HINSTANCE</a></b>
 
-A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
+A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlew">GetModuleHandle</a>.
 
-To load a predefined icon or a standalone icon file, set this parameter to <b>NULL</b>.
+To load a predefined system icon or a standalone icon file, set this parameter to <b>NULL</b>.
 
 ### -param pszName [in]
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">PCWSTR</a></b>
 
-A pointer to a null-terminated, Unicode buffer that contains location information about the icon to load. It is interpreted as follows:
+A pointer to a null-terminated, Unicode buffer that contains location information about the icon to load. 
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> can specify one of two things.
+If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-<ol>
-<li>The name of a standalone icon (.ico) file.</li>
-<li>The identifier of a predefined icon to load. These identifiers are recognized:</li>
-
-<ul>
-<li>IDI_APPLICATION</li>
-<li>IDI_INFORMATION</li>
-<li>IDI_ERROR</li>
-<li>IDI_WARNING</li>
-<li>IDI_SHIELD</li>
-<li>IDI_QUESTION
-
-To pass these constants to the <b>LoadIconMetric</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the IDI_ERROR icon, pass <code>MAKEINTRESOURCE(IDI_ERROR)</code> as the <i>pszName</i> parameter and <b>NULL</b> as the <i>hinst</i> parameter.
-</ul>
-</ol>
-
-If <i>hinst</i> is non-null, <i>pszName</i> can specify one of two things.
-
-<ol>
-<li>The name of the icon resource, if the icon resource is to be loaded by name from the module.</li>
-<li>The icon ordinal, if the icon resource is to be loaded by ordinal from the module. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro.</li>
-</ol>
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param lims [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param cx [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
@@ -2,12 +2,12 @@
 UID: NF:commctrl.LoadIconWithScaleDown
 title: LoadIconWithScaleDown function (commctrl.h)
 description: Loads an icon. If the icon is not a standard size, this function scales down a larger image instead of scaling up a smaller image.
-helpviewer_keywords: ["IDI_APPLICATION","IDI_ASTERISK","IDI_ERROR","IDI_EXCLAMATION","IDI_HAND","IDI_INFORMATION","IDI_QUESTION","IDI_SHIELD","IDI_WARNING","IDI_WINLOGO","LoadIconWithScaleDown","LoadIconWithScaleDown function [Windows Controls]","_shell_LoadIconWithScaleDown","_shell_LoadIconWithScaleDown_cpp","commctrl/LoadIconWithScaleDown","controls.LoadIconWithScaleDown","controls._shell_LoadIconWithScaleDown"]
+helpviewer_keywords: ["LoadIconWithScaleDown","LoadIconWithScaleDown function [Windows Controls]","_shell_LoadIconWithScaleDown","_shell_LoadIconWithScaleDown_cpp","commctrl/LoadIconWithScaleDown","controls.LoadIconWithScaleDown","controls._shell_LoadIconWithScaleDown"]
 old-location: controls\LoadIconWithScaleDown.htm
 tech.root: Controls
 ms.assetid: VS|Controls|~\controls\common\functions\loadiconwithscaledown.htm
 ms.date: 12/05/2018
-ms.keywords: IDI_APPLICATION, IDI_ASTERISK, IDI_ERROR, IDI_EXCLAMATION, IDI_HAND, IDI_INFORMATION, IDI_QUESTION, IDI_SHIELD, IDI_WARNING, IDI_WINLOGO, LoadIconWithScaleDown, LoadIconWithScaleDown function [Windows Controls], _shell_LoadIconWithScaleDown, _shell_LoadIconWithScaleDown_cpp, commctrl/LoadIconWithScaleDown, controls.LoadIconWithScaleDown, controls._shell_LoadIconWithScaleDown
+ms.keywords: LoadIconWithScaleDown, LoadIconWithScaleDown function [Windows Controls], _shell_LoadIconWithScaleDown, _shell_LoadIconWithScaleDown_cpp, commctrl/LoadIconWithScaleDown, controls.LoadIconWithScaleDown, controls._shell_LoadIconWithScaleDown
 req.header: commctrl.h
 req.include-header: 
 req.target-type: Windows
@@ -58,11 +58,9 @@ Loads an icon. If the icon is not a standard size, this function scales down a l
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HINSTANCE</a></b>
 
-A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandleexa">GetModuleHandle</a>.
+A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
 
-                    
-
-To load a predefined icon or a standalone icon file, set this parameter to <b>NULL</b>.
+To load a predefined system icon or a standalone icon file, set this parameter to <b>NULL</b>.
 
 ### -param pszName [in]
 
@@ -70,120 +68,9 @@ Type: <b><a href="/windows/desktop/WinProg/windows-data-types">PCWSTR</a></b>
 
 A pointer to a null-terminated, Unicode buffer that contains location information about the icon to load. 
 
+If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-                    
-
-If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i>  specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro.
-
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the identifier of a predefined icon to load. The following identifiers are recognized. To pass these constants to the <b>LoadIconWithScaleDown</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the IDI_ERROR icon, pass <code>MAKEINTRESOURCE(IDI_ERROR)</code> as the <i>pszName</i> parameter and <b>NULL</b> as the <i>hinst</i> parameter.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-</dl>
-</td>
-<td width="60%">
-Default application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-</dl>
-</td>
-<td width="60%">
-Same as IDI_INFORMATION.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ERROR"></a><a id="idi_error"></a><dl>
-<dt><b>IDI_ERROR</b></dt>
-</dl>
-</td>
-<td width="60%">
-Hand-shaped icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-</dl>
-</td>
-<td width="60%">
-Same as IDI_WARNING.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-</dl>
-</td>
-<td width="60%">
-Same as IDI_ERROR. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_INFORMATION"></a><a id="idi_information"></a><dl>
-<dt><b>IDI_INFORMATION</b></dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-</dl>
-</td>
-<td width="60%">
-Question mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WARNING"></a><a id="idi_warning"></a><dl>
-<dt><b>IDI_WARNING</b></dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-</dl>
-</td>
-<td width="60%">
-Windows logo icon. 
-						
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_SHIELD"></a><a id="idi_shield"></a><dl>
-<dt><b>IDI_SHIELD</b></dt>
-</dl>
-</td>
-<td width="60%">
-Security Shield icon.
-
-</td>
-</tr>
-</table>
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param cx [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfo.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfo.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.GetIconInfo
 title: GetIconInfo function (winuser.h)
 description: Retrieves information about the specified icon or cursor.
-helpviewer_keywords: ["GetIconInfo","GetIconInfo function [Menus and Other Resources]","IDC_APPSTARTING","IDC_ARROW","IDC_CROSS","IDC_HAND","IDC_HELP","IDC_IBEAM","IDC_NO","IDC_SIZEALL","IDC_SIZENESW","IDC_SIZENS","IDC_SIZENWSE","IDC_SIZEWE","IDC_UPARROW","IDC_WAIT","IDI_APPLICATION","IDI_ASTERISK","IDI_EXCLAMATION","IDI_HAND","IDI_QUESTION","IDI_WINLOGO","_win32_GetIconInfo","_win32_geticoninfo_cpp","menurc.geticoninfo","winui._win32_geticoninfo","winuser/GetIconInfo"]
+helpviewer_keywords: ["GetIconInfo","GetIconInfo function [Menus and Other Resources]","_win32_GetIconInfo","_win32_geticoninfo_cpp","menurc.geticoninfo","winui._win32_geticoninfo","winuser/GetIconInfo"]
 old-location: menurc\geticoninfo.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\geticoninfo.htm
 ms.date: 12/05/2018
-ms.keywords: GetIconInfo, GetIconInfo function [Menus and Other Resources], IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT, IDI_APPLICATION, IDI_ASTERISK, IDI_EXCLAMATION, IDI_HAND, IDI_QUESTION, IDI_WINLOGO, _win32_GetIconInfo, _win32_geticoninfo_cpp, menurc.geticoninfo, winui._win32_geticoninfo, winuser/GetIconInfo
+ms.keywords: GetIconInfo, GetIconInfo function [Menus and Other Resources], _win32_GetIconInfo, _win32_geticoninfo_cpp, menurc.geticoninfo, winui._win32_geticoninfo, winuser/GetIconInfo
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -66,236 +66,9 @@ Retrieves information about the specified icon or cursor.
 
 Type: <b>HICON</b>
 
-A handle to the icon or cursor. To retrieve information about a standard icon or cursor, specify one of the following values. 
+A handle to the icon or cursor.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_APPSTARTING"></a><a id="idc_appstarting"></a><dl>
-<dt><b>IDC_APPSTARTING</b></dt>
-<dt>MAKEINTRESOURCE(32650)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow and small hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ARROW"></a><a id="idc_arrow"></a><dl>
-<dt><b>IDC_ARROW</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_CROSS"></a><a id="idc_cross"></a><dl>
-<dt><b>IDC_CROSS</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Crosshair cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HAND"></a><a id="idc_hand"></a><dl>
-<dt><b>IDC_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32649)</dt>
-</dl>
-</td>
-<td width="60%">
-Hand cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HELP"></a><a id="idc_help"></a><dl>
-<dt><b>IDC_HELP</b></dt>
-<dt>MAKEINTRESOURCE(32651)</dt>
-</dl>
-</td>
-<td width="60%">
-Arrow and question mark cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_IBEAM"></a><a id="idc_ibeam"></a><dl>
-<dt><b>IDC_IBEAM</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-I-beam cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_NO"></a><a id="idc_no"></a><dl>
-<dt><b>IDC_NO</b></dt>
-<dt>MAKEINTRESOURCE(32648)</dt>
-</dl>
-</td>
-<td width="60%">
-Slashed circle cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEALL"></a><a id="idc_sizeall"></a><dl>
-<dt><b>IDC_SIZEALL</b></dt>
-<dt>MAKEINTRESOURCE(32646)</dt>
-</dl>
-</td>
-<td width="60%">
-Four-pointed arrow cursor pointing north, south, east, and west.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENESW"></a><a id="idc_sizenesw"></a><dl>
-<dt><b>IDC_SIZENESW</b></dt>
-<dt>MAKEINTRESOURCE(32643)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northeast and southwest.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENS"></a><a id="idc_sizens"></a><dl>
-<dt><b>IDC_SIZENS</b></dt>
-<dt>MAKEINTRESOURCE(32645)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing north and south.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENWSE"></a><a id="idc_sizenwse"></a><dl>
-<dt><b>IDC_SIZENWSE</b></dt>
-<dt>MAKEINTRESOURCE(32642)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northwest and southeast.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEWE"></a><a id="idc_sizewe"></a><dl>
-<dt><b>IDC_SIZEWE</b></dt>
-<dt>MAKEINTRESOURCE(32644)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing west and east.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_UPARROW"></a><a id="idc_uparrow"></a><dl>
-<dt><b>IDC_UPARROW</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Vertical arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_WAIT"></a><a id="idc_wait"></a><dl>
-<dt><b>IDC_WAIT</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Stop sign icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Question-mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-<dt>MAKEINTRESOURCE(32517)</dt>
-</dl>
-</td>
-<td width="60%">
- Application icon.
-
-<b>Windows 2000:  </b>Windows logo icon. 
-
-</td>
-</tr>
-</table>
+To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [out]
 
@@ -313,7 +86,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-<b>GetIconInfo</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfo">ICONINFO</a>. The calling application must manage these bitmaps and delete them when they are no longer necessary.
+<b>GetIconInfo</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfo">ICONINFO</a>. The calling application must manage these bitmaps and delete them with <a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a> call when they are no longer necessary.
 
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
@@ -322,30 +95,30 @@ This API does not participate in DPI virtualization. The output returned is not 
 
 <b>Conceptual</b>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createicon">CreateIcon</a>
+<a href="/windows/win32/gdi/bitmaps">Bitmaps</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
+<a href="/windows/win32/menurc/icons">Icons</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
+<a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
+<a href="/windows/win32/api/wingdi/nf-wingdi-getobject">GetObject</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-drawicon">DrawIcon</a>
+<a href="/windows/win32/api/wingdi/ns-wingdi-bitmap">BITMAP</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
+<a href="/windows/win32/api/winuser/nf-winuser-createicon">CreateIcon</a>
 
-<a href="/windows/desktop/api/winuser/ns-winuser-iconinfo">ICONINFO</a>
+<a href="/windows/win32/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
 
-<a href="/windows/desktop/menurc/icons">Icons</a>
+<a href="/windows/win32/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
+<a href="/windows/win32/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
+<a href="/windows/win32/api/winuser/nf-winuser-drawicon">DrawIcon</a>
 
-<a href="/windows/desktop/gdi/bitmaps">Bitmaps</a>
+<a href="/windows/win32/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
 
-<a href="/windows/desktop/api/wingdi/nf-wingdi-getobject">GetObject</a>
+<a href="/windows/win32/api/winuser/nf-winuser-loadicona">LoadIcon</a>
 
-<a href="/windows/desktop/api/wingdi/ns-wingdi-bitmap">BITMAP</a>
+<a href="/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
 
-<b>Reference</b>
+<a href="/windows/win32/api/winuser/ns-winuser-iconinfo">ICONINFO</a>

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfo.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfo.md
@@ -68,7 +68,7 @@ Type: <b>HICON</b>
 
 A handle to the icon or cursor.
 
-To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
+To retrieve information about a standard icon or cursor, specify the [identifier beginning with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier beginning with the IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [out]
 

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfoexa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfoexa.md
@@ -62,7 +62,7 @@ Type: <b>HICON</b>
 
 A handle to the icon or cursor.
 
-To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
+To retrieve information about a standard icon or cursor, specify the [identifier beginning with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier beginning with the IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [in, out]
 

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfoexa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfoexa.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.GetIconInfoExA
 title: GetIconInfoExA function (winuser.h)
 description: Retrieves information about the specified icon or cursor. GetIconInfoEx extends GetIconInfo by using the newer ICONINFOEX structure. (ANSI)
-helpviewer_keywords: ["GetIconInfoExA", "IDC_APPSTARTING", "IDC_ARROW", "IDC_CROSS", "IDC_HAND", "IDC_HELP", "IDC_IBEAM", "IDC_NO", "IDC_SIZEALL", "IDC_SIZENESW", "IDC_SIZENS", "IDC_SIZENWSE", "IDC_SIZEWE", "IDC_UPARROW", "IDC_WAIT", "IDI_APPLICATION", "IDI_ASTERISK", "IDI_EXCLAMATION", "IDI_HAND", "IDI_QUESTION", "IDI_WINLOGO", "winuser/GetIconInfoExA"]
+helpviewer_keywords: ["GetIconInfoExA" "winuser/GetIconInfoExA"]
 old-location: menurc\geticoninfoex.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\geticoninfoex.htm
 ms.date: 12/05/2018
-ms.keywords: GetIconInfoEx, GetIconInfoEx function [Menus and Other Resources], GetIconInfoExA, GetIconInfoExW, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT, IDI_APPLICATION, IDI_ASTERISK, IDI_EXCLAMATION, IDI_HAND, IDI_QUESTION, IDI_WINLOGO, _win32_GetIconInfoEx, _win32_geticoninfoex_cpp, menurc.geticoninfoex, winui._win32_geticoninfoex, winuser/GetIconInfoEx, winuser/GetIconInfoExA, winuser/GetIconInfoExW
+ms.keywords: GetIconInfoEx, GetIconInfoEx function [Menus and Other Resources], GetIconInfoExA, GetIconInfoExW, _win32_GetIconInfoEx, _win32_geticoninfoex_cpp, menurc.geticoninfoex, winui._win32_geticoninfoex, winuser/GetIconInfoEx, winuser/GetIconInfoExA, winuser/GetIconInfoExW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -60,236 +60,9 @@ Retrieves information about the specified icon or cursor. <b>GetIconInfoEx</b> e
 
 Type: <b>HICON</b>
 
-A handle to the icon or cursor. To retrieve information about a standard icon or cursor, specify one of the following values.
+A handle to the icon or cursor.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_APPSTARTING"></a><a id="idc_appstarting"></a><dl>
-<dt><b>IDC_APPSTARTING</b></dt>
-<dt>MAKEINTRESOURCE(32650)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow and small hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ARROW"></a><a id="idc_arrow"></a><dl>
-<dt><b>IDC_ARROW</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_CROSS"></a><a id="idc_cross"></a><dl>
-<dt><b>IDC_CROSS</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Crosshair cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HAND"></a><a id="idc_hand"></a><dl>
-<dt><b>IDC_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32649)</dt>
-</dl>
-</td>
-<td width="60%">
- Hand cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HELP"></a><a id="idc_help"></a><dl>
-<dt><b>IDC_HELP</b></dt>
-<dt>MAKEINTRESOURCE(32651)</dt>
-</dl>
-</td>
-<td width="60%">
-Arrow and question mark cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_IBEAM"></a><a id="idc_ibeam"></a><dl>
-<dt><b>IDC_IBEAM</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-I-beam cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_NO"></a><a id="idc_no"></a><dl>
-<dt><b>IDC_NO</b></dt>
-<dt>MAKEINTRESOURCE(32648)</dt>
-</dl>
-</td>
-<td width="60%">
-Slashed circle cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEALL"></a><a id="idc_sizeall"></a><dl>
-<dt><b>IDC_SIZEALL</b></dt>
-<dt>MAKEINTRESOURCE(32646)</dt>
-</dl>
-</td>
-<td width="60%">
-Four-pointed arrow cursor pointing north, south, east, and west.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENESW"></a><a id="idc_sizenesw"></a><dl>
-<dt><b>IDC_SIZENESW</b></dt>
-<dt>MAKEINTRESOURCE(32643)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northeast and southwest.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENS"></a><a id="idc_sizens"></a><dl>
-<dt><b>IDC_SIZENS</b></dt>
-<dt>MAKEINTRESOURCE(32645)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing north and south.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENWSE"></a><a id="idc_sizenwse"></a><dl>
-<dt><b>IDC_SIZENWSE</b></dt>
-<dt>MAKEINTRESOURCE(32642)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northwest and southeast.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEWE"></a><a id="idc_sizewe"></a><dl>
-<dt><b>IDC_SIZEWE</b></dt>
-<dt>MAKEINTRESOURCE(32644)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing west and east.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_UPARROW"></a><a id="idc_uparrow"></a><dl>
-<dt><b>IDC_UPARROW</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Vertical arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_WAIT"></a><a id="idc_wait"></a><dl>
-<dt><b>IDC_WAIT</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Stop sign icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Question-mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-<dt>MAKEINTRESOURCE(32517)</dt>
-</dl>
-</td>
-<td width="60%">
- Application icon.
-
-<b>Windows 2000:  </b>Windows logo icon. 
-
-</td>
-</tr>
-</table>
+To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [in, out]
 
@@ -305,7 +78,7 @@ Type: <b>BOOL</b>
 
 ## -remarks
 
-<b>GetIconInfoEx</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfoexa">ICONINFOEX</a>. The calling application must manage these bitmaps and delete them when they are no longer necessary.
+<b>GetIconInfoEx</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfoexa">ICONINFOEX</a>. The calling application must manage these bitmaps and delete them with <a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a> call when they are no longer necessary.
 
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
@@ -317,46 +90,30 @@ This API does not participate in DPI virtualization. The output returned is not 
 
 <b>Conceptual</b>
 
+<a href="/windows/win32/gdi/bitmaps">Bitmaps</a>
 
+<a href="/windows/win32/menurc/icons">Icons</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createicon">CreateIcon</a>
+<a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a>
 
+<a href="/windows/win32/api/wingdi/nf-wingdi-getobject">GetObject</a>
 
+<a href="/windows/win32/api/wingdi/ns-wingdi-bitmap">BITMAP</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
+<a href="/windows/win32/api/winuser/nf-winuser-createicon">CreateIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
+<a href="/windows/win32/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-drawicon">DrawIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
+<a href="/windows/win32/api/winuser/nf-winuser-loadicona">LoadIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
 
-
-<a href="/windows/desktop/api/winuser/nf-winuser-drawicon">DrawIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
-
-
-
-<a href="/windows/desktop/api/winuser/ns-winuser-iconinfo">ICONINFO</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
-
-
-
-<b>Reference</b>
+<a href="/windows/win32/api/winuser/ns-winuser-iconinfo">ICONINFO</a>

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfoexw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfoexw.md
@@ -62,7 +62,7 @@ Type: <b>HICON</b>
 
 A handle to the icon or cursor.
 
-To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
+To retrieve information about a standard icon or cursor, specify the [identifier beginning with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier beginning with the IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [in, out]
 

--- a/sdk-api-src/content/winuser/nf-winuser-geticoninfoexw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-geticoninfoexw.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.GetIconInfoExW
 title: GetIconInfoExW function (winuser.h)
 description: Retrieves information about the specified icon or cursor. GetIconInfoEx extends GetIconInfo by using the newer ICONINFOEX structure. (Unicode)
-helpviewer_keywords: ["GetIconInfoEx", "GetIconInfoEx function [Menus and Other Resources]", "GetIconInfoExW", "IDC_APPSTARTING", "IDC_ARROW", "IDC_CROSS", "IDC_HAND", "IDC_HELP", "IDC_IBEAM", "IDC_NO", "IDC_SIZEALL", "IDC_SIZENESW", "IDC_SIZENS", "IDC_SIZENWSE", "IDC_SIZEWE", "IDC_UPARROW", "IDC_WAIT", "IDI_APPLICATION", "IDI_ASTERISK", "IDI_EXCLAMATION", "IDI_HAND", "IDI_QUESTION", "IDI_WINLOGO", "_win32_GetIconInfoEx", "_win32_geticoninfoex_cpp", "menurc.geticoninfoex", "winui._win32_geticoninfoex", "winuser/GetIconInfoEx", "winuser/GetIconInfoExW"]
+helpviewer_keywords: ["GetIconInfoEx", "GetIconInfoEx function [Menus and Other Resources]", "GetIconInfoExW", "_win32_GetIconInfoEx", "_win32_geticoninfoex_cpp", "menurc.geticoninfoex", "winui._win32_geticoninfoex", "winuser/GetIconInfoEx", "winuser/GetIconInfoExW"]
 old-location: menurc\geticoninfoex.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\geticoninfoex.htm
 ms.date: 12/05/2018
-ms.keywords: GetIconInfoEx, GetIconInfoEx function [Menus and Other Resources], GetIconInfoExA, GetIconInfoExW, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT, IDI_APPLICATION, IDI_ASTERISK, IDI_EXCLAMATION, IDI_HAND, IDI_QUESTION, IDI_WINLOGO, _win32_GetIconInfoEx, _win32_geticoninfoex_cpp, menurc.geticoninfoex, winui._win32_geticoninfoex, winuser/GetIconInfoEx, winuser/GetIconInfoExA, winuser/GetIconInfoExW
+ms.keywords: GetIconInfoEx, GetIconInfoEx function [Menus and Other Resources], GetIconInfoExA, GetIconInfoExW, _win32_GetIconInfoEx, _win32_geticoninfoex_cpp, menurc.geticoninfoex, winui._win32_geticoninfoex, winuser/GetIconInfoEx, winuser/GetIconInfoExA, winuser/GetIconInfoExW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -60,236 +60,9 @@ Retrieves information about the specified icon or cursor. <b>GetIconInfoEx</b> e
 
 Type: <b>HICON</b>
 
-A handle to the icon or cursor. To retrieve information about a standard icon or cursor, specify one of the following values.
+A handle to the icon or cursor.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_APPSTARTING"></a><a id="idc_appstarting"></a><dl>
-<dt><b>IDC_APPSTARTING</b></dt>
-<dt>MAKEINTRESOURCE(32650)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow and small hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ARROW"></a><a id="idc_arrow"></a><dl>
-<dt><b>IDC_ARROW</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_CROSS"></a><a id="idc_cross"></a><dl>
-<dt><b>IDC_CROSS</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Crosshair cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HAND"></a><a id="idc_hand"></a><dl>
-<dt><b>IDC_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32649)</dt>
-</dl>
-</td>
-<td width="60%">
- Hand cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HELP"></a><a id="idc_help"></a><dl>
-<dt><b>IDC_HELP</b></dt>
-<dt>MAKEINTRESOURCE(32651)</dt>
-</dl>
-</td>
-<td width="60%">
-Arrow and question mark cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_IBEAM"></a><a id="idc_ibeam"></a><dl>
-<dt><b>IDC_IBEAM</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-I-beam cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_NO"></a><a id="idc_no"></a><dl>
-<dt><b>IDC_NO</b></dt>
-<dt>MAKEINTRESOURCE(32648)</dt>
-</dl>
-</td>
-<td width="60%">
-Slashed circle cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEALL"></a><a id="idc_sizeall"></a><dl>
-<dt><b>IDC_SIZEALL</b></dt>
-<dt>MAKEINTRESOURCE(32646)</dt>
-</dl>
-</td>
-<td width="60%">
-Four-pointed arrow cursor pointing north, south, east, and west.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENESW"></a><a id="idc_sizenesw"></a><dl>
-<dt><b>IDC_SIZENESW</b></dt>
-<dt>MAKEINTRESOURCE(32643)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northeast and southwest.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENS"></a><a id="idc_sizens"></a><dl>
-<dt><b>IDC_SIZENS</b></dt>
-<dt>MAKEINTRESOURCE(32645)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing north and south.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENWSE"></a><a id="idc_sizenwse"></a><dl>
-<dt><b>IDC_SIZENWSE</b></dt>
-<dt>MAKEINTRESOURCE(32642)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing northwest and southeast.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEWE"></a><a id="idc_sizewe"></a><dl>
-<dt><b>IDC_SIZEWE</b></dt>
-<dt>MAKEINTRESOURCE(32644)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow cursor pointing west and east.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_UPARROW"></a><a id="idc_uparrow"></a><dl>
-<dt><b>IDC_UPARROW</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Vertical arrow cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_WAIT"></a><a id="idc_wait"></a><dl>
-<dt><b>IDC_WAIT</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Hourglass cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Stop sign icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Question-mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-<dt>MAKEINTRESOURCE(32517)</dt>
-</dl>
-</td>
-<td width="60%">
- Application icon.
-
-<b>Windows 2000:  </b>Windows logo icon. 
-
-</td>
-</tr>
-</table>
+To retrieve information about a standard icon or cursor, specify the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) or the [identifier begin with IDC\_ prefix](/windows/win32/menurc/about-cursors) in this parameter.
 
 ### -param piconinfo [in, out]
 
@@ -305,7 +78,7 @@ Type: <b>BOOL</b>
 
 ## -remarks
 
-<b>GetIconInfoEx</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfoexa">ICONINFOEX</a>. The calling application must manage these bitmaps and delete them when they are no longer necessary.
+<b>GetIconInfoEx</b> creates bitmaps for the <b>hbmMask</b> and <b>hbmColor</b> or members of <a href="/windows/desktop/api/winuser/ns-winuser-iconinfoexw">ICONINFOEX</a>. The calling application must manage these bitmaps and delete them with <a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a> call when they are no longer necessary.
 
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
@@ -317,46 +90,30 @@ This API does not participate in DPI virtualization. The output returned is not 
 
 <b>Conceptual</b>
 
+<a href="/windows/win32/gdi/bitmaps">Bitmaps</a>
 
+<a href="/windows/win32/menurc/icons">Icons</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createicon">CreateIcon</a>
+<a href="/windows/win32/api/wingdi/nf-wingdi-deleteobject">DeleteObject</a>
 
+<a href="/windows/win32/api/wingdi/nf-wingdi-getobject">GetObject</a>
 
+<a href="/windows/win32/api/wingdi/ns-wingdi-bitmap">BITMAP</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
+<a href="/windows/win32/api/winuser/nf-winuser-createicon">CreateIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
+<a href="/windows/win32/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-drawicon">DrawIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
 
-<a href="/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
+<a href="/windows/win32/api/winuser/nf-winuser-loadicona">LoadIcon</a>
 
+<a href="/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
 
-
-<a href="/windows/desktop/api/winuser/nf-winuser-drawicon">DrawIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-drawiconex">DrawIconEx</a>
-
-
-
-<a href="/windows/desktop/api/winuser/ns-winuser-iconinfo">ICONINFO</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
-
-
-
-<b>Reference</b>
+<a href="/windows/win32/api/winuser/ns-winuser-iconinfo">ICONINFO</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadcursora.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadcursora.md
@@ -81,7 +81,7 @@ Type: <b>LPCTSTR</b>
 
 If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the cursor resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDC\_ prefix](/windows/win32/menurc/about-cursors) of a predefined system cursor to load.
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier (beginning with the IDC\_ prefix)](/windows/win32/menurc/about-cursors) of a predefined system cursor to load.
 
 ## -returns
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadcursora.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadcursora.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.LoadCursorA
 title: LoadCursorA function (winuser.h)
 description: Loads the specified cursor resource from the executable (.EXE) file associated with an application instance. (ANSI)
-helpviewer_keywords: ["IDC_APPSTARTING", "IDC_ARROW", "IDC_CROSS", "IDC_HAND", "IDC_HELP", "IDC_IBEAM", "IDC_ICON", "IDC_NO", "IDC_SIZE", "IDC_SIZEALL", "IDC_SIZENESW", "IDC_SIZENS", "IDC_SIZENWSE", "IDC_SIZEWE", "IDC_UPARROW", "IDC_WAIT", "LoadCursorA", "winuser/LoadCursorA"]
+helpviewer_keywords: ["LoadCursorA", "winuser/LoadCursorA"]
 old-location: menurc\loadcursor.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\cursors\cursorreference\cursorfunctions\loadcursor.htm
 ms.date: 12/05/2018
-ms.keywords: IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_ICON, IDC_NO, IDC_SIZE, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT, LoadCursor, LoadCursor function [Menus and Other Resources], LoadCursorA, LoadCursorW, _win32_LoadCursor, _win32_loadcursor_cpp, menurc.loadcursor, winui._win32_loadcursor, winuser/LoadCursor, winuser/LoadCursorA, winuser/LoadCursorW
+ms.keywords: LoadCursor, LoadCursor function [Menus and Other Resources], LoadCursorA, LoadCursorW, _win32_LoadCursor, _win32_loadcursor_cpp, menurc.loadcursor, winui._win32_loadcursor, winuser/LoadCursor, winuser/LoadCursorA, winuser/LoadCursorW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -60,8 +60,10 @@ api_name:
 
 ## -description
 
-Loads the specified cursor resource from the executable (.EXE) file associated with an application instance.
-<div class="alert"><b>Note</b>  This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function.</div><div> </div>
+Loads the specified cursor resource from the executable (.exe) file associated with an application instance.
+
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_SHARED</b> flags set.
 
 ## -parameters
 
@@ -69,196 +71,17 @@ Loads the specified cursor resource from the executable (.EXE) file associated w
 
 Type: <b>HINSTANCE</b>
 
-A handle to an instance of the module whose executable file contains the cursor to be loaded.
+A handle to the module of either a DLL or executable (.exe) file that contains the cursor to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
+
+To load a predefined system cursor, set this parameter to <b>NULL</b>.
 
 ### -param lpCursorName [in]
 
 Type: <b>LPCTSTR</b>
 
-The name of the cursor resource to be loaded. Alternatively, this parameter can consist of the resource identifier in the low-order word and zero in the high-order word. The <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro can also be used to create this value. To use one of the predefined cursors, the application must set the <i>hInstance</i> parameter to <b>NULL</b> and the <i>lpCursorName</i> parameter to one the following values.
+If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the cursor resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_APPSTARTING"></a><a id="idc_appstarting"></a><dl>
-<dt><b>IDC_APPSTARTING</b></dt>
-<dt>MAKEINTRESOURCE(32650)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow and small hourglass
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ARROW"></a><a id="idc_arrow"></a><dl>
-<dt><b>IDC_ARROW</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_CROSS"></a><a id="idc_cross"></a><dl>
-<dt><b>IDC_CROSS</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Crosshair
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HAND"></a><a id="idc_hand"></a><dl>
-<dt><b>IDC_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32649)</dt>
-</dl>
-</td>
-<td width="60%">
- Hand
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HELP"></a><a id="idc_help"></a><dl>
-<dt><b>IDC_HELP</b></dt>
-<dt>MAKEINTRESOURCE(32651)</dt>
-</dl>
-</td>
-<td width="60%">
-Arrow and question mark
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_IBEAM"></a><a id="idc_ibeam"></a><dl>
-<dt><b>IDC_IBEAM</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-I-beam
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ICON"></a><a id="idc_icon"></a><dl>
-<dt><b>IDC_ICON</b></dt>
-<dt>MAKEINTRESOURCE(32641)</dt>
-</dl>
-</td>
-<td width="60%">
-Obsolete for applications marked version 4.0 or later.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_NO"></a><a id="idc_no"></a><dl>
-<dt><b>IDC_NO</b></dt>
-<dt>MAKEINTRESOURCE(32648)</dt>
-</dl>
-</td>
-<td width="60%">
-Slashed circle
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZE"></a><a id="idc_size"></a><dl>
-<dt><b>IDC_SIZE</b></dt>
-<dt>MAKEINTRESOURCE(32640)</dt>
-</dl>
-</td>
-<td width="60%">
-Obsolete for applications marked version 4.0 or later. Use <b>IDC_SIZEALL</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEALL"></a><a id="idc_sizeall"></a><dl>
-<dt><b>IDC_SIZEALL</b></dt>
-<dt>MAKEINTRESOURCE(32646)</dt>
-</dl>
-</td>
-<td width="60%">
-Four-pointed arrow pointing north, south, east, and west
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENESW"></a><a id="idc_sizenesw"></a><dl>
-<dt><b>IDC_SIZENESW</b></dt>
-<dt>MAKEINTRESOURCE(32643)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing northeast and southwest
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENS"></a><a id="idc_sizens"></a><dl>
-<dt><b>IDC_SIZENS</b></dt>
-<dt>MAKEINTRESOURCE(32645)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing north and south
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENWSE"></a><a id="idc_sizenwse"></a><dl>
-<dt><b>IDC_SIZENWSE</b></dt>
-<dt>MAKEINTRESOURCE(32642)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing northwest and southeast
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEWE"></a><a id="idc_sizewe"></a><dl>
-<dt><b>IDC_SIZEWE</b></dt>
-<dt>MAKEINTRESOURCE(32644)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing west and east
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_UPARROW"></a><a id="idc_uparrow"></a><dl>
-<dt><b>IDC_UPARROW</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Vertical arrow
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_WAIT"></a><a id="idc_wait"></a><dl>
-<dt><b>IDC_WAIT</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Hourglass
-
-</td>
-</tr>
-</table>
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDC\_ prefix](/windows/win32/menurc/about-cursors) of a predefined system cursor to load.
 
 ## -returns
 
@@ -277,15 +100,9 @@ The <b>LoadCursor</b> function searches the cursor resource most appropriate for
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
 
-
 #### Examples
 
 For an example, see <a href="/windows/desktop/menurc/using-cursors">Creating a Cursor</a>.
-
-<div class="code"></div>
-
-
-
 
 > [!NOTE]
 > The winuser.h header defines LoadCursor as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
@@ -294,30 +111,18 @@ For an example, see <a href="/windows/desktop/menurc/using-cursors">Creating a C
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/menurc/cursors">Cursors</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
 
-
+<a href="/windows/win32/api/winuser/nf-winuser-is_intresource">IS_INTRESOURCE</a>
 
 <b>Reference</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursor">SetCursor</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursorpos">SetCursorPos</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-showcursor">ShowCursor</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadcursorfromfilea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadcursorfromfilea.md
@@ -50,10 +50,12 @@ api_name:
 
 # LoadCursorFromFileA function
 
-
 ## -description
 
 Creates a cursor based on data contained in a file.
+
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_LOADFROMFILE</b> flags set.
 
 ## -parameters
 
@@ -71,8 +73,7 @@ Type: <b>HCURSOR</b>
 
 If the function is successful, the return value is a handle to the new cursor.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. 
-						<b>GetLastError</b> may return the following value.
+If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. <b>GetLastError</b> may return the following value.
 
 <table>
 <tr>
@@ -97,10 +98,6 @@ The specified file cannot be found.
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
 
-
-
-
-
 > [!NOTE]
 > The winuser.h header defines LoadCursorFromFile as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
@@ -108,22 +105,12 @@ This API does not participate in DPI virtualization. The output returned is not 
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/menurc/cursors">Cursors</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a>
 
-
-
 <b>Reference</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursor">SetCursor</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-setsystemcursor">SetSystemCursor</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadcursorfromfilew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadcursorfromfilew.md
@@ -55,6 +55,9 @@ api_name:
 
 Creates a cursor based on data contained in a file.
 
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagew">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_LOADFROMFILE</b> flags set.
+
 ## -parameters
 
 ### -param lpFileName [in]
@@ -71,8 +74,7 @@ Type: <b>HCURSOR</b>
 
 If the function is successful, the return value is a handle to the new cursor.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. 
-						<b>GetLastError</b> may return the following value.
+If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>. <b>GetLastError</b> may return the following value.
 
 <table>
 <tr>
@@ -97,10 +99,6 @@ The specified file cannot be found.
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
 
-
-
-
-
 > [!NOTE]
 > The winuser.h header defines LoadCursorFromFile as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
@@ -108,22 +106,12 @@ This API does not participate in DPI virtualization. The output returned is not 
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/menurc/cursors">Cursors</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a>
 
-
-
 <b>Reference</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursor">SetCursor</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-setsystemcursor">SetSystemCursor</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadcursorw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadcursorw.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.LoadCursorW
 title: LoadCursorW function (winuser.h)
 description: Loads the specified cursor resource from the executable (.EXE) file associated with an application instance. (Unicode)
-helpviewer_keywords: ["IDC_APPSTARTING", "IDC_ARROW", "IDC_CROSS", "IDC_HAND", "IDC_HELP", "IDC_IBEAM", "IDC_ICON", "IDC_NO", "IDC_SIZE", "IDC_SIZEALL", "IDC_SIZENESW", "IDC_SIZENS", "IDC_SIZENWSE", "IDC_SIZEWE", "IDC_UPARROW", "IDC_WAIT", "LoadCursor", "LoadCursor function [Menus and Other Resources]", "LoadCursorW", "_win32_LoadCursor", "_win32_loadcursor_cpp", "menurc.loadcursor", "winui._win32_loadcursor", "winuser/LoadCursor", "winuser/LoadCursorW"]
+helpviewer_keywords: ["LoadCursor", "LoadCursor function [Menus and Other Resources]", "LoadCursorW", "_win32_LoadCursor", "_win32_loadcursor_cpp", "menurc.loadcursor", "winui._win32_loadcursor", "winuser/LoadCursor", "winuser/LoadCursorW"]
 old-location: menurc\loadcursor.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\cursors\cursorreference\cursorfunctions\loadcursor.htm
 ms.date: 12/05/2018
-ms.keywords: IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_ICON, IDC_NO, IDC_SIZE, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_UPARROW, IDC_WAIT, LoadCursor, LoadCursor function [Menus and Other Resources], LoadCursorA, LoadCursorW, _win32_LoadCursor, _win32_loadcursor_cpp, menurc.loadcursor, winui._win32_loadcursor, winuser/LoadCursor, winuser/LoadCursorA, winuser/LoadCursorW
+ms.keywords: LoadCursor, LoadCursor function [Menus and Other Resources], LoadCursorA, LoadCursorW, _win32_LoadCursor, _win32_loadcursor_cpp, menurc.loadcursor, winui._win32_loadcursor, winuser/LoadCursor, winuser/LoadCursorA, winuser/LoadCursorW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -60,8 +60,10 @@ api_name:
 
 ## -description
 
-Loads the specified cursor resource from the executable (.EXE) file associated with an application instance.
-<div class="alert"><b>Note</b>  This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function.</div><div> </div>
+Loads the specified cursor resource from the executable (.exe) file associated with an application instance.
+
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagew">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_SHARED</b> flags set.
 
 ## -parameters
 
@@ -69,196 +71,16 @@ Loads the specified cursor resource from the executable (.EXE) file associated w
 
 Type: <b>HINSTANCE</b>
 
-A handle to an instance of the module whose executable file contains the cursor to be loaded.
+A handle to the module of either a DLL or executable (.exe) file that contains the cursor to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
 
+To load a predefined system cursor, set this parameter to <b>NULL</b>.
 ### -param lpCursorName [in]
 
 Type: <b>LPCTSTR</b>
 
-The name of the cursor resource to be loaded. Alternatively, this parameter can consist of the resource identifier in the low-order word and zero in the high-order word. The <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro can also be used to create this value. To use one of the predefined cursors, the application must set the <i>hInstance</i> parameter to <b>NULL</b> and the <i>lpCursorName</i> parameter to one the following values.
+If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the cursor resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_APPSTARTING"></a><a id="idc_appstarting"></a><dl>
-<dt><b>IDC_APPSTARTING</b></dt>
-<dt>MAKEINTRESOURCE(32650)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow and small hourglass
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ARROW"></a><a id="idc_arrow"></a><dl>
-<dt><b>IDC_ARROW</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Standard arrow
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_CROSS"></a><a id="idc_cross"></a><dl>
-<dt><b>IDC_CROSS</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Crosshair
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HAND"></a><a id="idc_hand"></a><dl>
-<dt><b>IDC_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32649)</dt>
-</dl>
-</td>
-<td width="60%">
- Hand
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_HELP"></a><a id="idc_help"></a><dl>
-<dt><b>IDC_HELP</b></dt>
-<dt>MAKEINTRESOURCE(32651)</dt>
-</dl>
-</td>
-<td width="60%">
-Arrow and question mark
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_IBEAM"></a><a id="idc_ibeam"></a><dl>
-<dt><b>IDC_IBEAM</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-I-beam
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_ICON"></a><a id="idc_icon"></a><dl>
-<dt><b>IDC_ICON</b></dt>
-<dt>MAKEINTRESOURCE(32641)</dt>
-</dl>
-</td>
-<td width="60%">
-Obsolete for applications marked version 4.0 or later.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_NO"></a><a id="idc_no"></a><dl>
-<dt><b>IDC_NO</b></dt>
-<dt>MAKEINTRESOURCE(32648)</dt>
-</dl>
-</td>
-<td width="60%">
-Slashed circle
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZE"></a><a id="idc_size"></a><dl>
-<dt><b>IDC_SIZE</b></dt>
-<dt>MAKEINTRESOURCE(32640)</dt>
-</dl>
-</td>
-<td width="60%">
-Obsolete for applications marked version 4.0 or later. Use <b>IDC_SIZEALL</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEALL"></a><a id="idc_sizeall"></a><dl>
-<dt><b>IDC_SIZEALL</b></dt>
-<dt>MAKEINTRESOURCE(32646)</dt>
-</dl>
-</td>
-<td width="60%">
-Four-pointed arrow pointing north, south, east, and west
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENESW"></a><a id="idc_sizenesw"></a><dl>
-<dt><b>IDC_SIZENESW</b></dt>
-<dt>MAKEINTRESOURCE(32643)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing northeast and southwest
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENS"></a><a id="idc_sizens"></a><dl>
-<dt><b>IDC_SIZENS</b></dt>
-<dt>MAKEINTRESOURCE(32645)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing north and south
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZENWSE"></a><a id="idc_sizenwse"></a><dl>
-<dt><b>IDC_SIZENWSE</b></dt>
-<dt>MAKEINTRESOURCE(32642)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing northwest and southeast
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_SIZEWE"></a><a id="idc_sizewe"></a><dl>
-<dt><b>IDC_SIZEWE</b></dt>
-<dt>MAKEINTRESOURCE(32644)</dt>
-</dl>
-</td>
-<td width="60%">
-Double-pointed arrow pointing west and east
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_UPARROW"></a><a id="idc_uparrow"></a><dl>
-<dt><b>IDC_UPARROW</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Vertical arrow
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDC_WAIT"></a><a id="idc_wait"></a><dl>
-<dt><b>IDC_WAIT</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Hourglass
-
-</td>
-</tr>
-</table>
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDC\_ prefix](/windows/win32/menurc/about-cursors) of a predefined system cursor to load.
 
 ## -returns
 
@@ -277,15 +99,9 @@ The <b>LoadCursor</b> function searches the cursor resource most appropriate for
 <h3><a id="DPI_Virtualization"></a><a id="dpi_virtualization"></a><a id="DPI_VIRTUALIZATION"></a>DPI Virtualization</h3>
 This API does not participate in DPI virtualization. The output returned is not affected by the DPI of the calling thread.
 
-
 #### Examples
 
 For an example, see <a href="/windows/desktop/menurc/using-cursors">Creating a Cursor</a>.
-
-<div class="code"></div>
-
-
-
 
 > [!NOTE]
 > The winuser.h header defines LoadCursor as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
@@ -294,30 +110,18 @@ For an example, see <a href="/windows/desktop/menurc/using-cursors">Creating a C
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/menurc/cursors">Cursors</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
 
-
+<a href="/windows/win32/api/winuser/nf-winuser-is_intresource">IS_INTRESOURCE</a>
 
 <b>Reference</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursor">SetCursor</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-setcursorpos">SetCursorPos</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-showcursor">ShowCursor</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadicona.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadicona.md
@@ -80,7 +80,7 @@ Type: <b>LPCTSTR</b>
 
 If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ## -returns
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadicona.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadicona.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.LoadIconA
 title: LoadIconA function (winuser.h)
 description: Loads the specified icon resource from the executable (.exe) file associated with an application instance. (ANSI)
-helpviewer_keywords: ["IDI_APPLICATION", "IDI_ASTERISK", "IDI_ERROR", "IDI_EXCLAMATION", "IDI_HAND", "IDI_INFORMATION", "IDI_QUESTION", "IDI_SHIELD", "IDI_WARNING", "IDI_WINLOGO", "LoadIconA", "winuser/LoadIconA"]
+helpviewer_keywords: ["LoadIconA", "winuser/LoadIconA"]
 old-location: menurc\loadicon.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\loadicon.htm
 ms.date: 12/05/2018
-ms.keywords: IDI_APPLICATION, IDI_ASTERISK, IDI_ERROR, IDI_EXCLAMATION, IDI_HAND, IDI_INFORMATION, IDI_QUESTION, IDI_SHIELD, IDI_WARNING, IDI_WINLOGO, LoadIcon, LoadIcon function [Menus and Other Resources], LoadIconA, LoadIconW, _win32_LoadIcon, _win32_loadicon_cpp, menurc.loadicon, winui._win32_loadicon, winuser/LoadIcon, winuser/LoadIconA, winuser/LoadIconW
+ms.keywords: LoadIcon, LoadIcon function [Menus and Other Resources], LoadIconA, LoadIconW, _win32_LoadIcon, _win32_loadicon_cpp, menurc.loadicon, winui._win32_loadicon, winuser/LoadIcon, winuser/LoadIconA, winuser/LoadIconW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -57,11 +57,12 @@ req.apiset: ext-ms-win-ntuser-gui-l1-1-0 (introduced in Windows 8)
 
 # LoadIconA function
 
-
 ## -description
 
 Loads the specified icon resource from the executable (.exe) file associated with an application instance.
-<div class="alert"><b>Note</b>  This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function.</div><div> </div>
+
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_SHARED</b> flags set.
 
 ## -parameters
 
@@ -69,135 +70,17 @@ Loads the specified icon resource from the executable (.exe) file associated wit
 
 Type: <b>HINSTANCE</b>
 
-A handle to an instance of the module whose executable file contains the icon to be loaded. This parameter must be <b>NULL</b> when a standard icon is being loaded.
+A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
+
+To load a predefined system icon, set this parameter to <b>NULL</b>.
 
 ### -param lpIconName [in]
 
 Type: <b>LPCTSTR</b>
 
-The name of the icon resource to be loaded. Alternatively, this parameter can contain the resource identifier in the low-order word and zero in the high-order word. Use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro to create this value.
+If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-To use one of the predefined icons, set the <i>hInstance</i> parameter to <b>NULL</b> and the <i>lpIconName</i> parameter to one of the following values.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Default application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon. Same as <b>IDI_INFORMATION</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ERROR"></a><a id="idi_error"></a><dl>
-<dt><b>IDI_ERROR</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Hand-shaped icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon. Same as <b>IDI_WARNING</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Hand-shaped icon. Same as <b>IDI_ERROR</b>. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_INFORMATION"></a><a id="idi_information"></a><dl>
-<dt><b>IDI_INFORMATION</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Question mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_SHIELD"></a><a id="idi_shield"></a><dl>
-<dt><b>IDI_SHIELD</b></dt>
-<dt>MAKEINTRESOURCE(32518)</dt>
-</dl>
-</td>
-<td width="60%">
-Security Shield icon. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WARNING"></a><a id="idi_warning"></a><dl>
-<dt><b>IDI_WARNING</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-<dt>MAKEINTRESOURCE(32517)</dt>
-</dl>
-</td>
-<td width="60%">
- 
-						Default application icon.
-
-<b>Windows 2000:  </b>Windows logo icon.
-
-</td>
-</tr>
-</table>
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ## -returns
 
@@ -213,10 +96,6 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 <b>LoadIcon</b> can only load an icon whose size conforms to the <b>SM_CXICON</b> and <b>SM_CYICON</b> system metric values. Use the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function to load icons of other sizes.
 
-
-
-
-
 > [!NOTE]
 > The winuser.h header defines LoadIcon as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
@@ -224,22 +103,12 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-createicon">CreateIcon</a>
-
-
 
 <a href="/windows/desktop/menurc/icons">Icons</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
 
-
-
-<b>Reference</b>
+<a href="/windows/win32/api/winuser/nf-winuser-is_intresource">IS_INTRESOURCE</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadiconw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadiconw.md
@@ -80,7 +80,7 @@ Type: <b>LPCTSTR</b>
 
 If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ## -returns
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadiconw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadiconw.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.LoadIconW
 title: LoadIconW function (winuser.h)
 description: Loads the specified icon resource from the executable (.exe) file associated with an application instance. (Unicode)
-helpviewer_keywords: ["IDI_APPLICATION", "IDI_ASTERISK", "IDI_ERROR", "IDI_EXCLAMATION", "IDI_HAND", "IDI_INFORMATION", "IDI_QUESTION", "IDI_SHIELD", "IDI_WARNING", "IDI_WINLOGO", "LoadIcon", "LoadIcon function [Menus and Other Resources]", "LoadIconW", "_win32_LoadIcon", "_win32_loadicon_cpp", "menurc.loadicon", "winui._win32_loadicon", "winuser/LoadIcon", "winuser/LoadIconW"]
+helpviewer_keywords: ["LoadIcon", "LoadIcon function [Menus and Other Resources]", "LoadIconW", "_win32_LoadIcon", "_win32_loadicon_cpp", "menurc.loadicon", "winui._win32_loadicon", "winuser/LoadIcon", "winuser/LoadIconW"]
 old-location: menurc\loadicon.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\loadicon.htm
 ms.date: 12/05/2018
-ms.keywords: IDI_APPLICATION, IDI_ASTERISK, IDI_ERROR, IDI_EXCLAMATION, IDI_HAND, IDI_INFORMATION, IDI_QUESTION, IDI_SHIELD, IDI_WARNING, IDI_WINLOGO, LoadIcon, LoadIcon function [Menus and Other Resources], LoadIconA, LoadIconW, _win32_LoadIcon, _win32_loadicon_cpp, menurc.loadicon, winui._win32_loadicon, winuser/LoadIcon, winuser/LoadIconA, winuser/LoadIconW
+ms.keywords: LoadIcon, LoadIcon function [Menus and Other Resources], LoadIconA, LoadIconW, _win32_LoadIcon, _win32_loadicon_cpp, menurc.loadicon, winui._win32_loadicon, winuser/LoadIcon, winuser/LoadIconA, winuser/LoadIconW
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -57,11 +57,12 @@ req.apiset: ext-ms-win-ntuser-gui-l1-1-0 (introduced in Windows 8)
 
 # LoadIconW function
 
-
 ## -description
 
 Loads the specified icon resource from the executable (.exe) file associated with an application instance.
-<div class="alert"><b>Note</b>  This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function.</div><div> </div>
+
+> [!NOTE]
+> This function has been superseded by the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagew">LoadImage</a> function with <b>LR_DEFAULTSIZE</b> and <b>LR_SHARED</b> flags set.
 
 ## -parameters
 
@@ -69,135 +70,17 @@ Loads the specified icon resource from the executable (.exe) file associated wit
 
 Type: <b>HINSTANCE</b>
 
-A handle to an instance of the module whose executable file contains the icon to be loaded. This parameter must be <b>NULL</b> when a standard icon is being loaded.
+A handle to the module of either a DLL or executable (.exe) file that contains the icon to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>.
+
+To load a predefined system icon, set this parameter to <b>NULL</b>.
 
 ### -param lpIconName [in]
 
 Type: <b>LPCTSTR</b>
 
-The name of the icon resource to be loaded. Alternatively, this parameter can contain the resource identifier in the low-order word and zero in the high-order word. Use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro to create this value.
+If <i>hInstance</i> is non-<b>NULL</b>, <i>lpIconName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-To use one of the predefined icons, set the <i>hInstance</i> parameter to <b>NULL</b> and the <i>lpIconName</i> parameter to one of the following values.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_APPLICATION"></a><a id="idi_application"></a><dl>
-<dt><b>IDI_APPLICATION</b></dt>
-<dt>MAKEINTRESOURCE(32512)</dt>
-</dl>
-</td>
-<td width="60%">
-Default application icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ASTERISK"></a><a id="idi_asterisk"></a><dl>
-<dt><b>IDI_ASTERISK</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon. Same as <b>IDI_INFORMATION</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_ERROR"></a><a id="idi_error"></a><dl>
-<dt><b>IDI_ERROR</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Hand-shaped icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_EXCLAMATION"></a><a id="idi_exclamation"></a><dl>
-<dt><b>IDI_EXCLAMATION</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon. Same as <b>IDI_WARNING</b>.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_HAND"></a><a id="idi_hand"></a><dl>
-<dt><b>IDI_HAND</b></dt>
-<dt>MAKEINTRESOURCE(32513)</dt>
-</dl>
-</td>
-<td width="60%">
-Hand-shaped icon. Same as <b>IDI_ERROR</b>. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_INFORMATION"></a><a id="idi_information"></a><dl>
-<dt><b>IDI_INFORMATION</b></dt>
-<dt>MAKEINTRESOURCE(32516)</dt>
-</dl>
-</td>
-<td width="60%">
-Asterisk icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_QUESTION"></a><a id="idi_question"></a><dl>
-<dt><b>IDI_QUESTION</b></dt>
-<dt>MAKEINTRESOURCE(32514)</dt>
-</dl>
-</td>
-<td width="60%">
-Question mark icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_SHIELD"></a><a id="idi_shield"></a><dl>
-<dt><b>IDI_SHIELD</b></dt>
-<dt>MAKEINTRESOURCE(32518)</dt>
-</dl>
-</td>
-<td width="60%">
-Security Shield icon. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WARNING"></a><a id="idi_warning"></a><dl>
-<dt><b>IDI_WARNING</b></dt>
-<dt>MAKEINTRESOURCE(32515)</dt>
-</dl>
-</td>
-<td width="60%">
-Exclamation point icon.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IDI_WINLOGO"></a><a id="idi_winlogo"></a><dl>
-<dt><b>IDI_WINLOGO</b></dt>
-<dt>MAKEINTRESOURCE(32517)</dt>
-</dl>
-</td>
-<td width="60%">
- 
-						Default application icon.
-
-<b>Windows 2000:  </b>Windows logo icon.
-
-</td>
-</tr>
-</table>
+If <i>hInstance</i> is <b>NULL</b>, <i>lpIconName</i> specifies the [identifier begin with the IDI\_ prefix](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ## -returns
 
@@ -213,10 +96,6 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 <b>LoadIcon</b> can only load an icon whose size conforms to the <b>SM_CXICON</b> and <b>SM_CYICON</b> system metric values. Use the <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> function to load icons of other sizes.
 
-
-
-
-
 > [!NOTE]
 > The winuser.h header defines LoadIcon as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
@@ -224,22 +103,12 @@ If the function fails, the return value is <b>NULL</b>. To get extended error in
 
 <b>Conceptual</b>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-createicon">CreateIcon</a>
-
-
 
 <a href="/windows/desktop/menurc/icons">Icons</a>
 
-
-
 <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
-
-
 
 <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
 
-
-
-<b>Reference</b>
+<a href="/windows/win32/api/winuser/nf-winuser-is_intresource">IS_INTRESOURCE</a>

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
@@ -70,90 +70,49 @@ Type: <b>HINSTANCE</b>
 
 A handle to the module of either a DLL or executable (.exe) that contains the image to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>. Note that as of  32-bit Windows, an instance handle (<b>HINSTANCE</b>), such as the application instance handle exposed by system function call of <a href="/windows/desktop/api/winbase/nf-winbase-winmain">WinMain</a>, and a module handle (<b>HMODULE</b>) are the same thing.
 
-
-To load an OEM image, set this parameter to <b>NULL</b>.
-
-To load a stand-alone resource (icon, cursor, or bitmap file)—for example, c:\myimage.bmp—set this parameter to <b>NULL</b>.
+To load a predefined image or a standalone resource (icon, cursor, or bitmap file), set this parameter to <b>NULL</b>.
 
 ### -param name [in]
 
 Type: <b>LPCTSTR</b>
 
-The image to be loaded. If the <i>hinst</i> parameter is non-<b>NULL</b> and the <i>fuLoad</i> parameter omits <b>LR_LOADFROMFILE</b>, <i>lpszName</i> specifies the image resource in the <i>hinst</i> module. If the image resource is to be loaded by name from the module, the <i>lpszName</i> parameter is a pointer to a null-terminated string that contains the name of the image resource. If the image resource is to be loaded by ordinal from the module, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro to convert the image ordinal into a form that can be passed to the <b>LoadImage</b> function.
+The image to be loaded.
+
+If the <i>hinst</i> parameter is non-<b>NULL</b> and the <i>fuLoad</i> parameter omits <b>LR_LOADFROMFILE</b>, <i>lpszName</i> specifies the image resource in the <i>hinst</i> module.
+
+If the image resource is to be loaded by name from the module, the <i>lpszName</i> parameter is a pointer to a null-terminated string that contains the name of the image resource.
+
+If the image resource is to be loaded by ordinal from the module, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro to convert the image ordinal into a form that can be passed to the <b>LoadImage</b> function.
 
 For more information, see the Remarks section below.
 
-If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter omits the <b>LR_LOADFROMFILE</b> value, the <i>lpszName</i> specifies the OEM image to load. The OEM image identifiers are defined in Winuser.h and have the following prefixes.
+If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter omits the <b>LR_LOADFROMFILE</b> value, the <i>lpszName</i> specifies the predefined image to load. The predefined image identifiers are defined in `Winuser.h` and have the following prefixes:
 
-<table class="clsStd">
-<tr>
-<th>Prefix</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td><b>OBM_</b></td>
-<td>OEM bitmaps</td>
-</tr>
-<tr>
-<td><b>OIC_</b></td>
-<td>OEM icons</td>
-</tr>
-<tr>
-<td><b>OCR_</b></td>
-<td>OEM cursors</td>
-</tr>
-</table>
+| Prefix | Meaning |
+|---|---|
+| **OBM\_** | OEM bitmaps |
+| **OIC\_** | OEM icons |
+| **OCR\_** | OEM cursors |
+| **IDI\_** | [Standard icons](/windows/win32/menurc/about-icons) |
+| **IDC\_** | [Standard cursors](/windows/win32/menurc/about-cursors) |
  
+To pass OEM image identifiers constants to the <b>LoadImage</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the <b>OCR_NORMAL</b> cursor, pass <code>MAKEINTRESOURCE(OCR_NORMAL)</code> as the <i>lpszName</i> parameter, <b>NULL</b> as the <i>hinst</i> parameter, and <b>LR_SHARED</b> as one of the flags to the <i>fuLoad</i> parameter.
 
-To pass these constants to the <b>LoadImage</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the <b>OCR_NORMAL</b> cursor, pass <code>MAKEINTRESOURCE(OCR_NORMAL)</code> as the <i>lpszName</i> parameter, <b>NULL</b> as the <i>hinst</i> parameter, and <b>LR_SHARED</b> as one of the flags to the <i>fuLoad</i> parameter.
-
-If the <i>fuLoad</i> parameter includes the <b>LR_LOADFROMFILE</b> value, <i>lpszName</i> is the name of the file that contains the  stand-alone resource (icon, cursor, or bitmap file). Therefore, set <i>hinst</i> to <b>NULL</b>.
+If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter includes the <b>LR_LOADFROMFILE</b> value, <i>lpszName</i> is the name of the file that contains the standalone resource (icon, cursor, or bitmap file), - for example, `c:\myicon.ico`.
 
 ### -param type [in]
 
 Type: <b>UINT</b>
 
-The type of image to be loaded. This parameter can be one of the following values.
+The type of image to be loaded.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_BITMAP"></a><a id="image_bitmap"></a><dl>
-<dt><b>IMAGE_BITMAP</b></dt>
-<dt>0</dt>
-</dl>
-</td>
-<td width="60%">
-Loads a bitmap.
+This parameter can be one of the following values:
 
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_CURSOR"></a><a id="image_cursor"></a><dl>
-<dt><b>IMAGE_CURSOR</b></dt>
-<dt>2</dt>
-</dl>
-</td>
-<td width="60%">
-Loads a cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_ICON"></a><a id="image_icon"></a><dl>
-<dt><b>IMAGE_ICON</b></dt>
-<dt>1</dt>
-</dl>
-</td>
-<td width="60%">
-Loads an icon.
-
-</td>
-</tr>
-</table>
+| Value | Meaning |
+|---|---|
+| **IMAGE\_BITMAP** | Loads a bitmap. |
+| **IMAGE\_CURSOR** | Loads a cursor. |
+| **IMAGE\_ICON** | Loads an icon. |
 
 ### -param cx [in]
 
@@ -218,7 +177,7 @@ Uses the width or height specified by the system metric values for cursors or ic
 </dl>
 </td>
 <td width="60%">
-Loads the stand-alone image from the file specified by  <i>lpszName</i> (icon, cursor, or bitmap file).
+Loads the standalone image from the file specified by  <i>lpszName</i> (icon, cursor, or bitmap file).
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
@@ -70,90 +70,49 @@ Type: <b>HINSTANCE</b>
 
 A handle to the module of either a DLL or executable (.exe) that contains the image to be loaded. For more information, see <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>. Note that as of  32-bit Windows, an instance handle (<b>HINSTANCE</b>), such as the application instance handle exposed by system function call of <a href="/windows/desktop/api/winbase/nf-winbase-winmain">WinMain</a>, and a module handle (<b>HMODULE</b>) are the same thing.
 
-
-To load an OEM image, set this parameter to <b>NULL</b>.
-
-To load a stand-alone resource (icon, cursor, or bitmap file)—for example, c:\myimage.bmp—set this parameter to <b>NULL</b>.
+To load a predefined image or a standalone resource (icon, cursor, or bitmap file), set this parameter to <b>NULL</b>.
 
 ### -param name [in]
 
 Type: <b>LPCTSTR</b>
 
-The image to be loaded. If the <i>hinst</i> parameter is non-<b>NULL</b> and the <i>fuLoad</i> parameter omits <b>LR_LOADFROMFILE</b>, <i>lpszName</i> specifies the image resource in the <i>hinst</i> module. If the image resource is to be loaded by name from the module, the <i>lpszName</i> parameter is a pointer to a null-terminated string that contains the name of the image resource. If the image resource is to be loaded by ordinal from the module, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro to convert the image ordinal into a form that can be passed to the <b>LoadImage</b> function.
+The image to be loaded.
+
+If the <i>hinst</i> parameter is non-<b>NULL</b> and the <i>fuLoad</i> parameter omits <b>LR_LOADFROMFILE</b>, <i>lpszName</i> specifies the image resource in the <i>hinst</i> module.
+
+If the image resource is to be loaded by name from the module, the <i>lpszName</i> parameter is a pointer to a null-terminated string that contains the name of the image resource.
+
+If the image resource is to be loaded by ordinal from the module, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro to convert the image ordinal into a form that can be passed to the <b>LoadImage</b> function.
 
 For more information, see the Remarks section below.
 
-If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter omits the <b>LR_LOADFROMFILE</b> value, the <i>lpszName</i> specifies the OEM image to load. The OEM image identifiers are defined in Winuser.h and have the following prefixes.
+If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter omits the <b>LR_LOADFROMFILE</b> value, the <i>lpszName</i> specifies the predefined image to load. The predefined image identifiers are defined in `Winuser.h` and have the following prefixes:
 
-<table class="clsStd">
-<tr>
-<th>Prefix</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td><b>OBM_</b></td>
-<td>OEM bitmaps</td>
-</tr>
-<tr>
-<td><b>OIC_</b></td>
-<td>OEM icons</td>
-</tr>
-<tr>
-<td><b>OCR_</b></td>
-<td>OEM cursors</td>
-</tr>
-</table>
+| Prefix | Meaning |
+|---|---|
+| **OBM\_** | OEM bitmaps |
+| **OIC\_** | OEM icons |
+| **OCR\_** | OEM cursors |
+| **IDI\_** | [Standard icons](/windows/win32/menurc/about-icons) |
+| **IDC\_** | [Standard cursors](/windows/win32/menurc/about-cursors) |
  
+To pass OEM image identifiers constants to the <b>LoadImage</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the <b>OCR_NORMAL</b> cursor, pass <code>MAKEINTRESOURCE(OCR_NORMAL)</code> as the <i>lpszName</i> parameter, <b>NULL</b> as the <i>hinst</i> parameter, and <b>LR_SHARED</b> as one of the flags to the <i>fuLoad</i> parameter.
 
-To pass these constants to the <b>LoadImage</b> function, use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. For example, to load the <b>OCR_NORMAL</b> cursor, pass <code>MAKEINTRESOURCE(OCR_NORMAL)</code> as the <i>lpszName</i> parameter, <b>NULL</b> as the <i>hinst</i> parameter, and <b>LR_SHARED</b> as one of the flags to the <i>fuLoad</i> parameter.
-
-If the <i>fuLoad</i> parameter includes the <b>LR_LOADFROMFILE</b> value, <i>lpszName</i> is the name of the file that contains the  stand-alone resource (icon, cursor, or bitmap file). Therefore, set <i>hinst</i> to <b>NULL</b>.
+If the <i>hinst</i> parameter is <b>NULL</b> and the <i>fuLoad</i> parameter includes the <b>LR_LOADFROMFILE</b> value, <i>lpszName</i> is the name of the file that contains the standalone resource (icon, cursor, or bitmap file), - for example, `c:\myicon.ico`.
 
 ### -param type [in]
 
 Type: <b>UINT</b>
 
-The type of image to be loaded. This parameter can be one of the following values.
+The type of image to be loaded.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_BITMAP"></a><a id="image_bitmap"></a><dl>
-<dt><b>IMAGE_BITMAP</b></dt>
-<dt>0</dt>
-</dl>
-</td>
-<td width="60%">
-Loads a bitmap.
+This parameter can be one of the following values:
 
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_CURSOR"></a><a id="image_cursor"></a><dl>
-<dt><b>IMAGE_CURSOR</b></dt>
-<dt>2</dt>
-</dl>
-</td>
-<td width="60%">
-Loads a cursor.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="IMAGE_ICON"></a><a id="image_icon"></a><dl>
-<dt><b>IMAGE_ICON</b></dt>
-<dt>1</dt>
-</dl>
-</td>
-<td width="60%">
-Loads an icon.
-
-</td>
-</tr>
-</table>
+| Value | Meaning |
+|---|---|
+| **IMAGE\_BITMAP** | Loads a bitmap. |
+| **IMAGE\_CURSOR** | Loads a cursor. |
+| **IMAGE\_ICON** | Loads an icon. |
 
 ### -param cx [in]
 
@@ -218,7 +177,7 @@ Uses the width or height specified by the system metric values for cursors or ic
 </dl>
 </td>
 <td width="60%">
-Loads the stand-alone image from the file specified by  <i>lpszName</i> (icon, cursor, or bitmap file).
+Loads the standalone image from the file specified by  <i>lpszName</i> (icon, cursor, or bitmap file).
 
 </td>
 </tr>


### PR DESCRIPTION
Update docs for icon and cursor APIs:

```
GetIconInfo
GetIconInfoExA
GetIconInfoExW
LoadCursorA
LoadCursorFromFileA
LoadCursorFromFileW
LoadCursorW
LoadIconA
LoadIconMetric
LoadIconW
LoadIconWithScaleDown
LoadImageA
LoadImageW
```

These pages now have links to corresponding pages with [identifiers begin with the IDI\_ prefix](https://learn.microsoft.com/en-us/windows/win32/menurc/about-icons) and [identifiers begin with IDC\_ prefix](https://learn.microsoft.com/en-us/windows/win32/menurc/about-cursors). This way they are defined in one place with corresponding images (see https://github.com/MicrosoftDocs/win32/pull/1613).

Also clarify docs a bit.

Related PRs:
https://github.com/MicrosoftDocs/win32/pull/1540
https://github.com/MicrosoftDocs/win32/pull/1565
https://github.com/MicrosoftDocs/win32/pull/1613