### PR TITLE
Remove D2D1_PIXEL_OPTIONS copypasta (from D2D1_VERTEX_USAGE?)

### DIFF
--- a/sdk-api-src/content/d2d1effectauthor/ne-d2d1effectauthor-d2d1_pixel_options.md
+++ b/sdk-api-src/content/d2d1effectauthor/ne-d2d1effectauthor-d2d1_pixel_options.md
@@ -51,7 +51,7 @@ api_name:
 
 ## -description
 
-Indicates how pixel shader sampling will be restricted. This indicates whether the vertex buffer is large and tends to change infrequently or smaller and changes frequently (typically frame over frame).
+Indicates how pixel shader sampling will be restricted.
 
 ## -enum-fields
 


### PR DESCRIPTION
This sentence seems to have been accidentally copy-pasted from a version of [D2D1_VERTEX_USAGE](https://learn.microsoft.com/en-us/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_vertex_usage)