### PR TITLE
LoadIconMetric and LoadIconWithScaleDown not working properly with *.ico files

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param lims [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconmetric.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param lims [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param cx [in]
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-loadiconwithscaledown.md
@@ -70,7 +70,7 @@ A pointer to a null-terminated, Unicode buffer that contains location informatio
 
 If <i>hinst</i> is non-<b>NULL</b>, <i>pszName</i> specifies the icon resource either by name or ordinal. This ordinal must be packaged by using the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcew">MAKEINTRESOURCE</a> macro.
 
-If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the name of a standalone icon (.ico) file or the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
+If <i>hinst</i> is <b>NULL</b>, <i>pszName</i> specifies either the [identifier (beginning with the IDI\_ prefix)](/windows/win32/menurc/about-icons) of a predefined system icon to load.
 
 ### -param cx [in]
 


### PR DESCRIPTION
It looks like `LoadIconMetric` and `LoadIconWithScaleDown` are not working properly with `*.ico` files from the disk.

This code is not working:
```cpp
HICON h;
HRESULT r = LoadIconWithScaleDown(nullptr, L"c:\\test.ico", GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON), &h);
```
(but works if `cx`/`cy` is not `SM_CXICON`/`SM_CYICON`)

Also this is not working:
```cpp
HICON h;
HRESULT r = LoadIconMetric(nullptr, L"c:\\test.ico", LIM_LARGE, &h);
```

But this works:
```cpp
HICON h;
HRESULT r = LoadIconMetric(nullptr, L"c:\\test.ico", LIM_SMALL, &h);
```

I think it is easier just to remove mention of `*.ico` from the docs.

Was also reported a while ago here:
http://rsdn.org/forum/winapi/3976498.all