### PR TITLE
Patch 2

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-setwindowshookexa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowshookexa.md
@@ -83,7 +83,7 @@ The type of hook procedure to be installed. This parameter can be one of the fol
 </td>
 <td width="60%">
 
-Installs a hook procedure that monitors messages before the system sends them to the destination window procedure. For more information, see the [CallWindowProcW function](nf-winuser-callwindowprocw.md)/[CallWindowProcA function](nf-winuser-callwindowproca.md) hook procedure.
+Installs a hook procedure that monitors messages before the system sends them to the destination window procedure. For more information, see the [CallWndProc](/windows/win32/winmsg/callwndproc) hook procedure.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowshookexw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowshookexw.md
@@ -82,7 +82,7 @@ The type of hook procedure to be installed. This parameter can be one of the fol
 </td>
 <td width="60%">
 
-Installs a hook procedure that monitors messages before the system sends them to the destination window procedure. For more information, see the [CallWindowProcW function](nf-winuser-callwindowprocw.md)/[CallWindowProcA function](nf-winuser-callwindowproca.md) hook procedure.
+Installs a hook procedure that monitors messages before the system sends them to the destination window procedure. For more information, see the [CallWndProc](/windows/win32/winmsg/callwndproc) hook procedure.
 
 </td>
 </tr>


### PR DESCRIPTION
The table under the idHook parameter details hook procedure types one can specify when using SetWindowsHookExA, including links to the relevant callback functions. 

The row for WH_CALLWNDPROC references [CallWindowProcA](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-callwindowproca) (which the docs specify to use for subclassing) instead of the associated callback function, CallWndProc.

CallWindowProc
> Use the CallWindowProc function for window subclassing

CallWndProc
> An application installs the hook procedure by specifying the [WH_CALLWNDPROC](https://msdn.microsoft.com/en-us/library/ms644959(v=vs.85)) hook type and a pointer to the hook procedure in a call to the [SetWindowsHookEx](https://msdn.microsoft.com/en-us/library/ms644990(v=vs.85)) function