### PR TITLE
FIX:  ")X04000" -> "0x04000"

### DIFF
--- a/sdk-api-src/content/wincred/nf-wincred-creduipromptforcredentialsa.md
+++ b/sdk-api-src/content/wincred/nf-wincred-creduipromptforcredentialsa.md
@@ -286,7 +286,7 @@ Populate the combo box with certificates or smart cards only. Do not allow a use
 <tr>
 <td width="40%"><a id="CREDUI_FLAGS_SERVER_CREDENTIAL"></a><a id="credui_flags_server_credential"></a><dl>
 <dt><b>CREDUI_FLAGS_SERVER_CREDENTIAL</b></dt>
-<dt>)X04000</dt>
+<dt>0x04000</dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
Trying to write a python call, and as I'm copy/paste flags, this sticks out as a clear mistake.

Hex doesn't include )X someone got their shift key stuck.
