### PR TITLE
Add missing "optional" for GetFileVersionInfoSizeEx lpdwHandle

### DIFF
--- a/sdk-api-src/content/winver/nf-winver-getfileversioninfosizeexa.md
+++ b/sdk-api-src/content/winver/nf-winver-getfileversioninfosizeexa.md
@@ -104,7 +104,7 @@ Type: <b>LPCTSTR</b>
 
 The name of the file of interest. The function uses the search sequence specified by the  <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function.
 
-### -param lpdwHandle [out]
+### -param lpdwHandle [out, optional]
 
 Type: <b>LPDWORD</b>
 

--- a/sdk-api-src/content/winver/nf-winver-getfileversioninfosizeexw.md
+++ b/sdk-api-src/content/winver/nf-winver-getfileversioninfosizeexw.md
@@ -104,7 +104,7 @@ Type: <b>LPCTSTR</b>
 
 The name of the file of interest. The function uses the search sequence specified by the  <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> function.
 
-### -param lpdwHandle [out]
+### -param lpdwHandle [out, optional]
 
 Type: <b>LPDWORD</b>
 


### PR DESCRIPTION
The same as there is in `GetFileVersionInfoSize` which is the same as `GetFileVersionInfoSizeEx` with default flags.