### PR TITLE
Update nf-shobjidl_core-ishelliconoverlayidentifier-ismemberof.md

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishelliconoverlayidentifier-ismemberof.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishelliconoverlayidentifier-ismemberof.md
@@ -64,7 +64,7 @@ A Unicode string that contains the fully qualified path of the Shell object.
 
 Type: <b>DWORD</b>
 
-The object's attributes. For a complete list of file attributes and their associated flags, see <a href="/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ishellfolder-getattributesof">IShellFolder::GetAttributesOf</a>.
+The object's attributes. For a complete list of file attributes and their associated flags, see <a href="/windows/desktop/FileIO/file-attribute-constants">File Attribute Constants</a>.
 
 ## -returns
 


### PR DESCRIPTION
The attributes passed to IShellIconOverlayIdentifier::IsMemberOf are the FILE_ATTRIBUTE_ type of attributes and not SFGAO_ type of attributes. See IShellIconOverlayManager::GetFileOverlayInfo (https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-ishelliconoverlaymanager-getfileoverlayinfo) & IShellIconOverlayManager::GetReservedOverlayInfo (https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-ishelliconoverlaymanager-getreservedoverlayinfo)

@microsoft-github-policy-service agree