### PR TITLE
Add IDCLOSE to return value table of TaskDialog

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-taskdialog.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-taskdialog.md
@@ -248,6 +248,10 @@ When this function returns, contains a pointer to an integer location that recei
 <td><b>IDYES</b></td>
 <td><b>Yes</b> button was selected.</td>
 </tr>
+<tr>
+<td><b>IDCLOSE</b></td>
+<td><b>Close</b> button was selected.</td>
+</tr>
 </table>
  
 


### PR DESCRIPTION
Testing reveals this works correctly, but is yet to be documented.