### PR TITLE
Fix links

### DIFF
--- a/sdk-api-src/content/winuser/ns-winuser-kbdllhookstruct.md
+++ b/sdk-api-src/content/winuser/ns-winuser-kbdllhookstruct.md
@@ -198,7 +198,7 @@ Additional information associated with the message.
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a>
+<a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a>
 
 
 


### PR DESCRIPTION
`/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)` -> `/windows/win32/winmsg/lowlevelkeyboardproc`
`/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)` -> `/windows/win32/winmsg/lowlevelmouseproc`