### PR TITLE
Update ne-winevt-evt_channel_config_property_id.md

### DIFF
--- a/sdk-api-src/content/winevt/ne-winevt-evt_channel_config_property_id.md
+++ b/sdk-api-src/content/winevt/ne-winevt-evt_channel_config_property_id.md
@@ -162,7 +162,7 @@ You cannot set this property.
 
 ### -field EvtChannelPublisherList
 
-Identifies the configuration property that contains the list of providers that import this channel.  The variant type for this property is <b>EvtVarTypeString | EVT_VARIANT_TYPE_ARRAY</b>. 
+Identifies the configuration property that contains the list of providers that import this channel.  The variant type for this property is <b>EvtVarTypeString \| EVT_VARIANT_TYPE_ARRAY</b>. 
 
 You cannot set this property.
 


### PR DESCRIPTION
Fixed markup character in [Constants](https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_channel_config_property_id#constants) section.