### PR TITLE
Update nf-bcrypt-bcryptgenrandom.md

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgenrandom.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptgenrandom.md
@@ -22,7 +22,7 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Bcrypt.lib
+req.lib: Bcrypt.lib or Cng.lib(For Kernel mode)
 req.dll: Bcrypt.dll
 req.irql: 
 targetos: Windows


### PR DESCRIPTION
To use this function in Kernel mode, Cng.lib has to be added. This line was explained in the later part. So it good to highlight in Requrements.