### PR TITLE
Update nf-processthreadsapi-setthreadselectedcpusets.md

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadselectedcpusets.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setthreadselectedcpusets.md
@@ -65,6 +65,8 @@ Specifies the number of IDs in the list passed in the **CpuSetIds** argument. If
 
 ## -returns
 
+If the function succeeds, the return value is nonzero.
+
 This function cannot fail when passed valid parameters.
 
 ## -remarks


### PR DESCRIPTION
The return value on success should be explicit and unambiguous. 

The terminology used here is consistent with the other documentation. 