### PR TITLE
WinUser: Fix CreateWindowA return type in syntax

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-createwindowa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createwindowa.md
@@ -56,6 +56,24 @@ Creates an overlapped, pop-up, or child window. It specifies the window class, w
 
 To use extended window styles in addition to the styles supported by <b>CreateWindow</b>, use the <a href="/windows/desktop/api/winuser/nf-winuser-createwindowexa">CreateWindowEx</a> function.
 
+## -syntax
+
+```cpp
+HWND CreateWindowA(
+  [in, optional]  lpClassName,
+  [in, optional]  lpWindowName,
+  [in]            dwStyle,
+  [in]            x,
+  [in]            y,
+  [in]            nWidth,
+  [in]            nHeight,
+  [in, optional]  hWndParent,
+  [in, optional]  hMenu,
+  [in, optional]  hInstance,
+  [in, optional]  lpParam
+);
+```
+
 ## -parameters
 
 ### -param lpClassName [in, optional]


### PR DESCRIPTION
Problem: Currently the displayed return type in the syntax of the CreateWindowA macro is void which is incorrect

Solution: Explicitly add the syntax, like in CreateWindowW, and correct the return type

PS: Unrelated to this, I also noticed a bug in which I see in both CreateWindowA/W which there is also a Returns section in the page and also a Return Value section and the Return Value section claims there is no return which can confuse, I will try looking into this later, but it may be related to something generated automatically from the template.