### PR TITLE
Update nf-winevt-evtcreaterendercontext.md

### DIFF
--- a/sdk-api-src/content/winevt/nf-winevt-evtcreaterendercontext.md
+++ b/sdk-api-src/content/winevt/nf-winevt-evtcreaterendercontext.md
@@ -73,7 +73,7 @@ Attribute names in the expressions must not be followed by a space.
 
 ### -param Flags [in]
 
-One or more flags that identify the information in the event that you want to render. For example, the system information, user information, or specific values. For possible values, see the <a href="/windows/desktop/api/winevt/ne-winevt-evt_render_context_flags">EVT_RENDER_CONTEXT_FLAGS</a> enumeration.
+Flag that identifies the information in the event that you want to render. For example, the system information, user information, or specific values. For possible values, see the <a href="/windows/desktop/api/winevt/ne-winevt-evt_render_context_flags">EVT_RENDER_CONTEXT_FLAGS</a> enumeration.
 
 ## -returns
 


### PR DESCRIPTION
Edited the `Flags` description in the [Parameters](https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreaterendercontext#parameters) section to clarify that only one flag value can be used. As written, one could interpret the description to indicate that the flag values can be combined.