### PR TITLE
Make each DeviceIoControl parameter in USN IOCTLs appear on their own line

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_query_usn_journal.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_query_usn_journal.md
@@ -57,7 +57,10 @@ Queries for information on the current update sequence number (USN) change journ
 <pre>BOOL 
 WINAPI 
 DeviceIoControl( (HANDLE)       Device,          // handle to volume
-                 (DWORD) FSCTL_QUERY_USN_JOURNAL,// dwIoControlCode(LPVOID)       NULL,            // lpInBuffer(DWORD)        0,               // nInBufferSize(LPVOID)       lpOutBuffer,     // output buffer
+                 (DWORD) FSCTL_QUERY_USN_JOURNAL,// dwIoControlCode
+                 (LPVOID)       NULL,            // lpInBuffer
+                 (DWORD)        0,               // nInBufferSize
+                 (LPVOID)       lpOutBuffer,     // output buffer
                  (DWORD)        nOutBufferSize,  // size of output buffer
                  (LPDWORD)      lpBytesReturned, // number of bytes returned
                  (LPOVERLAPPED) lpOverlapped );  // OVERLAPPED structure</pre>

--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_read_file_usn_data.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_read_file_usn_data.md
@@ -61,7 +61,8 @@ To perform this operation, call the
 <pre>BOOL 
 WINAPI 
 DeviceIoControl( (HANDLE)       hDevice,         // handle to device
-                 (DWORD) FSCTL_READ_FILE_USN_DATA, // dwIoControlCode(LPVOID)       lpInBuffer,      // input buffer
+                 (DWORD) FSCTL_READ_FILE_USN_DATA, // dwIoControlCode
+                 (LPVOID)       lpInBuffer,      // input buffer
                  (DWORD)        nInBufferSize,   // size of input buffer
                  (LPVOID)       lpOutBuffer,     // output buffer
                  (DWORD)        nOutBufferSize,  // size of output buffer


### PR DESCRIPTION
FSCTL_READ_FILE_USN_DATA and FSCTL_QUERY_USN_JOURNAL each had multiple parameters collapsed onto a single line.