### PR TITLE
Update SEE_MASK_FLAG_NO_UI description in ns-shellapi-shellexecuteinfoa.md

### DIFF
--- a/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
@@ -134,7 +134,7 @@ For further discussion on when this flag is necessary, see the Remarks section.<
 </tr>
 <tr valign="top">
 <td>SEE_MASK_FLAG_NO_UI (0x00000400)</td>
-<td>Do not display an error message box if an error occurs.</td>
+<td>Do not display any user interface (UI) including error dialogs, security warnings or other user interface that would normally be presented without this option.</td>
 </tr>
 <tr valign="top">
 <td>SEE_MASK_UNICODE (0x00004000)


### PR DESCRIPTION
This change updates SEE_MASK_FLAG_NO_UI description to be the same as defined inside ns-shellapi-shellexecuteinfow.md.

Refer #806 