### PR TITLE
Indicate TreeView_SortChildren recurse flag is NOTIMPL

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-treeview_sortchildren.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-treeview_sortchildren.md
@@ -70,7 +70,7 @@ Handle to the parent item whose child items are to be sorted.
 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">BOOL</a></b>
 
-Value that specifies whether the sorting is recursive. Set <i>fRecurse</i> to <b>TRUE</b> to sort all levels of child items below the parent item. Otherwise, only the parent's immediate children are sorted.
+Not implemented; see remarks.
 
 ## -remarks
 


### PR DESCRIPTION
After investigating [a reported `TreeView_SortChildren` issue](https://github.com/microsoft/win32metadata/issues/1823), it was determined that the default TreeView sorting callback (`comctl32!TV_SortCB`) receives the recurse flag value but doesn't do anything with it. It remains unimplemented in Common Controls v5 and v6.