### PR TITLE
Update nf-pathcch-pathcchfindextension.md

### DIFF
--- a/sdk-api-src/content/pathcch/nf-pathcch-pathcchfindextension.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathcchfindextension.md
@@ -66,7 +66,7 @@ A pointer to the path to search.
 
 ### -param cchPath [in]
 
-The size of the buffer pointed to by <i>pszPath</i>, in characters.
+The size of the buffer pointed to by <i>pszPath</i> in characters, including the null terminator.
 
 ### -param ppszExt [out]
 


### PR DESCRIPTION
The function fails with E_INVALIDARG unless the size includes the terminating '\0'