### PR TITLE
Remove unused variable dwSize

### DIFF
--- a/sdk-api-src/content/iphlpapi/nf-iphlpapi-getadaptersaddresses.md
+++ b/sdk-api-src/content/iphlpapi/nf-iphlpapi-getadaptersaddresses.md
@@ -389,7 +389,6 @@ int __cdecl main(int argc, char **argv)
 
     /* Declare and initialize variables */
 
-    DWORD dwSize = 0;
     DWORD dwRetVal = 0;
 
     unsigned int i = 0;


### PR DESCRIPTION
dwSize was not used for anything in this example, and there is no obvious place where it should have been used.