### PR TITLE
Note that using `SetCurrentDirectory` with a path longer than `MAX_PATH` will break `CreateProcess`

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
@@ -72,7 +72,7 @@ By default, the name is limited to **MAX_PATH** characters.
 > Starting with Windows 10, Version 1607, you can opt in to remove the **MAX_PATH** limitation. For details, see the *Maximum path length limitation* section of [Naming files, paths, and namespaces](/windows/win32/fileio/naming-a-file).
 
 > [!IMPORTANT]
-> Unless the caller overrides the current directory, setting a current directory longer than **MAX_PATH** causes [CreateProcessW](/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) to fail.
+> Setting a current directory longer than **MAX_PATH** causes [CreateProcessW](/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) to fail.
 
 The final character before the null character must be a backslash ('\\'). If you don't specify the backslash, then it will be added for you. Therefore, specify **>MAX_PATH**-2 characters for the path unless you include the trailing backslash; in which case, specify **MAX_PATH**-1 characters for the path.
 

--- a/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
@@ -54,7 +54,6 @@ api_name:
 
 # SetCurrentDirectory function
 
-
 ## -description
 
 Changes the current directory for the current process.
@@ -63,28 +62,25 @@ Changes the current directory for the current process.
 
 ### -param lpPathName [in]
 
-The path to the new current directory. This parameter may specify a relative path or a full path. In either case, the full path of the specified directory is calculated and stored as the current directory. 
+The path to the new current directory. This parameter may specify a relative path or a full path. In either case, the full path of the specified directory is calculated and stored as the current directory.
 
-
-For more information, see <a href="/windows/desktop/FileIO/naming-a-file">File Names, Paths, and Namespaces</a>.
+For more info, see [Naming files, paths, and namespaces](/windows/win32/fileio/naming-a-file).
  
-By default, the name is limited to MAX_PATH characters.
+By default, the name is limited to **MAX_PATH** characters.
 
 > [!TIP]
-> Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation. See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
->
-> Note that setting a current directory longer than the MAX_PATH limitation will cause <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessw">CreateProcess</a> to fail unless the caller overrides the current directory.
+> Starting with Windows 10, Version 1607, you can opt in to remove the **MAX_PATH** limitation. For details, see the *Maximum path length limitation* section of [Naming files, paths, and namespaces](/windows/win32/fileio/naming-a-file).
 
-The final character before the null character must be a backslash ('\\'). If you do not specify the backslash, it will be added for you; therefore, specify <b>MAX_PATH</b>-2 characters for the path unless you  include the trailing backslash, in which case, specify <b>MAX_PATH</b>-1 characters for the path.
+> [!IMPORTANT]
+> Unless the caller overrides the current directory, setting a current directory longer than **MAX_PATH** causes [CreateProcessW](/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) to fail.
 
-
+The final character before the null character must be a backslash ('\\'). If you don't specify the backslash, then it will be added for you. Therefore, specify **>MAX_PATH**-2 characters for the path unless you include the trailing backslash; in which case, specify **MAX_PATH**-1 characters for the path.
 
 ## -returns
 
-If the function succeeds, the return value is nonzero.
+If the function succeeds, then the return value is non-zero.
 
-If the function fails, the return value is zero. To get extended error information, call 
-<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, then the return value is zero. To get extended error information, call [GetLastError](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 
@@ -98,15 +94,18 @@ Each process has a single current directory made up of two parts:
 The current directory is shared by all threads of the process:
 If one thread changes the current directory, it affects all threads
 in the process.
+
 Multithreaded applications and shared library code should avoid
 calling the <b>SetCurrentDirectory</b> function due to the risk of
 affecting relative path calculations being performed by other threads.
 Conversely,
+
 multithreaded applications and shared library code should avoid
 using relative paths so that they are unaffected by changes to the
 current directory performed by other threads.
 
-Note that the current directory for a process is locked while the process is executing. This will prevent the directory from being deleted, moved, or renamed.
+> [!NOTE]
+The current directory for a process is locked while the process is executing. That prevents the directory from being deleted, moved, or renamed.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.
 
@@ -166,25 +165,13 @@ Yes
 </td>
 </tr>
 </table>
- 
 
+## Examples
 
-#### Examples
-
-For an example, see 
-<a href="/windows/desktop/FileIO/changing-the-current-directory">Changing the Current Directory</a>.
-				
-
-<div class="code"></div>
+For an example, see <a href="/windows/desktop/FileIO/changing-the-current-directory">Changing the current directory</a>.
 
 ## -see-also
 
-<a href="/windows/desktop/FileIO/directory-management-functions">Directory Management Functions</a>
-
-
-
-<a href="/windows/desktop/api/winbase/nf-winbase-getcurrentdirectory">GetCurrentDirectory</a>
-
-
-
-<a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a>
+* <a href="/windows/desktop/FileIO/directory-management-functions">Directory Management Functions</a>
+* <a href="/windows/desktop/api/winbase/nf-winbase-getcurrentdirectory">GetCurrentDirectory</a>
+* <a href="/windows/desktop/api/fileapi/nf-fileapi-getfullpathnamea">GetFullPathName</a>

--- a/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
+++ b/sdk-api-src/content/winbase/nf-winbase-setcurrentdirectory.md
@@ -72,6 +72,8 @@ By default, the name is limited to MAX_PATH characters.
 
 > [!TIP]
 > Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation. See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
+>
+> Note that setting a current directory longer than the MAX_PATH limitation will cause <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessw">CreateProcess</a> to fail unless the caller overrides the current directory.
 
 The final character before the null character must be a backslash ('\\'). If you do not specify the backslash, it will be added for you; therefore, specify <b>MAX_PATH</b>-2 characters for the path unless you  include the trailing backslash, in which case, specify <b>MAX_PATH</b>-1 characters for the path.
 


### PR DESCRIPTION
Using `SetCurrentDirectory` with `longPathAware` to set a current directory longer than the `MAX_PATH - 2` limit will cause `CreateProcess` to fail with `ERROR_INVALID_INPUT`.

This is a pretty big caveat for anyone using `SetCurrentDirectory` with long paths as it will appear to work initially but then prevents spawning any child process, with an error code that does not make it obvious where the problem originated.