### PR TITLE
Fix links

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-callmsgfiltera.md
+++ b/sdk-api-src/content/winuser/nf-winuser-callmsgfiltera.md
@@ -114,7 +114,7 @@ For an example, see <a href="/windows/desktop/winmsg/about-hooks">WH_MSGFILTER a
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a>
+<a href="/windows/win32/winmsg/messageproc">MessageProc</a>
 
 
 
@@ -126,4 +126,4 @@ For an example, see <a href="/windows/desktop/winmsg/about-hooks">WH_MSGFILTER a
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a>
+<a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-callmsgfilterw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-callmsgfilterw.md
@@ -114,7 +114,7 @@ For an example, see <a href="/windows/desktop/winmsg/about-hooks">WH_MSGFILTER a
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a>
+<a href="/windows/win32/winmsg/messageproc">MessageProc</a>
 
 
 
@@ -126,4 +126,4 @@ For an example, see <a href="/windows/desktop/winmsg/about-hooks">WH_MSGFILTER a
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a>
+<a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-defwindowproca.md
+++ b/sdk-api-src/content/winuser/nf-winuser-defwindowproca.md
@@ -130,7 +130,7 @@ LRESULT DefWindowProcA(
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-defwindowprocw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-defwindowprocw.md
@@ -130,7 +130,7 @@ LRESULT DefWindowProcW(
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayouta.md
@@ -99,7 +99,7 @@ Specifies how the input locale identifier is to be loaded. This parameter can be
 </dl>
 </td>
 <td width="60%">
-<b>Prior to Windows 8:</b> Prevents a <a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a> hook procedure from receiving an <b>HSHELL_LANGUAGE</b> hook code when the new input locale identifier is loaded. This value is typically used when an application loads multiple input locale identifiers one after another. Applying this value to all but the last input locale identifier delays the shell's processing until all input locale identifiers have been added.
+<b>Prior to Windows 8:</b> Prevents a <a href="/windows/win32/winmsg/shellproc">ShellProc</a> hook procedure from receiving an <b>HSHELL_LANGUAGE</b> hook code when the new input locale identifier is loaded. This value is typically used when an application loads multiple input locale identifiers one after another. Applying this value to all but the last input locale identifier delays the shell's processing until all input locale identifiers have been added.
 
 <b>Beginning in  Windows 8:</b> In this scenario, the last input locale identifier is set for the entire system.
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadkeyboardlayoutw.md
@@ -99,7 +99,7 @@ Specifies how the input locale identifier is to be loaded. This parameter can be
 </dl>
 </td>
 <td width="60%">
-<b>Prior to Windows 8:</b> Prevents a <a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a> hook procedure from receiving an <b>HSHELL_LANGUAGE</b> hook code when the new input locale identifier is loaded. This value is typically used when an application loads multiple input locale identifiers one after another. Applying this value to all but the last input locale identifier delays the shell's processing until all input locale identifiers have been added.
+<b>Prior to Windows 8:</b> Prevents a <a href="/windows/win32/winmsg/shellproc">ShellProc</a> hook procedure from receiving an <b>HSHELL_LANGUAGE</b> hook code when the new input locale identifier is loaded. This value is typically used when an application loads multiple input locale identifiers one after another. Applying this value to all but the last input locale identifier delays the shell's processing until all input locale identifiers have been added.
 
 <b>Beginning in  Windows 8:</b> In this scenario, the last input locale identifier is set for the entire system.
 

--- a/sdk-api-src/content/winuser/nf-winuser-registerclassa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerclassa.md
@@ -157,4 +157,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-procedures">As
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-registerclassexa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerclassexa.md
@@ -157,4 +157,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-classes">Using
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-registerclassexw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerclassexw.md
@@ -157,4 +157,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-classes">Using
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-registerclassw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registerclassw.md
@@ -157,4 +157,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-procedures">As
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-registershellhookwindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-registershellhookwindow.md
@@ -60,7 +60,7 @@ api_name:
 
 Registers a specified Shell window to receive certain messages for events or notifications that are useful to Shell applications.
 
-The event messages received are only those sent to the Shell window associated with the specified window's desktop. Many of the messages    are the same as those that can be received after calling the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowshookexa">SetWindowsHookEx</a> function and specifying <b>WH_SHELL</b> for the hook type. The difference with <b>RegisterShellHookWindow</b> is that the messages are received through the specified window's <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> and not through a call back procedure.
+The event messages received are only those sent to the Shell window associated with the specified window's desktop. Many of the messages    are the same as those that can be received after calling the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowshookexa">SetWindowsHookEx</a> function and specifying <b>WH_SHELL</b> for the hook type. The difference with <b>RegisterShellHookWindow</b> is that the messages are received through the specified window's <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> and not through a call back procedure.
 
 ## -parameters
 
@@ -177,7 +177,7 @@ This function was not included in the SDK headers and libraries until Windows X
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a>
+<a href="/windows/win32/winmsg/shellproc">ShellProc</a>
 
 
 
@@ -189,7 +189,7 @@ This function was not included in the SDK headers and libraries until Windows X
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-setclasslonga.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclasslonga.md
@@ -207,7 +207,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-If you use the <b>SetClassLong</b> function and the <b>GCL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use the <b>SetClassLong</b> function and the <b>GCL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 Calling <b>SetClassLong</b> with the <b>GCL_WNDPROC</b> index creates a subclass of the window class that affects all windows subsequently created with the class. An application can subclass a system class, but should not subclass a window class created by another process. 
 
@@ -262,4 +262,4 @@ For an example, see <a href="/windows/desktop/menurc/using-icons">Displaying an 
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setclasslongptra.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclasslongptra.md
@@ -205,7 +205,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-If you use the <b>SetClassLongPtr</b> function and the <b>GCLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use the <b>SetClassLongPtr</b> function and the <b>GCLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 Calling <b>SetClassLongPtr</b> with the <b>GCLP_WNDPROC</b> index creates a subclass of the window class that affects all windows subsequently created with the class. An application can subclass a system class, but should not subclass a window class created by another process. 
 
@@ -251,4 +251,4 @@ Use the <b>SetClassLongPtr</b> function with care. For example, it is possible t
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setclasslongptrw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclasslongptrw.md
@@ -205,7 +205,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-If you use the <b>SetClassLongPtr</b> function and the <b>GCLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use the <b>SetClassLongPtr</b> function and the <b>GCLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 Calling <b>SetClassLongPtr</b> with the <b>GCLP_WNDPROC</b> index creates a subclass of the window class that affects all windows subsequently created with the class. An application can subclass a system class, but should not subclass a window class created by another process. 
 
@@ -251,4 +251,4 @@ Use the <b>SetClassLongPtr</b> function with care. For example, it is possible t
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setclasslongw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setclasslongw.md
@@ -207,7 +207,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-If you use the <b>SetClassLong</b> function and the <b>GCL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use the <b>SetClassLong</b> function and the <b>GCL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 Calling <b>SetClassLong</b> with the <b>GCL_WNDPROC</b> index creates a subclass of the window class that affects all windows subsequently created with the class. An application can subclass a system class, but should not subclass a window class created by another process. 
 
@@ -262,4 +262,4 @@ For an example, see <a href="/windows/desktop/menurc/using-icons">Displaying an 
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
@@ -219,7 +219,7 @@ If the previous value of the specified 32-bit integer is zero, and the function 
 
 Certain window data is cached, so changes you make using <b>SetWindowLong</b> will not take effect until you call the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowpos">SetWindowPos</a> function. Specifically, if you change any of the frame styles, you must call <b>SetWindowPos</b> with the <b>SWP_FRAMECHANGED</b> flag for the cache to be updated properly. 
 
-If you use <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 If you use <b>SetWindowLong</b> with the <b>DWL_MSGRESULT</b> index to set the return value for a message processed by a dialog procedure, you should return <b>TRUE</b> directly afterward. Otherwise, if you call any function that results in your dialog procedure receiving a window message, the nested window message could overwrite the return value you set using <b>DWL_MSGRESULT</b>. 
 
@@ -285,4 +285,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-procedures">Su
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
@@ -219,7 +219,7 @@ If the previous value is zero and the function succeeds, the return value is zer
 
 Certain window data is cached, so changes you make using <b>SetWindowLongPtr</b> will not take effect until you call the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowpos">SetWindowPos</a> function.
 
-If you use <b>SetWindowLongPtr</b> with the <b>GWLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use <b>SetWindowLongPtr</b> with the <b>GWLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 If you use <b>SetWindowLongPtr</b> with the <b>DWLP_MSGRESULT</b> index to set the return value for a message processed by a dialog box procedure, the dialog box procedure should return <b>TRUE</b> directly afterward. Otherwise, if you call any function that results in your dialog box procedure receiving a window message, the nested window message could overwrite the return value you set by using <b>DWLP_MSGRESULT</b>. 
 
@@ -275,4 +275,4 @@ If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do n
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
@@ -219,7 +219,7 @@ If the previous value is zero and the function succeeds, the return value is zer
 
 Certain window data is cached, so changes you make using <b>SetWindowLongPtr</b> will not take effect until you call the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowpos">SetWindowPos</a> function.
 
-If you use <b>SetWindowLongPtr</b> with the <b>GWLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use <b>SetWindowLongPtr</b> with the <b>GWLP_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 If you use <b>SetWindowLongPtr</b> with the <b>DWLP_MSGRESULT</b> index to set the return value for a message processed by a dialog box procedure, the dialog box procedure should return <b>TRUE</b> directly afterward. Otherwise, if you call any function that results in your dialog box procedure receiving a window message, the nested window message could overwrite the return value you set by using <b>DWLP_MSGRESULT</b>. 
 
@@ -275,4 +275,4 @@ If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do n
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
@@ -219,7 +219,7 @@ If the previous value of the specified 32-bit integer is zero, and the function 
 
 Certain window data is cached, so changes you make using <b>SetWindowLong</b> will not take effect until you call the <a href="/windows/desktop/api/winuser/nf-winuser-setwindowpos">SetWindowPos</a> function. Specifically, if you change any of the frame styles, you must call <b>SetWindowPos</b> with the <b>SWP_FRAMECHANGED</b> flag for the cache to be updated properly. 
 
-If you use <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a> callback function. 
+If you use <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index to replace the window procedure, the window procedure must conform to the guidelines specified in the description of the <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a> callback function. 
 
 If you use <b>SetWindowLong</b> with the <b>DWL_MSGRESULT</b> index to set the return value for a message processed by a dialog procedure, you should return <b>TRUE</b> directly afterward. Otherwise, if you call any function that results in your dialog procedure receiving a window message, the nested window message could overwrite the return value you set using <b>DWL_MSGRESULT</b>. 
 
@@ -285,4 +285,4 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-procedures">Su
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowshookexa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowshookexa.md
@@ -137,7 +137,7 @@ Installs a hook procedure that will be called when the application's foreground 
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages posted to a message queue. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644981(v=vs.85)">GetMsgProc</a> hook procedure.
+Installs a hook procedure that monitors messages posted to a message queue. For more information, see the <a href="/windows/win32/winmsg/getmsgproc">GetMsgProc</a> hook procedure.
 
 </td>
 </tr>
@@ -152,7 +152,7 @@ Installs a hook procedure that monitors messages posted to a message queue. For 
 > [!WARNING]
 > Journaling Hooks APIs are unsupported starting in Windows 11 and will be removed in a future release. Because of this, we highly recommend calling the [**SendInput**](/windows/win32/api/winuser/nf-winuser-sendinput) TextInput API instead.
 
-Installs a hook procedure that posts messages previously recorded by a <a href="/windows/desktop/winmsg/about-hooks">WH_JOURNALRECORD</a> hook procedure. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a> hook procedure.
+Installs a hook procedure that posts messages previously recorded by a <a href="/windows/desktop/winmsg/about-hooks">WH_JOURNALRECORD</a> hook procedure. For more information, see the <a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a> hook procedure.
 
 </td>
 </tr>
@@ -167,7 +167,7 @@ Installs a hook procedure that posts messages previously recorded by a <a href="
 > [!WARNING]
 > Journaling Hooks APIs are unsupported starting in Windows 11 and will be removed in a future release. Because of this, we highly recommend calling the [**SendInput**](/windows/win32/api/winuser/nf-winuser-sendinput) TextInput API instead.
 
-Installs a hook procedure that records input messages posted to the system message queue. This hook is useful for recording macros. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644983(v=vs.85)">JournalRecordProc</a> hook procedure.
+Installs a hook procedure that records input messages posted to the system message queue. This hook is useful for recording macros. For more information, see the <a href="/windows/win32/winmsg/journalrecordproc">JournalRecordProc</a> hook procedure.
 
 </td>
 </tr>
@@ -178,7 +178,7 @@ Installs a hook procedure that records input messages posted to the system messa
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors keystroke messages. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644984(v=vs.85)">KeyboardProc</a> hook procedure.
+Installs a hook procedure that monitors keystroke messages. For more information, see the <a href="/windows/win32/winmsg/keyboardproc">KeyboardProc</a> hook procedure.
 
 </td>
 </tr>
@@ -189,7 +189,7 @@ Installs a hook procedure that monitors keystroke messages. For more information
 </dl>
 </td>
 <td width="60%">
- Installs a hook procedure that monitors low-level keyboard input events. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a> hook procedure.
+ Installs a hook procedure that monitors low-level keyboard input events. For more information, see the <a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a> hook procedure.
 
 </td>
 </tr>
@@ -200,7 +200,7 @@ Installs a hook procedure that monitors keystroke messages. For more information
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors mouse messages. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a> hook procedure.
+Installs a hook procedure that monitors mouse messages. For more information, see the <a href="/windows/win32/winmsg/mouseproc">MouseProc</a> hook procedure.
 
 </td>
 </tr>
@@ -211,7 +211,7 @@ Installs a hook procedure that monitors mouse messages. For more information, se
 </dl>
 </td>
 <td width="60%">
- Installs a hook procedure that monitors low-level mouse input events. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)">LowLevelMouseProc</a> hook procedure.
+ Installs a hook procedure that monitors low-level mouse input events. For more information, see the <a href="/windows/win32/winmsg/lowlevelmouseproc">LowLevelMouseProc</a> hook procedure.
 
 </td>
 </tr>
@@ -222,7 +222,7 @@ Installs a hook procedure that monitors mouse messages. For more information, se
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a> hook procedure.
+Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. For more information, see the <a href="/windows/win32/winmsg/messageproc">MessageProc</a> hook procedure.
 
 </td>
 </tr>
@@ -233,7 +233,7 @@ Installs a hook procedure that monitors messages generated as a result of an inp
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that receives notifications useful to shell applications. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a> hook procedure.
+Installs a hook procedure that receives notifications useful to shell applications. For more information, see the <a href="/windows/win32/winmsg/shellproc">ShellProc</a> hook procedure.
 
 </td>
 </tr>
@@ -244,7 +244,7 @@ Installs a hook procedure that receives notifications useful to shell applicatio
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. The hook procedure monitors these messages for all applications in the same desktop as the calling thread. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a> hook procedure.
+Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. The hook procedure monitors these messages for all applications in the same desktop as the calling thread. For more information, see the <a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a> hook procedure.
 
 </td>
 </tr>
@@ -437,7 +437,7 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644981(v=vs.85)">GetMsgProc</a>
+<a href="/windows/win32/winmsg/getmsgproc">GetMsgProc</a>
 
 
 
@@ -445,31 +445,31 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a>
+<a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644983(v=vs.85)">JournalRecordProc</a>
+<a href="/windows/win32/winmsg/journalrecordproc">JournalRecordProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644984(v=vs.85)">KeyboardProc</a>
+<a href="/windows/win32/winmsg/keyboardproc">KeyboardProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a>
+<a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)">LowLevelMouseProc</a>
+<a href="/windows/win32/winmsg/lowlevelmouseproc">LowLevelMouseProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a>
+<a href="/windows/win32/winmsg/messageproc">MessageProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>
+<a href="/windows/win32/winmsg/mouseproc">MouseProc</a>
 
 
 
@@ -477,11 +477,11 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a>
+<a href="/windows/win32/winmsg/shellproc">ShellProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a>
+<a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowshookexw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowshookexw.md
@@ -137,7 +137,7 @@ Installs a hook procedure that will be called when the application's foreground 
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages posted to a message queue. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644981(v=vs.85)">GetMsgProc</a> hook procedure.
+Installs a hook procedure that monitors messages posted to a message queue. For more information, see the <a href="/windows/win32/winmsg/getmsgproc">GetMsgProc</a> hook procedure.
 
 </td>
 </tr>
@@ -152,7 +152,7 @@ Installs a hook procedure that monitors messages posted to a message queue. For 
 > [!WARNING]
 > Journaling Hooks APIs are unsupported starting in Windows 11 and will be removed in a future release. Because of this, we highly recommend calling the [**SendInput**](/windows/win32/api/winuser/nf-winuser-sendinput) TextInput API instead.
 
-Installs a hook procedure that posts messages previously recorded by a <a href="/windows/desktop/winmsg/about-hooks">WH_JOURNALRECORD</a> hook procedure. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a> hook procedure.
+Installs a hook procedure that posts messages previously recorded by a <a href="/windows/desktop/winmsg/about-hooks">WH_JOURNALRECORD</a> hook procedure. For more information, see the <a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a> hook procedure.
 
 </td>
 </tr>
@@ -167,7 +167,7 @@ Installs a hook procedure that posts messages previously recorded by a <a href="
 > [!WARNING]
 > Journaling Hooks APIs are unsupported starting in Windows 11 and will be removed in a future release. Because of this, we highly recommend calling the [**SendInput**](/windows/win32/api/winuser/nf-winuser-sendinput) TextInput API instead.
 
-Installs a hook procedure that records input messages posted to the system message queue. This hook is useful for recording macros. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644983(v=vs.85)">JournalRecordProc</a> hook procedure.
+Installs a hook procedure that records input messages posted to the system message queue. This hook is useful for recording macros. For more information, see the <a href="/windows/win32/winmsg/journalrecordproc">JournalRecordProc</a> hook procedure.
 
 </td>
 </tr>
@@ -178,7 +178,7 @@ Installs a hook procedure that records input messages posted to the system messa
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors keystroke messages. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644984(v=vs.85)">KeyboardProc</a> hook procedure.
+Installs a hook procedure that monitors keystroke messages. For more information, see the <a href="/windows/win32/winmsg/keyboardproc">KeyboardProc</a> hook procedure.
 
 </td>
 </tr>
@@ -189,7 +189,7 @@ Installs a hook procedure that monitors keystroke messages. For more information
 </dl>
 </td>
 <td width="60%">
- Installs a hook procedure that monitors low-level keyboard input events. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a> hook procedure.
+ Installs a hook procedure that monitors low-level keyboard input events. For more information, see the <a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a> hook procedure.
 
 </td>
 </tr>
@@ -200,7 +200,7 @@ Installs a hook procedure that monitors keystroke messages. For more information
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors mouse messages. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a> hook procedure.
+Installs a hook procedure that monitors mouse messages. For more information, see the <a href="/windows/win32/winmsg/mouseproc">MouseProc</a> hook procedure.
 
 </td>
 </tr>
@@ -211,7 +211,7 @@ Installs a hook procedure that monitors mouse messages. For more information, se
 </dl>
 </td>
 <td width="60%">
- Installs a hook procedure that monitors low-level mouse input events. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)">LowLevelMouseProc</a> hook procedure.
+ Installs a hook procedure that monitors low-level mouse input events. For more information, see the <a href="/windows/win32/winmsg/lowlevelmouseproc">LowLevelMouseProc</a> hook procedure.
 
 </td>
 </tr>
@@ -222,7 +222,7 @@ Installs a hook procedure that monitors mouse messages. For more information, se
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a> hook procedure.
+Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. For more information, see the <a href="/windows/win32/winmsg/messageproc">MessageProc</a> hook procedure.
 
 </td>
 </tr>
@@ -233,7 +233,7 @@ Installs a hook procedure that monitors messages generated as a result of an inp
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that receives notifications useful to shell applications. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a> hook procedure.
+Installs a hook procedure that receives notifications useful to shell applications. For more information, see the <a href="/windows/win32/winmsg/shellproc">ShellProc</a> hook procedure.
 
 </td>
 </tr>
@@ -244,7 +244,7 @@ Installs a hook procedure that receives notifications useful to shell applicatio
 </dl>
 </td>
 <td width="60%">
-Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. The hook procedure monitors these messages for all applications in the same desktop as the calling thread. For more information, see the <a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a> hook procedure.
+Installs a hook procedure that monitors messages generated as a result of an input event in a dialog box, message box, menu, or scroll bar. The hook procedure monitors these messages for all applications in the same desktop as the calling thread. For more information, see the <a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a> hook procedure.
 
 </td>
 </tr>
@@ -437,7 +437,7 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644981(v=vs.85)">GetMsgProc</a>
+<a href="/windows/win32/winmsg/getmsgproc">GetMsgProc</a>
 
 
 
@@ -445,31 +445,31 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a>
+<a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644983(v=vs.85)">JournalRecordProc</a>
+<a href="/windows/win32/winmsg/journalrecordproc">JournalRecordProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644984(v=vs.85)">KeyboardProc</a>
+<a href="/windows/win32/winmsg/keyboardproc">KeyboardProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a>
+<a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)">LowLevelMouseProc</a>
+<a href="/windows/win32/winmsg/lowlevelmouseproc">LowLevelMouseProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)">MessageProc</a>
+<a href="/windows/win32/winmsg/messageproc">MessageProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>
+<a href="/windows/win32/winmsg/mouseproc">MouseProc</a>
 
 
 
@@ -477,11 +477,11 @@ For an example, see <a href="/windows/desktop/winmsg/using-hooks">Installing and
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)">ShellProc</a>
+<a href="/windows/win32/winmsg/shellproc">ShellProc</a>
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)">SysMsgProc</a>
+<a href="/windows/win32/winmsg/sysmsgproc">SysMsgProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-eventmsg.md
+++ b/sdk-api-src/content/winuser/ns-winuser-eventmsg.md
@@ -54,7 +54,7 @@ api_name:
 
 ## -description
 
-Contains information about a hardware message sent to the system message queue. This structure is used to store message information for the <a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a> callback function.
+Contains information about a hardware message sent to the system message queue. This structure is used to store message information for the <a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a> callback function.
 
 ## -struct-fields
 
@@ -100,7 +100,7 @@ A handle to the window to which the message was posted.
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)">JournalPlaybackProc</a>
+<a href="/windows/win32/winmsg/journalplaybackproc">JournalPlaybackProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-kbdllhookstruct.md
+++ b/sdk-api-src/content/winuser/ns-winuser-kbdllhookstruct.md
@@ -198,7 +198,7 @@ Additional information associated with the message.
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)">LowLevelKeyboardProc</a>
+<a href="/windows/win32/winmsg/lowlevelkeyboardproc">LowLevelKeyboardProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-mousehookstruct.md
+++ b/sdk-api-src/content/winuser/ns-winuser-mousehookstruct.md
@@ -54,7 +54,7 @@ api_name:
 
 ## -description
 
-Contains information about a mouse event passed to a <b>WH_MOUSE</b> hook procedure, <a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>.
+Contains information about a mouse event passed to a <b>WH_MOUSE</b> hook procedure, <a href="/windows/win32/winmsg/mouseproc">MouseProc</a>.
 
 ## -struct-fields
 
@@ -92,7 +92,7 @@ Additional information associated with the message.
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>
+<a href="/windows/win32/winmsg/mouseproc">MouseProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-mousehookstructex.md
+++ b/sdk-api-src/content/winuser/ns-winuser-mousehookstructex.md
@@ -54,7 +54,7 @@ api_name:
 
 ## -description
 
-Contains information about a mouse event passed to a <b>WH_MOUSE</b> hook procedure, <a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>. 
+Contains information about a mouse event passed to a <b>WH_MOUSE</b> hook procedure, <a href="/windows/win32/winmsg/mouseproc">MouseProc</a>. 
 
 This is an extension of the <a href="/windows/desktop/api/winuser/ns-winuser-mousehookstruct">MOUSEHOOKSTRUCT</a> structure that includes information about wheel movement or the use of the X button.
 
@@ -119,7 +119,7 @@ The members of a <a href="/windows/desktop/api/winuser/ns-winuser-mousehookstruc
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)">MouseProc</a>
+<a href="/windows/win32/winmsg/mouseproc">MouseProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-msllhookstruct.md
+++ b/sdk-api-src/content/winuser/ns-winuser-msllhookstruct.md
@@ -159,7 +159,7 @@ Additional information associated with the message.
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)">LowLevelMouseProc</a>
+<a href="/windows/win32/winmsg/lowlevelmouseproc">LowLevelMouseProc</a>
 
 
 

--- a/sdk-api-src/content/winuser/ns-winuser-wndclassa.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassa.md
@@ -72,7 +72,7 @@ The class style(s). This member can be any combination of the <a href="/windows/
 
 Type: <b>WNDPROC</b>
 
-A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>.
+A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>.
 
 ### -field cbClsExtra
 
@@ -216,7 +216,7 @@ The maximum length for <b>lpszClassName</b> is 256. If <b>lpszClassName</b> is g
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/ns-winuser-wndclassexa.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassexa.md
@@ -79,7 +79,7 @@ The class style(s). This member can be any combination of the <a href="/windows/
 
 Type: <b>WNDPROC</b>
 
-A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>.
+A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>.
 
 ### -field cbClsExtra
 

--- a/sdk-api-src/content/winuser/ns-winuser-wndclassexw.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassexw.md
@@ -79,7 +79,7 @@ The class style(s). This member can be any combination of the <a href="/windows/
 
 Type: <b>WNDPROC</b>
 
-A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>.
+A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>.
 
 ### -field cbClsExtra
 

--- a/sdk-api-src/content/winuser/ns-winuser-wndclassw.md
+++ b/sdk-api-src/content/winuser/ns-winuser-wndclassw.md
@@ -72,7 +72,7 @@ The class style(s). This member can be any combination of the <a href="/windows/
 
 Type: <b>WNDPROC</b>
 
-A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>.
+A pointer to the window procedure. You must use the <a href="/windows/desktop/api/winuser/nf-winuser-callwindowproca">CallWindowProc</a> function to call the window procedure. For more information, see <a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>.
 
 ### -field cbClsExtra
 
@@ -216,7 +216,7 @@ The maximum length for <b>lpszClassName</b> is 256. If <b>lpszClassName</b> is g
 
 
 
-<a href="/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)">WindowProc</a>
+<a href="/windows/win32/api/winuser/nc-winuser-wndproc">WindowProc</a>
 
 ## -remarks
 


### PR DESCRIPTION
`/previous-versions/windows/desktop/legacy/ms644981(v=vs.85)` -> `/windows/win32/winmsg/getmsgproc`
`/previous-versions/windows/desktop/legacy/ms644982(v=vs.85)` -> `/windows/win32/winmsg/journalplaybackproc`
`/previous-versions/windows/desktop/legacy/ms644983(v=vs.85)` -> `/windows/win32/winmsg/journalrecordproc`
`/previous-versions/windows/desktop/legacy/ms644984(v=vs.85)` -> `/windows/win32/winmsg/keyboardproc`
`/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)` -> `/windows/win32/winmsg/lowlevelkeyboardproc`
`/previous-versions/windows/desktop/legacy/ms644986(v=vs.85)` -> `/windows/win32/winmsg/lowlevelmouseproc`
`/previous-versions/windows/desktop/legacy/ms644987(v=vs.85)` -> `/windows/win32/winmsg/messageproc`
`/previous-versions/windows/desktop/legacy/ms644988(v=vs.85)` -> `/windows/win32/winmsg/mouseproc`
`/previous-versions/windows/desktop/legacy/ms644991(v=vs.85)` -> `/windows/win32/winmsg/shellproc`
`/previous-versions/windows/desktop/legacy/ms644992(v=vs.85)` -> `/windows/win32/winmsg/sysmsgproc`
`/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)` -> `/windows/win32/api/winuser/nc-winuser-wndproc`

**TODO**: These pages are still mandatory and should be restored from archive and links get fixed in the docs:
- [HIBYTE](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632656(v=vs.85))
- [HIWORD](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632657(v=vs.85))
- [LOBYTE](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632658(v=vs.85))
- [LOWORD](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632659(v=vs.85))
- [MAKELONG](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632660(v=vs.85))
- [MAKEWORD](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms632663(v=vs.85))
- [DebugProc](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms644978(v=vs.85))
- [ForegroundIdleProc](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms644980(v=vs.85) )
- [CBTProc](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms644977(v=vs.85))
- [CallWndProc](https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms644975(v=vs.85))

Related PR https://github.com/MicrosoftDocs/win32/pull/1614