### PR TITLE
Fix incorrect links in STACKFRAME64 documentation

### DIFF
--- a/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe64.md
+++ b/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe64.md
@@ -62,7 +62,7 @@ Represents a stack frame.
 ### -field AddrPC
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the program counter. 
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the program counter. 
 
 
 
@@ -76,12 +76,12 @@ An
 ### -field AddrReturn
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the return address.
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the return address.
 
 ### -field AddrFrame
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the frame pointer. 
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the frame pointer. 
 
 
 
@@ -95,7 +95,7 @@ An
 ### -field AddrStack
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the stack pointer. 
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the stack pointer. 
 
 
 
@@ -109,7 +109,7 @@ An
 ### -field AddrBStore
 
 <b>Intel Itanium:  </b>An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the backing store (RsBSP).
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the backing store (RsBSP).
 
 ### -field FuncTableEntry
 
@@ -131,12 +131,12 @@ This member is <b>TRUE</b> if this is a virtual frame.
 ### -field Reserved
 
 This member is used internally by the 
-<a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk">StackWalk64</a> function.
+<a href="/windows/win32/api/dbghelp/nf-dbghelp-stackwalk64">StackWalk64</a> function.
 
 ### -field KdHelp
 
 A 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP64</a> structure that specifies helper data for walking kernel callback frames.
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-kdhelp64">KDHELP64</a> structure that specifies helper data for walking kernel callback frames.
 
 ## -remarks
 
@@ -167,7 +167,7 @@ typedef struct _tagSTACKFRAME {
 
 ## -see-also
 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a>
+<a href="/windows/win32/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a>
 
 
 


### PR DESCRIPTION
A number of links on https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-stackframe64 link to the 32-bit version of what they are talking about rather than the 64-bit version.