### PR TITLE
Update ns-shlwapi-parsedurla.md

### DIFF
--- a/sdk-api-src/content/shlwapi/ns-shlwapi-parsedurla.md
+++ b/sdk-api-src/content/shlwapi/ns-shlwapi-parsedurla.md
@@ -76,7 +76,7 @@ Type: <b>LPCTSTR</b>
 
 Type: <b>UINT</b>
 
-The number of characters in the URL's protocol section.
+[out] The number of characters in the URL's protocol section.
 
 ### -field pszSuffix
 


### PR DESCRIPTION
Added missing `[out]` in [Members](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/ns-shlwapi-parsedurla#members) section.