### PR TITLE
Fix typo in nf-winnls-lcmapstringex.md

### DIFF
--- a/sdk-api-src/content/winnls/nf-winnls-lcmapstringex.md
+++ b/sdk-api-src/content/winnls/nf-winnls-lcmapstringex.md
@@ -283,7 +283,7 @@ Reserved; must be 0.
 
 If the function succeeds when used for string mapping, it returns the number of characters in the translated string (see *cchSrc* and *cchDest* for more details).
 
-If the function succeeds when used for string mapping it returns the number of bytes in the sort key.
+If the function succeeds when used for generating a sort key, it returns the number of bytes in the sort key.
 
 This function returns 0 if it does not succeed. To get extended error information, the application can call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>, which can return one of the following error codes:
 


### PR DESCRIPTION
In the "Return value" section, the first paragraph already talks about what is returned when the function is used for string mapping. The second paragraph intended to say what is returned when the function is used to generate a sort key, but repeated the words for the string mapping scenario.