### PR TITLE
Update nf-strmif-iamvideoprocamp-getrange.md

### DIFF
--- a/sdk-api-src/content/strmif/nf-strmif-iamvideoprocamp-getrange.md
+++ b/sdk-api-src/content/strmif/nf-strmif-iamvideoprocamp-getrange.md
@@ -79,7 +79,7 @@ Receives the default value of the property.
 
 ### -param pCapsFlags [out]
 
-Receives a member of the [VideoProcAmpFlags](/windows/desktop/api/strmif/ne-strmif-videoprocampflags) enumeration, indicating whether the property is controlled automatically or manually.
+Receives one or more members of the [VideoProcAmpFlags](/windows/desktop/api/strmif/ne-strmif-videoprocampflags) enumeration, indicating whether the property is controlled automatically, manually, or both.
 
 ## -returns
 


### PR DESCRIPTION
Clarified the `pCapsFlags` parameter in the [Parameters](https://learn.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-iamvideoprocamp-getrange#parameters) section so that the reader knows that a combination of the flags is allowed.