### PR TITLE
Correct WinMain Annotation

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-winmain.md
+++ b/sdk-api-src/content/winbase/nf-winbase-winmain.md
@@ -62,7 +62,7 @@ Type: <b>HINSTANCE</b>
 
 A handle to the current instance of the application.
 
-### -param hPrevInstance [in]
+### -param hPrevInstance [in, optional]
 
 Type: <b>HINSTANCE</b>
 


### PR DESCRIPTION
Currently, WinMain's annotations are documented incorrectly.
`hPrevInstance` is declared as `_In_opt_` in WinBase.h, which causes IntelliSense to complain about inconsistent annotation.

![image](https://github.com/MicrosoftDocs/sdk-api/assets/44537737/8dd87116-da98-492f-a7aa-b5d7bedecaad)
