### PR TITLE
Update ns-winioctl-usn_record_v3.md

### DIFF
--- a/sdk-api-src/content/winioctl/ns-winioctl-usn_record_v3.md
+++ b/sdk-api-src/content/winioctl/ns-winioctl-usn_record_v3.md
@@ -265,8 +265,6 @@ The file or directory is truncated.
 <td width="60%">
 The user made a change to the extended attributes of a file or directory.
 
-These NTFS file system attributes are not accessible to Windows-based applications.
-
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Extended attributes are easily available for end users both for reading and writing, except $KERNEL EAs, which don't create USN entries anyway.