### PR TITLE
Replace number of bytes with number of signs for ERROR_MORE_DATA

### DIFF
--- a/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getcomputernameexw.md
+++ b/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getcomputernameexw.md
@@ -199,7 +199,7 @@ If the function fails, the return value is zero. To get extended error informati
 </dl>
 </td>
 <td width="60%">
-The <i>lpBuffer</i> buffer is too small. The <i>lpnSize</i> parameter contains the number of bytes required to receive the name.
+The <i>lpBuffer</i> buffer is too small. The <i>lpnSize</i> parameter contains the number of signs required to receive the name.
 
 </td>
 </tr>


### PR DESCRIPTION
Error was found by using the ERROR_MORE_DATA to setup the buffer with correct size.
Computer name had 11 signes and it requires 22 bytes for wchar_t, but GetComputerNameExW returned 11 in nSize.

This is the fixed code for testing

    DWORD dwSize = 0;
    BOOL bSuccess = GetComputerNameExW(ComputerNameNetBIOS, nullptr, &dwSize);
    if(bSuccess == FALSE && GetLastError() == ERROR_MORE_DATA)
    {
      wchar_t* pName = new wchar_t[dwSize];
      bSuccess = GetComputerNameExW(ComputerNameNetBIOS, pName, &dwSize);
      if(bSuccess)
      {
        std::wstring sName = pName ;
      }
      delete pName;
    }
