### PR TITLE
Update ne-gdiplusenums-stringalignment.md

### DIFF
--- a/sdk-api-src/content/gdiplusenums/ne-gdiplusenums-stringalignment.md
+++ b/sdk-api-src/content/gdiplusenums/ne-gdiplusenums-stringalignment.md
@@ -61,8 +61,8 @@ Specifies that alignment is towards the origin of the bounding rectangle. May be
 
 ### -field StringAlignmentCenter:1
 
-Specifies that alignment is centered between origin and extent (width) of the formatting rectangle.
+Specifies that alignment is centered between origin and extent (width or height) of the formatting rectangle.
 
 ### -field StringAlignmentFar:2
 
-Specifies that alignment is to the far extent (right side) of the formatting rectangle.
+Specifies that alignment is to the far extent (lower right) of the formatting rectangle.


### PR DESCRIPTION
Clarifying description of parameters in the [Constants](https://learn.microsoft.com/en-us/windows/win32/api/gdiplusenums/ne-gdiplusenums-stringalignment#constants) section so that their meaning is clear when aligning vertically with the **StringFormat::SetLineAlignment** method.
