### PR TITLE
Add C++/WinRT links to IInspectable member functions

### DIFF
--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getiids.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getiids.md
@@ -113,6 +113,6 @@ The caller is responsible for freeing the IID array by using the <a href="/windo
 
 <a href="/windows/desktop/api/inputpaneinterop/nn-inputpaneinterop-iinputpaneinterop">IInputPaneInterop</a>
 
-
-
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
+
+[winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces), the C++/WinRT equivalent of this function

--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getiids.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getiids.md
@@ -46,9 +46,6 @@ api_name:
  - IInputPaneInterop.GetIids
 ---
 
-# IInspectable::GetIids
-
-
 ## -description
 
 Gets the interfaces that are implemented by the current Windows Runtime class.
@@ -115,4 +112,4 @@ The caller is responsible for freeing the IID array by using the <a href="/windo
 
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
 
-[winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces), the C++/WinRT equivalent of this function
+[winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces)

--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getruntimeclassname.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getruntimeclassname.md
@@ -46,9 +46,6 @@ api_name:
  - IInputPaneInterop.GetRuntimeClassName
 ---
 
-# IInspectable::GetRuntimeClassName
-
-
 ## -description
 
 Gets the fully qualified name of the current Windows Runtime object.
@@ -152,4 +149,4 @@ The <b>GetRuntimeClassName</b> method returns <b>E_ILLEGAL_METHOD_CALL</b> if th
 
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
 
-[winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name), the C++/WinRT wrapper for this function
+[winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name)

--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getruntimeclassname.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-getruntimeclassname.md
@@ -150,6 +150,6 @@ The <b>GetRuntimeClassName</b> method returns <b>E_ILLEGAL_METHOD_CALL</b> if th
 
 <a href="/windows/desktop/api/inputpaneinterop/nn-inputpaneinterop-iinputpaneinterop">IInputPaneInterop</a>
 
-
-
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
+
+[winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name), the C++/WinRT wrapper for this function

--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-gettrustlevel.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-gettrustlevel.md
@@ -71,6 +71,6 @@ This method always returns <b>S_OK</b>.
 
 <a href="/windows/desktop/api/inputpaneinterop/nn-inputpaneinterop-iinputpaneinterop">IInputPaneInterop</a>
 
-
-
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
+
+[winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level), the C++/WinRT wrapper for this function

--- a/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-gettrustlevel.md
+++ b/sdk-api-src/content/inspectable/nf-inspectable-iinspectable-gettrustlevel.md
@@ -46,9 +46,6 @@ api_name:
  - IInputPaneInterop.GetTrustLevel
 ---
 
-# IInspectable::GetTrustLevel
-
-
 ## -description
 
 Gets the trust level of the current Windows Runtime object.
@@ -73,4 +70,4 @@ This method always returns <b>S_OK</b>.
 
 <a href="/windows/desktop/api/inspectable/nn-inspectable-iinspectable">IInspectable</a>
 
-[winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level), the C++/WinRT wrapper for this function
+[winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level)

--- a/sdk-api-src/content/inspectable/nn-inspectable-iinspectable.md
+++ b/sdk-api-src/content/inspectable/nn-inspectable-iinspectable.md
@@ -45,9 +45,6 @@ api_name:
  - IInspectable
 ---
 
-# IInspectable interface
-
-
 ## -description
 
 Provides functionality required for all Windows Runtime classes.
@@ -66,8 +63,8 @@ The <b>IInspectable</b> interface inherits from the <a href="/windows/desktop/ap
 
 <a href="/windows/desktop/api/inspectable/ne-inspectable-trustlevel">TrustLevel</a>
 
-The C++/WinRT equivalents of IInspectable's member functions:
+[winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces)
 
-* [winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces), wraps `::GetIids`
-* [winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name), wraps `::GetRuntimeClassName`
-* [winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level), wraps `::GetTrustLevel`
+[winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name)
+
+[winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level)

--- a/sdk-api-src/content/inspectable/nn-inspectable-iinspectable.md
+++ b/sdk-api-src/content/inspectable/nn-inspectable-iinspectable.md
@@ -64,6 +64,10 @@ The <b>IInspectable</b> interface inherits from the <a href="/windows/desktop/ap
 
 <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>
 
-
-
 <a href="/windows/desktop/api/inspectable/ne-inspectable-trustlevel">TrustLevel</a>
+
+The C++/WinRT equivalents of IInspectable's member functions:
+
+* [winrt::get_interfaces](/uwp/cpp-ref-for-winrt/get-interfaces), wraps `::GetIids`
+* [winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name), wraps `::GetRuntimeClassName`
+* [winrt::get_trust_level](/uwp/cpp-ref-for-winrt/get-trust-level), wraps `::GetTrustLevel`


### PR DESCRIPTION
Today, the documentation IInspectable's member functions (`GetIids`, `GetRuntimeClassName`, and `GetTrustLevel`) does not mention their C++/WinRT equivalents. These wrappers are not obvious, since they are free functions in C++/WinRT and member functions in raw WinRT, _plus_ they are named differently in C++/WinRT.

This change adds simple links to the C++/WinRT helper.