### PR TITLE
Fixed incorrect url to structure in parameter description (ns-winnt-image_nt_headers64.md)

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-image_nt_headers64.md
+++ b/sdk-api-src/content/winnt/ns-winnt-image_nt_headers64.md
@@ -70,7 +70,7 @@ An
 ### -field OptionalHeader
 
 An 
-<a href="/windows/win32/api/winnt/ns-winnt-image_optional_header32">IMAGE_OPTIONAL_HEADER</a> structure that specifies the optional file header.
+<a href="/windows/win32/api/winnt/ns-winnt-image_optional_header64">IMAGE_OPTIONAL_HEADER64</a> structure that specifies the optional file header.
 
 ## -remarks
 


### PR DESCRIPTION
Fixed incorrect url to structure in parameter description (from IMAGE_OPTIONAL_HEADER32 to IMAGE_OPTIONAL_HEADER64)