### PR TITLE
nf-securitybaseapi-checktokenmembership: fix code sample formatting

### DIFF
--- a/sdk-api-src/content/securitybaseapi/nf-securitybaseapi-checktokenmembership.md
+++ b/sdk-api-src/content/securitybaseapi/nf-securitybaseapi-checktokenmembership.md
@@ -113,26 +113,27 @@ Return Value:
    FALSE - Caller does not have Administrators local group. --
 */ 
 {
-BOOL b;
-SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
-PSID AdministratorsGroup; 
-b = AllocateAndInitializeSid(
-    &NtAuthority,
-    2,
-    SECURITY_BUILTIN_DOMAIN_RID,
-    DOMAIN_ALIAS_RID_ADMINS,
-    0, 0, 0, 0, 0, 0,
-    &AdministratorsGroup); 
-if(b) 
-{
-    if (!CheckTokenMembership( NULL, AdministratorsGroup, &b)) 
-    {
-         b = FALSE;
-    } 
-    FreeSid(AdministratorsGroup); 
-}
+    BOOL b;
+    SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
+    PSID AdministratorsGroup;
+    b = AllocateAndInitializeSid(
+        &NtAuthority,
+        2,
+        SECURITY_BUILTIN_DOMAIN_RID,
+        DOMAIN_ALIAS_RID_ADMINS,
+        0, 0, 0, 0, 0, 0,
+        &AdministratorsGroup );
 
-return(b);
+    if(b)
+    {
+        if (!CheckTokenMembership( NULL, AdministratorsGroup, &b))
+        {
+             b = FALSE;
+        }
+        FreeSid(AdministratorsGroup);
+    }
+
+    return(b);
 }
 
 ```


### PR DESCRIPTION
After stumbling on this code sample on the public website I believe the code formatting can be improved upon to match the code formatting of other code samples across this repository.