### PR TITLE
[RemoveDirectoryW] clarify removes junction itself, target directory not affected

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
@@ -93,7 +93,7 @@ To recursively delete the files in a directory, use the
 
 <b>RemoveDirectory</b> can be used to remove a directory junction. Since the target directory and its contents 
     will remain accessible through its canonical path, the target directory itself is not affected by removing a 
-    junction which targets it. For this reason, when <b>lpPathName</b> refers to a directory junction, 
+    junction which targets it. For this reason, when <i>lpPathName</i> refers to a directory junction, 
     <b>RemoveDirectory</b> will remove the specified link regardless of whether the target directory is 
     empty or not. For more information on junctions, see 
     <a href="/windows/desktop/FileIO/hard-links-and-junctions">Hard Links and Junctions</a>.

--- a/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
@@ -91,9 +91,11 @@ The <b>RemoveDirectory</b> function marks a directory for
 To recursively delete the files in a directory, use the 
     <a href="/windows/desktop/api/shellapi/nf-shellapi-shfileoperationa">SHFileOperation</a> function.
 
-<b>RemoveDirectory</b> removes a directory junction, even 
-    if the contents of the target are not empty; the function removes directory junctions regardless of the state of 
-    the target object. For more information on junctions, see 
+<b>RemoveDirectory</b> can be used to remove a directory junction. Since the target directory and its contents 
+    will remain accessible through its canonical path, the target directory itself is not affected by removing a 
+    junction which targets it. For this reason, when <b>lpPathName</b> refers to a directory junction, 
+    <b>RemoveDirectory</b> will remove the specified link regardless of whether the target directory is 
+    empty or not. For more information on junctions, see 
     <a href="/windows/desktop/FileIO/hard-links-and-junctions">Hard Links and Junctions</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-removedirectoryw.md
@@ -96,7 +96,7 @@ To recursively delete the files in a directory, use the
     junction which targets it. For this reason, when <i>lpPathName</i> refers to a directory junction, 
     <b>RemoveDirectory</b> will remove the specified link regardless of whether the target directory is 
     empty or not. For more information on junctions, see 
-    <a href="/windows/desktop/FileIO/hard-links-and-junctions">Hard Links and Junctions</a>.
+    <a href="/windows/win32/FileIO/hard-links-and-junctions">Hard Links and Junctions</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.
 


### PR DESCRIPTION
The existing text has a couple confusions in it. Since the "state of the target" directory is essentially unrelated to the `RemoveDirectory` operation when the specified path refers to a directory junction, it was unclear what the point of the paragraph was at all. Namely, it was trying to point out that there is a special case for behavior that is detailed elsewhere on the page--but without clearly indicating exactly which behavior it was modifying.

So one was left wondering and worrying about why the target directory is being mentioned at all, for the case of deleting a junction.

My goal here is primarily to assure developers that, indeed, `RemoveDirectory` will *not*--and in fact, *never*--delete the target directory and its contents when removing a directory junction, The previous text seemed to raise the spectre of the opposite.

Please feel free to review, edit, or discard my attempt to remedy this.