### PR TITLE
Update nn-wtsprotocol-iwrdsprotocolconnection.md

### DIFF
--- a/sdk-api-src/content/wtsprotocol/nn-wtsprotocol-iwrdsprotocolconnection.md
+++ b/sdk-api-src/content/wtsprotocol/nn-wtsprotocol-iwrdsprotocolconnection.md
@@ -156,4 +156,4 @@ The <b>IWRdsProtocolConnection</b> interface inherits from the <a href="/windows
 
 ## -remarks
 
-To avoid a possible deadlock when calling any of the methods on this interface, you should not make any function or method calls that will directly or indirectly result in a Remote Desktop Services API being called. If you need to make any outbound call, you should start a new thread and make the outbound call from the new thread.
+To avoid a possible deadlock when calling any of the methods on this interface, you should not make any function or method calls that will directly or indirectly result in a Remote Desktop Services API being called. If you need to make any outbound call, you should start a new thread and make the outbound call from the new thread. If you make a new thread, do not wait on the thread to complete its work. Doing so defeats the purpose of making the work complete asynchronously.


### PR DESCRIPTION
Updated the contract to make sure it is clear that if the work is moved to a new thread that the creator of the new thread cannot wait on the thread to complete the work. The entire purpose of making a new thread to do the work is to make the work async, non-blocking.