### PR TITLE
Fix `fd_set` structure reference

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-__wsafdisset.md
+++ b/sdk-api-src/content/winsock/nf-winsock-__wsafdisset.md
@@ -60,7 +60,7 @@ TBD
 
 ### -param unnamedParam2
 
-Pointer to an <a href="/windows/desktop/api/winsock/nf-winsock-fd_set">fd_set</a> structure containing the set of socket descriptors. The <b>__WSAFDIsSet</b> function determines whether the socket specified in the <i>fd</i> parameter is a member of that set.
+Pointer to an <a href="/windows/desktop/api/winsock/ns-winsock-fd_set">fd_set</a> structure containing the set of socket descriptors. The <b>__WSAFDIsSet</b> function determines whether the socket specified in the <i>fd</i> parameter is a member of that set.
 
 
 #### - fd
@@ -83,7 +83,7 @@ Descriptor identifying a socket.
 
 
 
-<a href="/windows/desktop/api/winsock/nf-winsock-fd_set">fd_set</a>
+<a href="/windows/desktop/api/winsock/ns-winsock-fd_set">fd_set</a>
 
 
 

--- a/sdk-api-src/content/winsock2/nf-winsock2-__wsafdisset.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-__wsafdisset.md
@@ -60,7 +60,7 @@ Descriptor identifying a socket.
 
 ### -param unnamedParam2
 
-Pointer to an <a href="/windows/desktop/api/winsock/nf-winsock-fd_set">fd_set</a> structure containing the set of socket descriptors. The <b>__WSAFDIsSet</b> function determines whether the socket specified in the <i>fd</i> parameter is a member of that set.
+Pointer to an <a href="/windows/desktop/api/winsock2/ns-winsock2-fd_set">fd_set</a> structure containing the set of socket descriptors. The <b>__WSAFDIsSet</b> function determines whether the socket specified in the <i>fd</i> parameter is a member of that set.
 
 ## -remarks
 
@@ -78,7 +78,7 @@ Pointer to an <a href="/windows/desktop/api/winsock/nf-winsock-fd_set">fd_set</a
 
 
 
-<a href="/windows/desktop/api/winsock/nf-winsock-fd_set">fd_set</a>
+<a href="/windows/desktop/api/winsock2/ns-winsock2-fd_set">fd_set</a>
 
 
 

--- a/sdk-api-src/content/winsock2/nf-winsock2-select.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-select.md
@@ -81,7 +81,7 @@ The maximum time for
 
 The 
 <b>select</b> function returns the total number of socket handles that are ready and contained in the 
-<a href="/windows/desktop/api/winsock/ns-winsock-fd_set">fd_set</a> structures, zero if the time limit expired, or SOCKET_ERROR if an error occurred. If the return value is SOCKET_ERROR, 
+<a href="/windows/desktop/api/winsock2/ns-winsock2-fd_set">fd_set</a> structures, zero if the time limit expired, or SOCKET_ERROR if an error occurred. If the return value is SOCKET_ERROR, 
 <a href="/windows/desktop/api/winsock/nf-winsock-wsagetlasterror">WSAGetLastError</a> can be used to retrieve a specific error code.
 
 <table>
@@ -174,7 +174,7 @@ One of the descriptor sets contains an entry that is not a socket.
 
 The 
 <b>select</b> function is used to determine the status of one or more sockets. For each socket, the caller can request information on read, write, or error status. The set of sockets for which a given status is requested is indicated by an 
-<a href="/windows/desktop/api/winsock/ns-winsock-fd_set">fd_set</a> structure. The sockets contained within the 
+<a href="/windows/desktop/api/winsock2/ns-winsock2-fd_set">fd_set</a> structure. The sockets contained within the 
 <b>fd_set</b> structures must be associated with a single service provider. For the purpose of this restriction, sockets are considered to be from the same service provider if the 
 <a href="/windows/desktop/api/winsock2/ns-winsock2-wsaprotocol_infoa">WSAPROTOCOL_INFO</a> structures describing their protocols have the same <i>providerId</i> value. Upon return, the structures are updated to reflect the subset of these sockets that meet the specified condition. The 
 <b>select</b> function returns the number of sockets meeting the conditions. A set of macros is provided for manipulating an 
@@ -236,7 +236,7 @@ In summary, a socket will be identified in a particular set when
 <li>OOB data is available for reading (only if SO_OOBINLINE is disabled).</li>
 </ul>
 Four macros are defined in the header file Winsock2.h for manipulating and checking the descriptor sets. The variable FD_SETSIZE determines the maximum number of descriptors in a set. (The default value of FD_SETSIZE is 64, which can be modified by defining FD_SETSIZE to another value before including Winsock2.h.) Internally, socket handles in an 
-<a href="/windows/desktop/api/winsock/ns-winsock-fd_set">fd_set</a> structure are not represented as bit flags as in Berkeley Unix. Their data representation is opaque. Use of these macros will maintain software portability between different socket environments. The macros to manipulate and check 
+<a href="/windows/desktop/api/winsock2/ns-winsock2-fd_set">fd_set</a> structure are not represented as bit flags as in Berkeley Unix. Their data representation is opaque. Use of these macros will maintain software portability between different socket environments. The macros to manipulate and check 
 <b>fd_set</b> contents are:
 <ul>
 <li><i>FD_ZERO(*set)</i> - Initializes set to the empty set. A set should always be cleared before using.</li>

--- a/sdk-api-src/content/ws2spi/nc-ws2spi-lpwspselect.md
+++ b/sdk-api-src/content/ws2spi/nc-ws2spi-lpwspselect.md
@@ -71,7 +71,7 @@ Pointer to the error code.
 
 ## -returns
 
-The **LPWSPSelect** function returns the total number of descriptors that are ready and contained in the <a href="/windows/win32/api/winsock/nf-winsock-fd_set">fd_set</a> structures, or SOCKET_ERROR if an error occurred. If the return value is SOCKET_ERROR, a specific error code is available in <i>lpErrno</i>.
+The **LPWSPSelect** function returns the total number of descriptors that are ready and contained in the <a href="/windows/win32/api/winsock2/ns-winsock2-fd_set">fd_set</a> structures, or SOCKET_ERROR if an error occurred. If the return value is SOCKET_ERROR, a specific error code is available in <i>lpErrno</i>.
 
 <table>
 <tr>
@@ -148,7 +148,7 @@ One of the descriptor sets contains an entry that is not a socket.
 
 ## -remarks
 
-This function is used to determine the status of one or more sockets. For each socket, the caller can request information on read, write, or error status. The set of sockets for which a given status is requested is indicated by an <a href="/windows/win32/api/winsock/nf-winsock-fd_set">fd_set</a> structure. All entries in an **fd_set** correspond to sockets created by the service provider (that is, the <b><a href="/windows/win32/api/winsock2/ns-winsock2-wsaprotocol_infoa?redirectedfrom=MSDN">WSAPROTOCOL_INFO</a></b> structures describing their protocols have the same *providerId* value). Upon return, the structures are updated to reflect the subset of these sockets that meet the specified condition, and **LPWSPSelect** returns the total number of sockets meeting the conditions. A set of macros is provided for manipulating an **fd_set**. These macros are compatible with those used in the Berkeley software, but the underlying representation is completely different.
+This function is used to determine the status of one or more sockets. For each socket, the caller can request information on read, write, or error status. The set of sockets for which a given status is requested is indicated by an <a href="/windows/win32/api/winsock2/ns-winsock2-fd_set">fd_set</a> structure. All entries in an **fd_set** correspond to sockets created by the service provider (that is, the <b><a href="/windows/win32/api/winsock2/ns-winsock2-wsaprotocol_infoa?redirectedfrom=MSDN">WSAPROTOCOL_INFO</a></b> structures describing their protocols have the same *providerId* value). Upon return, the structures are updated to reflect the subset of these sockets that meet the specified condition, and **LPWSPSelect** returns the total number of sockets meeting the conditions. A set of macros is provided for manipulating an **fd_set**. These macros are compatible with those used in the Berkeley software, but the underlying representation is completely different.
 
 The parameter <i>readfds</i> identifies those sockets that are to be checked for readability. If the socket is currently listening through <b><a href="/windows/win32/api/ws2spi/nc-ws2spi-lpwsplisten">LPWSPListen</a></b>, it will be marked as readable if an incoming connection request has been received, so that a [LPWSPAccept](nc-ws2spi-lpwspaccept.md) is guaranteed to complete without blocking. For other sockets, readability means that queued data is available for reading so that a <b><a href="/windows/win32/api/ws2spi/nc-ws2spi-lpwsprecv">LPWSPRecv</a></b> or [LPWSPRecvFrom](./nc-ws2spi-lpwsprecvfrom.md) is guaranteed not to block.
 
@@ -182,7 +182,7 @@ Summary: A socket will be identified in a particular set when **LPWSPSelect** re
 
 Three macros and one upcall function are defined in the header file Ws2spi.h for manipulating and checking the descriptor sets. The variable FD_SETSIZE determines the maximum number of descriptors in a set. (The default value of FD_SETSIZE is 64, which can be modified by \#defining FD_SETSIZE to another value before \#including Ws2spi.h.) Internally, socket handles in a <a href="/windows/win32/api/winsock/nf-winsock-fd_set">fd_set</a> are not represented as bit flags as in Berkeley UNIX. Their data representation is opaque. Use of these macros will maintain software portability between different socket environments.
 
-The macros to manipulate and check <a href="/windows/win32/api/winsock/nf-winsock-fd_set">fd_set</a> contents are:
+The macros to manipulate and check <a href="/windows/win32/api/winsock2/ns-winsock2-fd_set">fd_set</a> contents are:
 
 <dl> <dt>
 


### PR DESCRIPTION
Fix references that meant the `fd_set` structure but linked to the `FD_SET` macro. ~~Renamed the use of `FD_SET` (from the typedef of `fd_set` structure) when referring to the structure, to its actual name of `fd_set` to prevent confusion with `FD_SET` macro.~~ (Edit: wrong PR)