### PR TITLE
Writes beyond the end of the file do zero initialize data

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-setfilepointer.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-setfilepointer.md
@@ -233,7 +233,7 @@ It is not an error to set a file pointer to a position beyond the end of the fil
     <a href="/windows/desktop/api/fileapi/nf-fileapi-writefile">WriteFile</a>, or 
     <a href="/windows/desktop/api/fileapi/nf-fileapi-writefileex">WriteFileEx</a> function. A write operation increases the size 
     of the file to the file pointer position plus the size of the buffer written, which results in the intervening 
-    bytes uninitialized.
+    bytes being zero initialized.
 
 If the return value is <b>INVALID_SET_FILE_POINTER</b> and if 
     <i>lpDistanceToMoveHigh</i> is non-<b>NULL</b>, an application must call 

--- a/sdk-api-src/content/fileapi/nf-fileapi-setfilepointerex.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-setfilepointerex.md
@@ -163,8 +163,8 @@ Note that it is not an error to set the file pointer to a position beyond the en
     file does not increase until you call the <a href="/windows/desktop/api/fileapi/nf-fileapi-setendoffile">SetEndOfFile</a>, 
     <a href="/windows/desktop/api/fileapi/nf-fileapi-writefile">WriteFile</a>, or 
     <a href="/windows/desktop/api/fileapi/nf-fileapi-writefileex">WriteFileEx</a> function. A write operation increases the size 
-    of the file to the file pointer position plus the size of the buffer written, leaving the intervening bytes 
-    uninitialized.
+    of the file to the file pointer position plus the size of the buffer written, which results in the intervening 
+    bytes being zero initialized.
 
 You can use <b>SetFilePointerEx</b> to determine the length of a file. To do this, 
     use <b>FILE_END</b> for <i>dwMoveMethod</i> and seek to location zero. The 


### PR DESCRIPTION
The docs for [`SetFileValidData`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilevaliddata) go into some detail about the security implications of allowing uninitialized bytes (and the privilege necessary to do that) and claims that:

> The SetFileValidData function allows you to avoid filling data with zeros when writing nonsequentially to a file

With the implication being that other methods do zero fill. However, the docs for `SetFilePointerEx` contradict this

> Note that it is not an error to set the file pointer to a position beyond the end of the file. The size of the file does not increase until you call the [SetEndOfFile](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-setendoffile), [WriteFile](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefile), or [WriteFileEx](https://learn.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-writefileex) function. A write operation increases the size of the file to the file pointer position plus the size of the buffer written, leaving the intervening bytes uninitialized.

I believe that `SetFileValidData` to be correct here and `SetFilePointer[Ex]` to be either wrong or outdated. Furthermore, I don't think general write operations could ever be changed to leave data uninitialized without introducing the security issues that `SetFileValidData` warns about.