### PR TITLE
Fix excess right angle bracket in `FD_SET`

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-fd_set.md
+++ b/sdk-api-src/content/winsock/nf-winsock-fd_set.md
@@ -57,7 +57,7 @@ A descriptor identifying a socket which will be added to the set.
 
 ### -param set
 
-A pointer to a <b>>fd_set</b>.
+A pointer to a <b>fd_set</b>.
 
 ## -remarks
 

--- a/sdk-api-src/content/winsock/nf-winsock-fd_set.md
+++ b/sdk-api-src/content/winsock/nf-winsock-fd_set.md
@@ -57,7 +57,7 @@ A descriptor identifying a socket which will be added to the set.
 
 ### -param set
 
-A pointer to a <b>fd_set</b>.
+A pointer to an [fd_set](/windows/win32/api/winsock/ns-winsock-fd_set).
 
 ## -remarks
 


### PR DESCRIPTION
Fix a typo I introduced in #1669. Combed through the whole repo and found no other similar occurrences.