### PR TITLE
Add default `FD_SETSIZE` info in `fd_set` structure

### DIFF
--- a/sdk-api-src/content/winsock/ns-winsock-fd_set.md
+++ b/sdk-api-src/content/winsock/ns-winsock-fd_set.md
@@ -65,7 +65,7 @@ The number of sockets in the set.
 
 ### -field fd_array
 
-An array of sockets that are in the set.
+An array of sockets that are in the set. The variable <b>FD_SETSIZE</b> defaults to 64.
 
 ## -see-also
 

--- a/sdk-api-src/content/winsock2/ns-winsock2-fd_set.md
+++ b/sdk-api-src/content/winsock2/ns-winsock2-fd_set.md
@@ -65,7 +65,7 @@ The number of sockets in the set.
 
 ### -field fd_array
 
-An array of sockets that are in the set.
+An array of sockets that are in the set. The variable <b>FD_SETSIZE</b> defaults to 64.
 
 ## -see-also
 


### PR DESCRIPTION
The only 2 places that mention `FD_SETSIZE` are:

https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/winsock2/nf-winsock2-select.md
https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/ws2spi/nc-ws2spi-lpwspselect.md

This PR adds info on the default value of `FD_SETSIZE` to prevent the need for users to traverse to one of the above pages to know the default.