### PR TITLE
Update nf-shlwapi-assocquerystringa.md

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-assocquerystringa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-assocquerystringa.md
@@ -79,29 +79,10 @@ Type: <b>LPCTSTR</b>
 
 A pointer to a null-terminated string that is used to determine the root key. The following four types of strings can be used.
 
-
-
-#### File name extension
-
-A file name extension, such as .txt.
-
-
-
-#### CLSID
-
-A CLSID GUID in the standard "{GUID}" format.
-
-
-
-#### ProgID
-
-An application's ProgID, such as <b>Word.Document.8</b>.
-
-
-
-#### Executable name
-
-The name of an application's .exe file. The <a href="/windows/win32/api/shlwapi/ne-shlwapi-url_scheme">ASSOCF_OPEN_BYEXENAME</a> flag must be set in <i>flags</i>.
+1. **File name extension**: A file name extension, such as .txt.
+2. **CLSID**: A CLSID GUID in the standard "{GUID}" format.
+3. **ProgID**: An application's ProgID, such as <a href="/windows/win32/shell/fa-progids">Word.Document.8</a>.
+4. **Executable name**: The name of an application's .exe file. The <a href="/windows/win32/api/shlwapi/ne-shlwapi-url_scheme">ASSOCF_OPEN_BYEXENAME</a> flag must be set in <i>flags</i>.
 
 ### -param pszExtra [in, optional]
 


### PR DESCRIPTION
1. The formatting for the shlwapi page was misleading, with `####` header being larger than header `###`. I think a numbered list makes more sense given the prior statement for four strings. 
2. I think an improvement would be to add the cross reference https://learn.microsoft.com/en-us/windows/win32/shell/fa-progids.


![image](https://github.com/MicrosoftDocs/sdk-api/assets/68693576/cd72660b-a27d-4966-9a7d-8bf864db4537)

This was rendered in Firefox, the headers shown are larger than the header which they are under.