### PR TITLE
Remove pre-release flag from IsWindowArranged docs

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-iswindowarranged.md
+++ b/sdk-api-src/content/winuser/nf-winuser-iswindowarranged.md
@@ -5,7 +5,7 @@ title: IsWindowArranged function (winuser.h)
 ms.date: 06/07/2023
 targetos: Windows
 description: Determines whether the specified window is arranged (that is, whether it's snapped).
-prerelease: true
+prerelease: false
 req.assembly: 
 req.construct-type: function
 req.ddi-compliance: 


### PR DESCRIPTION
IsWindowArranged claims to work back to **Windows 10, version 1903** so cannot be pre-release.