### PR TITLE
Update nf-winstring-windowsgetstringrawbuffer.md

### DIFF
--- a/sdk-api-src/content/winstring/nf-winstring-windowsgetstringrawbuffer.md
+++ b/sdk-api-src/content/winstring/nf-winstring-windowsgetstringrawbuffer.md
@@ -74,7 +74,7 @@ A pointer to the buffer that provides the backing store for <i>string</i>, or th
 
 ## -remarks
 
-Use the <b>WindowsGetStringRawBuffer</b> function to obtain a pointer to the backing buffer of an[**HSTRING**](/windows/win32/winrt/hstring).
+Use the <b>WindowsGetStringRawBuffer</b> function to obtain a pointer to the backing buffer of an [**HSTRING**](/windows/win32/winrt/hstring).
 
 Don't change the contents of the buffer&mdash;an [**HSTRING**](/windows/win32/winrt/hstring) is required to be immutable.
 


### PR DESCRIPTION
Added space between `an` and **`HSTRING`** in the [Remarks](https://learn.microsoft.com/en-us/windows/win32/api/winstring/nf-winstring-windowsgetstringrawbuffer#remarks) section.