### PR TITLE
w[v]sprintf[AW] - fix buffer sizes, document Id, Iu

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-wsprintfa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wsprintfa.md
@@ -61,7 +61,7 @@ Writes formatted data to the specified buffer. Any arguments are converted and c
 
 Type: <b>LPTSTR</b>
 
-The buffer that is to receive the formatted output. The maximum size of the buffer is 1,024 bytes.
+The buffer that is to receive the formatted output. The maximum size of the buffer is 1025 bytes (1024 characters and space for a null-terminator).
 
 ### -param unnamedParam2 [in]
 
@@ -185,6 +185,16 @@ Unsigned short integer.
 Signed decimal integer. This value is equivalent to <code>d</code>.
 
 </dd>
+<dt><a id="Id"></a><code>Id</code></dt>
+<dd>
+64-bit signed decimal integer on 64-bit platforms, 32-bit signed decimal integer on 32-bit platforms.
+
+</dd>
+<dt><a id="Iu"></a><code>Iu</code></dt>
+<dd>
+64-bit unsigned decimal integer on 64-bit platforms, 32-bit unsigned decimal integer on 32-bit platforms.
+
+</dd>
 <dt><a id="Ix__IX"></a><a id="ix__ix"></a><a id="IX__IX"></a><code>Ix</code>, <code>IX</code></dt>
 <dd>
 64-bit unsigned hexadecimal integer in lowercase or uppercase on 64-bit platforms, 32-bit unsigned hexadecimal integer in lowercase or uppercase on 32-bit platforms.
@@ -253,7 +263,7 @@ Unsigned hexadecimal integer in lowercase or uppercase.
 
 <div class="alert"><b>Note</b>  It is important to note that <b>wsprintf</b> uses the C calling convention (<b>_cdecl</b>), rather than the standard call (<b>_stdcall</b>) calling convention. As a result, it is the responsibility of the calling process to pop arguments off the stack, and arguments are pushed on the stack from right to left. In C-language modules, the C compiler performs this task.</div>
 <div> </div>
-To use buffers larger than 1024 bytes, use <b>_snwprintf</b>. For more information, see the documentation for the C run-time library. 
+To format strings larger than 1024 characters, use <b>_snwprintf</b>. For more information, see the documentation for the C run-time library. 
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wsprintfw.md
@@ -61,7 +61,7 @@ Writes formatted data to the specified buffer. Any arguments are converted and c
 
 Type: <b>LPTSTR</b>
 
-The buffer that is to receive the formatted output. The maximum size of the buffer is 1,024 bytes.
+The buffer that is to receive the formatted output. The maximum size of the buffer is 2050 bytes (1024 characters and space for a null-terminator).
 
 ### -param unnamedParam2 [in]
 
@@ -185,6 +185,16 @@ Unsigned short integer.
 Signed decimal integer. This value is equivalent to <code>d</code>.
 
 </dd>
+<dt><a id="Id"></a><code>Id</code></dt>
+<dd>
+64-bit signed decimal integer on 64-bit platforms, 32-bit signed decimal integer on 32-bit platforms.
+
+</dd>
+<dt><a id="Iu"></a><code>Iu</code></dt>
+<dd>
+64-bit unsigned decimal integer on 64-bit platforms, 32-bit unsigned decimal integer on 32-bit platforms.
+
+</dd>
 <dt><a id="Ix__IX"></a><a id="ix__ix"></a><a id="IX__IX"></a><code>Ix</code>, <code>IX</code></dt>
 <dd>
 64-bit unsigned hexadecimal integer in lowercase or uppercase on 64-bit platforms, 32-bit unsigned hexadecimal integer in lowercase or uppercase on 32-bit platforms.
@@ -253,7 +263,7 @@ Unsigned hexadecimal integer in lowercase or uppercase.
 
 <div class="alert"><b>Note</b>  It is important to note that <b>wsprintf</b> uses the C calling convention (<b>_cdecl</b>), rather than the standard call (<b>_stdcall</b>) calling convention. As a result, it is the responsibility of the calling process to pop arguments off the stack, and arguments are pushed on the stack from right to left. In C-language modules, the C compiler performs this task.</div>
 <div> </div>
-To use buffers larger than 1024 bytes, use <b>_snwprintf</b>. For more information, see the documentation for the C run-time library. 
+To format strings larger than 1024 characters, use <b>_snwprintf</b>. For more information, see the documentation for the C run-time library. 
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-wvsprintfa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wvsprintfa.md
@@ -63,7 +63,7 @@ Writes formatted data to the specified buffer using a pointer to a list of argum
 
 Type: <b>LPTSTR</b>
 
-The buffer that is to receive the formatted output. The maximum size of the buffer is 1,024 bytes.
+The buffer that is to receive the formatted output. The maximum size of the buffer is 1025 bytes (1024 characters and space for a null-terminator).
 
 ### -param unnamedParam2 [in]
 

--- a/sdk-api-src/content/winuser/nf-winuser-wvsprintfw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-wvsprintfw.md
@@ -63,7 +63,7 @@ Writes formatted data to the specified buffer using a pointer to a list of argum
 
 Type: <b>LPTSTR</b>
 
-The buffer that is to receive the formatted output. The maximum size of the buffer is 1,024 bytes.
+The buffer that is to receive the formatted output. The maximum size of the buffer is 1025 bytes (1024 characters and space for a null-terminator).
 
 ### -param unnamedParam2 [in]
 


### PR DESCRIPTION
It's mentioned in several StackOverflow answers but not documented