### PR TITLE
Fixed several typos of nf-winsock2-wsasocketa.md

### DIFF
--- a/sdk-api-src/content/winsock2/nf-winsock2-wsasocketa.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsasocketa.md
@@ -260,9 +260,9 @@ In Windows Sockets 1.1, the only possible socket types are <b>SOCK_DGRAM</b> and
 
 ### -param protocol [in]
 
-The protocol to be used. The possible options for the <i>protocol</i> parameter are specific to the address family and socket type specified. Possible values for the <i>protocol</i> are defined are defined in the  <i>Winsock2.h</i> and <i>Wsrm.h</i> header files. 
+The protocol to be used. The possible options for the <i>protocol</i> parameter are specific to the address family and socket type specified. Possible values for the <i>protocol</i> are defined in the  <i>Winsock2.h</i> and <i>Wsrm.h</i> header files. 
 
-On the Windows SDK released for Windows Vista and later,, the organization of header files has changed and this parameter can be one of the values from the <b>IPPROTO</b> enumeration type defined in the <i>Ws2def.h</i> header file. Note that the <i>Ws2def.h</i> header file is automatically included in <i>Winsock2.h</i>, and should never be used directly.
+On the Windows SDK released for Windows Vista and later, the organization of header files has changed and this parameter can be one of the values from the <b>IPPROTO</b> enumeration type defined in the <i>Ws2def.h</i> header file. Note that the <i>Ws2def.h</i> header file is automatically included in <i>Winsock2.h</i>, and should never be used directly.
 
 If a value of  0 is specified, the caller does not
               wish to specify a protocol and the service provider will choose the <i>protocol</i> to use.
@@ -543,7 +543,7 @@ Refer to
 </dl>
 </td>
 <td width="60%">
-Create a socket that allows the the ability to set a security descriptor on the socket that contains a security access control list (SACL) as opposed to just a discretionary access control list (DACL).
+Create a socket that allows the ability to set a security descriptor on the socket that contains a security access control list (SACL) as opposed to just a discretionary access control list (DACL).
 
 SACLs are used for generating audits and alarms when an access check occurs on the object. For a socket, an access check occurs to determine whether the socket should be allowed to bind to a specific address specified to the <a href="/windows/desktop/api/winsock/nf-winsock-bind">bind</a> function.
 
@@ -795,13 +795,13 @@ Connectionless, message-oriented sockets allow sending and receiving of datagram
 
 Support for sockets with type <b>SOCK_RAW</b> is not required, but service providers are encouraged to support raw sockets whenever possible.
 
-The <b>WSASocket</b> function can be used to create a socket to be used by a service so that if another socket tries to bind to the same port used by the service, and audit record is generated. To enable this option, an application would need to do the following:
+The <b>WSASocket</b> function can be used to create a socket to be used by a service so that if another socket tries to bind to the same port used by the service, an audit record is generated. To enable this option, an application would need to do the following:
 
 
 <ul>
 <li>Call the <a href="/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges">AdjustTokenPrivileges</a> function to enable the <b>SE_SECURITY_NAME</b> privilege in the access token for the process. This privilege is required to set the  <b>ACCESS_SYSTEM_SECURITY</b> access rights on the security descriptor for an object. </li>
 <li>Call the <b>WSASocket</b> function to create a socket with <i>dwFlag</i> with the <b>WSA_FLAG_ACCESS_SYSTEM_SECURITY</b> option set. The <b>WSASocket</b> function will fail if the <a href="/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges">AdjustTokenPrivileges</a> function is not called first to enable the <b>SE_SECURITY_NAME</b> privilege needed for this operation.</li>
-<li>Call the <a href="/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function to set a security descriptor with a System Access Control List (SACL) on the socket. The socket handle returned by the <b>WSASocket</b> function is passed in the <i>handle</i> parameter. If the function succeeds, this will set the the  <b>ACCESS_SYSTEM_SECURITY</b> access right on the security descriptor for the socket.</li>
+<li>Call the <a href="/windows/desktop/api/aclapi/nf-aclapi-setsecurityinfo">SetSecurityInfo</a> function to set a security descriptor with a System Access Control List (SACL) on the socket. The socket handle returned by the <b>WSASocket</b> function is passed in the <i>handle</i> parameter. If the function succeeds, this will set the  <b>ACCESS_SYSTEM_SECURITY</b> access right on the security descriptor for the socket.</li>
 <li>Call the <a href="/windows/desktop/api/winsock/nf-winsock-bind">bind</a> function to bind the socket to a specific port. If the <b>bind</b> function succeeds, then an audit entry is generated if another socket tries to bind to the same port. </li>
 <li>Call the <a href="/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges">AdjustTokenPrivileges</a> function to remove the <b>SE_SECURITY_NAME</b> privilege in the access token for the process, since this is no longer needed. </li>
 </ul>


### PR DESCRIPTION
Fixed several typos:
are defined are defined -> are defined
,, -> ,
the the -> the
and audit record is generated -> an audit record is generated