### PR TITLE
Remove `ID2D1DrawTransform` from the remarks

### DIFF
--- a/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1analysistransform.md
+++ b/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1analysistransform.md
@@ -59,4 +59,4 @@ The <b>ID2D1AnalysisTransform</b> interface inherits from the <a href="/windows/
 
 ## -remarks
 
- This interface can be implemented by either an <a href="/windows/desktop/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1drawtransform">ID2D1DrawTransform</a> or an <a href="/windows/desktop/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1computetransform">ID2D1ComputeTransform</a>.
+ This interface can be implemented by an <a href="/windows/desktop/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1computetransform">ID2D1ComputeTransform</a>.


### PR DESCRIPTION
`ID2D1AnalysisTransform` cannot be implemented by an `ID2D1DrawTransform` (pixel shader). I've tried it and it 100% does not work, this seems to be an error in the documentation.