### PR TITLE
Correct ERROR_INVALID_SERVER_RESPONSE

### DIFF
--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpwebsocketreceive.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpwebsocketreceive.md
@@ -120,7 +120,7 @@ A parameter is invalid.
 <tr>
 <td width="40%">
 <dl>
-<dt><b>ERROR_INVALID_SERVER_RESPONSE</b></dt>
+<dt><b>ERROR_WINHTTP_INVALID_SERVER_RESPONSE</b></dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
It appears the WINHTTP part of this define was omitted. I could be mistaken if this is coming from somewhere other than WinHttp.h.