### PR TITLE
Add ntdll.lib metadata to winternl APIs

### DIFF
--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetaddresstostringa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetaddresstostringa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetaddresstostringw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetaddresstostringw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetstringtoaddressa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetstringtoaddressa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetstringtoaddressw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlethernetstringtoaddressw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressa.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressw.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/rtlsupportapi/nf-rtlsupportapi-rtlraiseexception.md
+++ b/sdk-api-src/content/rtlsupportapi/nf-rtlsupportapi-rtlraiseexception.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlconvertdevicefamilyinfotostring.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlconvertdevicefamilyinfotostring.md
@@ -20,8 +20,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: NtDll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql:
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlfirstentryslist.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlfirstentryslist.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlinitializeslisthead.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlinitializeslisthead.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedflushslist.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedflushslist.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedpopentryslist.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedpopentryslist.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedpushentryslist.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlinterlockedpushentryslist.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winnt/nf-winnt-rtlquerydepthslist.md
+++ b/sdk-api-src/content/winnt/nf-winnt-rtlquerydepthslist.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntclose.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntclose.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: NtDll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
@@ -914,8 +914,7 @@ NTFS is the only Microsoft file system that implements <b>FILE_RESERVE_OPFILTER<
 For more information on oplocks, see <a href="https://msdn.microsoft.com/library/dd445267.aspx">Oplock Semantics</a>.
 
 Note that the WDK header file NtDef.h is necessary for many constant definitions 
-    as well as the <b>InitializeObjectAttributes</b> macro. The associated import library, 
-    NtDll.lib is available in the WDK. To obtain the WDK, see <a href="/windows-hardware/drivers/download-the-wdk">Download kits for Windows hardware development</a>. You can also use the 
+    as well as the <b>InitializeObjectAttributes</b> macro. You can also use the 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to dynamically link to 
     NtDll.dll.

--- a/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
@@ -51,7 +51,7 @@ api_name:
 ## -description
 
 Creates a new file or directory, or opens an existing file, device, directory, or 
-    volume.<div class="alert"><b>Note</b>  Before using this function, please read <a href="/windows/desktop/DevNotes/calling-internal-apis">Calling Internal APIs</a>.</div>
+    volume.
 <div> </div>
 
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntdeviceiocontrolfile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntdeviceiocontrolfile.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
@@ -161,7 +161,7 @@ The forms and significance of <b>NTSTATUS</b> error codes are listed in the Ntst
 
 ## -remarks
 
-This function has no associated header file. The associated import library, Ntdll.lib, is available in the WDK. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
+This function has no associated header file. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
 
 ## -see-also
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
@@ -101,9 +101,6 @@ The options to be applied when opening the file. For more information, see
 
 ## -remarks
 
-Before using this function, please read 
-    <a href="/windows/desktop/DevNotes/calling-internal-apis">Calling Internal APIs</a>.
-
 Driver routines that run in a process context other than that of the system process must set the 
      <b>OBJ_KERNEL_HANDLE</b> attribute for the <i>ObjectAttributes</i> 
      parameter of <b>ZwOpenFile</b>. This restricts the use of the handle returned by 

--- a/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
@@ -117,8 +117,7 @@ Driver routines that run in a process context other than that of the system proc
 Callers of <b>ZwCreateFile</b> must be running at IRQL = PASSIVE_LEVEL.
 
 Note that the WDK header file Ntdef.h is necessary for many constant definitions 
-    as well as the <b>InitializeObjectAttributes</b> macro. The associated import library, 
-    Ntdll.lib is available in the WDK. You can also use the 
+    as well as the <b>InitializeObjectAttributes</b> macro. You can also use the 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to dynamically link to 
     Ntdll.dll.

--- a/sdk-api-src/content/winternl/nf-winternl-ntqueryinformationprocess.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntqueryinformationprocess.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntqueryinformationthread.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntqueryinformationthread.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntquerymultiplevaluekey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntquerymultiplevaluekey.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntquerymultiplevaluekey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntquerymultiplevaluekey.md
@@ -90,7 +90,7 @@ The forms and significance of <b>NTSTATUS</b> error codes are listed in the Ntst
 
 ## -remarks
 
-This function has no associated header file. The associated import library, Ntdll.lib, is available in the WDK. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
+This function has no associated header file. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
 
 ## -see-also
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntqueryobject.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntqueryobject.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntquerysysteminformation.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntquerysysteminformation.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntquerysystemtime.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntquerysystemtime.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntrenamekey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntrenamekey.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntrenamekey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntrenamekey.md
@@ -72,7 +72,7 @@ The forms and significance of <b>NTSTATUS</b> error codes are listed in the Ntst
 
 ## -remarks
 
-This function has no associated header file. The associated import library, Ntdll.lib, is available in the WDK. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
+This function has no associated header file. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to Ntdll.dll.
 
 The <b>NtRenameKey</b> function can be used to rename an entire registry subtree. The caller must have <b>KEY_CREATE_SUB_KEY</b> access to the parent of the specified key and DELETE access to the entire subtree being renamed.
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntsetinformationkey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntsetinformationkey.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-ntsetinformationkey.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntsetinformationkey.md
@@ -88,8 +88,7 @@ The forms and significance of <b>NTSTATUS</b> error codes are listed in the Ntst
 
 ## -remarks
 
-The associated import library, Ntdll.lib, is available in the 
-    WDK. You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and 
+You can also use the <a href="/windows/desktop/DevNotes/-loadlibrary">LoadLibrary</a> and 
     <a href="/windows/desktop/DevNotes/-getprocaddress-">GetProcAddress</a> functions to dynamically link to 
     Ntdll.dll.
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntwaitforsingleobject.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntwaitforsingleobject.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlansistringtounicodestring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlansistringtounicodestring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlchartointeger.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlchartointeger.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlconvertsidtounicodestring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlconvertsidtounicodestring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlfreeansistring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlfreeansistring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlfreeoemstring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlfreeoemstring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlfreeunicodestring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlfreeunicodestring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: NtosKrnl.lib
-req.dll: Ntdll.dll; NtosKrnl.exe
+req.lib: ntdll.lib
+req.dll: ntdll.dll; NtosKrnl.exe
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlinitstring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlinitstring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlinitunicodestring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlinitunicodestring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: NtosKrnl.lib
-req.dll: Ntdll.dll; NtosKrnl.exe
+req.lib: ntdll.lib
+req.dll: ntdll.dll; NtosKrnl.exe
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlisnamelegaldos8dot3.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlisnamelegaldos8dot3.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: NtDll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtllocaltimetosystemtime.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtllocaltimetosystemtime.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlntstatustodoserror.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlntstatustodoserror.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtltimetosecondssince1970.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtltimetosecondssince1970.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlunicodestringtoansistring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlunicodestringtoansistring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: NtosKrnl.lib
-req.dll: Ntdll.dll; NtosKrnl.exe
+req.lib: ntdll.lib
+req.dll: ntdll.dll; NtosKrnl.exe
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlunicodestringtooemstring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlunicodestringtooemstring.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtlunicodetomultibytesize.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlunicodetomultibytesize.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/winternl/nf-winternl-rtluniform.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtluniform.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: 
-req.dll: Ntdll.dll
+req.lib: ntdll.lib
+req.dll: ntdll.dll
 req.irql: 
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
Adds:
* Import library to metadata for more prominent display at the bottom of the page

Removes:
* Outdated information regarding WDK dependency
* Outdated internal API warnings (given the libs shipped with the SDK/WDK)
