### PR TITLE
Update ne-gdiplusenums-stringformatflags.md

### DIFF
--- a/sdk-api-src/content/gdiplusenums/ne-gdiplusenums-stringformatflags.md
+++ b/sdk-api-src/content/gdiplusenums/ne-gdiplusenums-stringformatflags.md
@@ -65,8 +65,7 @@ Specifies that individual lines of text are drawn vertically on the display devi
 
 ### -field StringFormatFlagsNoFitBlackBox:0x00000004
 
-Specifies that parts of characters are allowed to overhang the string's layout rectangle. By default, characters are first aligned inside the rectangle's boundaries, then any characters which still overhang the boundaries are repositioned to avoid any overhang and thereby avoid affecting pixels outside the layout rectangle. An italic, lowercase letter F (
-				<i>f</i>) is an example of a character that may have overhanging parts. Setting this flag ensures that the character aligns visually with the lines above and below but may cause parts of characters, which lie outside the layout rectangle, to be clipped or painted.
+Specifies that parts of characters are allowed to overhang the string's layout rectangle. By default, characters are first aligned inside the rectangle's boundaries, then any characters which still overhang the boundaries are repositioned to avoid any overhang and thereby avoid affecting pixels outside the layout rectangle. An italic, lowercase letter F (<i>f</i>) is an example of a character that may have overhanging parts. Setting this flag ensures that the character aligns visually with the lines above and below but may cause parts of characters, which lie outside the layout rectangle, to be clipped or painted.
 
 ### -field StringFormatFlagsDisplayFormatControl:0x00000020
 


### PR DESCRIPTION
Deleted extra spaces in the [Constants](https://learn.microsoft.com/en-us/windows/win32/api/gdiplusenums/ne-gdiplusenums-stringformatflags#constants) section.
