### PR TITLE
Update ns-d3d12-d3d12_feature_data_d3d12_options1.md

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options1.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options1.md
@@ -64,7 +64,7 @@ Specifies the baseline number of lanes in the SIMD wave that this implementation
 
 ### -field WaveLaneCountMax
 
-Specifies the maximum number of lanes in the SIMD wave that this implementation can support. This capability is reserved for future expansion, and is not expected to be used by current applications.
+Specifies the maximum number of lanes in the SIMD wave that this implementation can support.
 
 ### -field TotalLaneCount
 


### PR DESCRIPTION
Remove text that incorrectly stated that WaveLaneCountMax isn't used.