### PR TITLE
Add mandatory note about GetKeyNameText API

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getkeynametexta.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeynametexta.md
@@ -97,13 +97,26 @@ If the function fails, the return value is zero. To get extended error informati
 ## -remarks
 
 The format of the key-name string depends on the current keyboard layout.
-The keyboard driver maintains a list of names in the form of character strings for keys with names longer than a single character.
-The key name is translated according to the layout of the currently installed keyboard, thus the function may give different results for different input locales.
+
+The keyboard layout maintains a list of names in the form of character strings for keys with names longer than a single character.
+The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), thus the function may give different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
+
 The name of a character key is the character itself. The names of dead keys are spelled out in full.
+
+> [!NOTE]
+> This method may not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. It is recommended to use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods that handles such cases properly.
 
 > [!NOTE]
 > The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 
-<a href="/windows/desktop/inputdev/keyboard-input">Keyboard Input</a>
+[Keyboard Input](/windows/desktop/inputdev/keyboard-input)
+
+[Keyboard Layouts](/globalization/windows-keyboard-layouts)
+
+[Keyboard Layout Samples](/samples/microsoft/windows-driver-samples/keyboard-layout-samples)
+
+[ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode)
+
+[ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex)

--- a/sdk-api-src/content/winuser/nf-winuser-getkeynametexta.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeynametexta.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["GetKeyNameTextA", "winuser/GetKeyNameTextA"]
 old-location: inputdev\getkeynametext.htm
 tech.root: inputdev
 ms.assetid: VS|winui|~\winui\windowsuserinterface\userinput\keyboardinput\keyboardinputreference\keyboardinputfunctions\getkeynametext.htm
-ms.date: 12/05/2018
+ms.date: 08/18/2023
 ms.keywords: GetKeyNameText, GetKeyNameText function [Keyboard and Mouse Input], GetKeyNameTextA, GetKeyNameTextW, _win32_GetKeyNameText, _win32_getkeynametext_cpp, inputdev.getkeynametext, winui._win32_getkeynametext, winuser/GetKeyNameText, winuser/GetKeyNameTextA, winuser/GetKeyNameTextW
 req.header: winuser.h
 req.include-header: Windows.h
@@ -99,15 +99,13 @@ If the function fails, the return value is zero. To get extended error informati
 The format of the key-name string depends on the current keyboard layout.
 
 The keyboard layout maintains a list of names in the form of character strings for keys with names longer than a single character.
-The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), thus the function may give different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
+The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), therefore the function might return different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
 
 The name of a character key is the character itself. The names of dead keys are spelled out in full.
 
-> [!NOTE]
-> This method may not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. It is recommended to use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods that handles such cases properly.
+This method might not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. Use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods in such cases.
 
-> [!NOTE]
-> The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
+The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-getkeynametextw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeynametextw.md
@@ -97,13 +97,26 @@ If the function fails, the return value is zero. To get extended error informati
 ## -remarks
 
 The format of the key-name string depends on the current keyboard layout.
-The keyboard driver maintains a list of names in the form of character strings for keys with names longer than a single character.
-The key name is translated according to the layout of the currently installed keyboard, thus the function may give different results for different input locales.
+
+The keyboard layout maintains a list of names in the form of character strings for keys with names longer than a single character.
+The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), thus the function may give different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
+
 The name of a character key is the character itself. The names of dead keys are spelled out in full.
+
+> [!NOTE]
+> This method may not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. It is recommended to use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods that handles such cases properly.
 
 > [!NOTE]
 > The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 
-<a href="/windows/desktop/inputdev/keyboard-input">Keyboard Input</a>
+[Keyboard Input](/windows/desktop/inputdev/keyboard-input)
+
+[Keyboard Layouts](/globalization/windows-keyboard-layouts)
+
+[Keyboard Layout Samples](/samples/microsoft/windows-driver-samples/keyboard-layout-samples)
+
+[ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode)
+
+[ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex)

--- a/sdk-api-src/content/winuser/nf-winuser-getkeynametextw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getkeynametextw.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["GetKeyNameText", "GetKeyNameText function [Keyboard and M
 old-location: inputdev\getkeynametext.htm
 tech.root: inputdev
 ms.assetid: VS|winui|~\winui\windowsuserinterface\userinput\keyboardinput\keyboardinputreference\keyboardinputfunctions\getkeynametext.htm
-ms.date: 12/05/2018
+ms.date: 08/18/2023
 ms.keywords: GetKeyNameText, GetKeyNameText function [Keyboard and Mouse Input], GetKeyNameTextA, GetKeyNameTextW, _win32_GetKeyNameText, _win32_getkeynametext_cpp, inputdev.getkeynametext, winui._win32_getkeynametext, winuser/GetKeyNameText, winuser/GetKeyNameTextA, winuser/GetKeyNameTextW
 req.header: winuser.h
 req.include-header: Windows.h
@@ -99,15 +99,13 @@ If the function fails, the return value is zero. To get extended error informati
 The format of the key-name string depends on the current keyboard layout.
 
 The keyboard layout maintains a list of names in the form of character strings for keys with names longer than a single character.
-The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), thus the function may give different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
+The key name is translated according to the [currently active keyboard layout](/windows/win32/inputdev/about-keyboard-input#languages-locales-and-keyboard-layouts), therefore the function might return different results for different [keyboard layouts](/globalization/windows-keyboard-layouts).
 
 The name of a character key is the character itself. The names of dead keys are spelled out in full.
 
-> [!NOTE]
-> This method may not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that may produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. It is recommended to use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods that handles such cases properly.
+This method might not work properly with some [keyboard layouts](/globalization/windows-keyboard-layouts) that produce multiple characters (i.e. ligatures) and/or supplementary Unicode characters that are printed on a single key press. Also, keys that are mapped to the 'A'..'Z' [virtual-key codes](/windows/win32/inputdev/virtual-key-codes) are translated to upper-case 'A'..'Z' characters regardless of current keyboard layout. Use the [ToUnicode](/windows/win32/api/winuser/nf-winuser-tounicode) or [ToUnicodeEx](/windows/win32/api/winuser/nf-winuser-tounicodeex) methods in such cases.
 
-> [!NOTE]
-> The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
+The winuser.h header defines GetKeyNameText as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 


### PR DESCRIPTION
`GetKeyNameText` method is full of pitfalls. it is necessary to at least mention them.

It uses a "broken" `MapVirtualKey(.., MAPVK_VK_TO_CHAR)` under the hood and thus is broken too for A..Z keys, ligatures and non-BMP Unicode chars. Bad, bad, bad.

Related PR https://github.com/MicrosoftDocs/sdk-api/pull/1376
https://stackoverflow.com/a/72464432/1795050