### PR TITLE
Update nf-d2d1_3-id2d1devicecontext2-createimagesourcefromdxgi.md

### DIFF
--- a/sdk-api-src/content/d2d1_3/nf-d2d1_3-id2d1devicecontext2-createimagesourcefromdxgi.md
+++ b/sdk-api-src/content/d2d1_3/nf-d2d1_3-id2d1devicecontext2-createimagesourcefromdxgi.md
@@ -176,7 +176,7 @@ When Surface Count is 2:
 When Surface Count is 3:
 
 <ul>
-<li>{DXGI_FORMAT_R8_UNORM, DXGI_FORMAT_R8_UNORM, DXGI_FORMAT_R8_UNORM}</li>
+<li>{DXGI_FORMAT_A8_UNORM, DXGI_FORMAT_A8_UNORM, DXGI_FORMAT_A8_UNORM}</li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
I found that 3 x DXGI_FORMAT_R8 does not work (get an unhelpful invalid argument error), but by stepping through the disassembly discovered they need to be 3 x DXGI_FORMAT_A8. Can someone verify this?