### PR TITLE
SetCurrentDirectoryW does not support \\?\ prepended path that exceed MAX_PATH

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
@@ -68,10 +68,10 @@ The path to the new current directory. This parameter may specify a relative pat
 
 For more information, see <a href="/windows/desktop/FileIO/naming-a-file">File Names, Paths, and Namespaces</a>.
  
-By default, the name is limited to MAX_PATH characters. To extend this limit to 32,767 wide characters, prepend "\\\\?\\" to the path. For more information, see [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file).
+By default, the name is limited to MAX_PATH characters.
 
 > [!TIP]
-> Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation without prepending "\\\\?\\". See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
+> Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation. See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
 
 The final character before the null character must be a backslash ('\\'). If you do not specify the backslash, it will be added for you; therefore, specify <b>MAX_PATH</b>-2 characters for the path unless you  include the trailing backslash, in which case, specify <b>MAX_PATH</b>-1 characters for the path.
 


### PR DESCRIPTION
SetCurrentDirectoryW fails with ERROR_FILENAME_EXCED_RANGE when called with a path prepended with \\?\ and exceeds MAX_PATH. Confirmed this behavior on Windows 7 - Windows 11 with a test application and code inspection.

The current version of the documentation states that you can prepend the path with \\?\ to bypass the MAX_PATH limitation. 