### PR TITLE
Update nf-mstcpip-in4_is_addr_linklocal.md

### DIFF
--- a/sdk-api-src/content/mstcpip/nf-mstcpip-in4_is_addr_linklocal.md
+++ b/sdk-api-src/content/mstcpip/nf-mstcpip-in4_is_addr_linklocal.md
@@ -58,7 +58,7 @@ Pointer to the address to test.
 
 `true` if the address is an IPv4 link-local address; otherwise, `false`.
 
-Returns `true` for local-use IPv4 unicast addresses. Returns `false` for the IPv4 loopback address. Doesn't return `true` for IPv4 multicast addresses of link-local scope.
+Returns `true` for local-use IPv4 unicast addresses. Returns `false` for the IPv4 loopback address. Returns `false` for IPv4 multicast addresses of link-local scope.
 
 ## -remarks
 


### PR DESCRIPTION
Instead of saying "doesn't return true", affirmatively says "returns false" as with the prior sentence.