### PR TITLE
Update nf-ocidl-ispecifypropertypages-getpages.md

### DIFF
--- a/sdk-api-src/content/ocidl/nf-ocidl-ispecifypropertypages-getpages.md
+++ b/sdk-api-src/content/ocidl/nf-ocidl-ispecifypropertypages-getpages.md
@@ -56,7 +56,7 @@ Retrieves a list of property pages that can be displayed in this object's proper
 
 ### -param pPages [out]
 
-A pointer to a caller-allocated <a href="/windows/desktop/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure that must be initialized and filled before returning. The <b>pElems</b> member in the structure is allocated by the callee with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a> and freed by the caller with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>.
+A pointer to a caller-allocated <a href="/windows/desktop/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure. The <b>pElems</b> member in the structure is allocated by the callee with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a> and freed by the caller with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>.
 
 ## -returns
 

--- a/sdk-api-src/content/ocidl/nf-ocidl-ispecifypropertypages-getpages.md
+++ b/sdk-api-src/content/ocidl/nf-ocidl-ispecifypropertypages-getpages.md
@@ -45,9 +45,6 @@ api_name:
  - ISpecifyPropertyPages.GetPages
 ---
 
-# ISpecifyPropertyPages::GetPages
-
-
 ## -description
 
 Retrieves a list of property pages that can be displayed in this object's property sheet.
@@ -56,7 +53,7 @@ Retrieves a list of property pages that can be displayed in this object's proper
 
 ### -param pPages [out]
 
-A pointer to a caller-allocated <a href="/windows/desktop/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure. The <b>pElems</b> member in the structure is allocated by the callee with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a> and freed by the caller with <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>.
+A pointer to a caller-allocated <a href="/windows/win32/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure that the function initializes and fills in before it returns. The <b>pElems</b> member in the structure is allocated by the function with <a href="/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a>, and should be freed by the caller with <a href="/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a>.
 
 ## -returns
 
@@ -87,21 +84,20 @@ The method completed successfully.
 <td width="60%">
 The address in <i>pPages</i> is not valid. For example, it may be <b>NULL</b>.
 
-
 </td>
 </tr>
 </table>
 
 ## -remarks
 
-The <a href="/windows/desktop/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure is caller-allocated, but is not initialized by the caller. The <b>GetPages</b> method fills the <b>cElements</b> member in the structure. This method also allocates memory for the array pointed to by the <b>pElems</b> member using <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a>. Then, it fills the newly allocated array. After this method returns successfully, the structure contains a counted array of UUIDs, each UUID specifying a property page CLSID.
+The <a href="/windows/win32/api/ocidl/ns-ocidl-cauuid">CAUUID</a> structure is caller-allocated, but is not initialized by the caller. The <b>GetPages</b> method fills the <b>cElements</b> member in the structure. This method also allocates memory for the array pointed to by the <b>pElems</b> member using <a href="/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemalloc">CoTaskMemAlloc</a>. Then, it fills the newly allocated array. After this method returns successfully, the structure contains a counted array of UUIDs, each UUID specifying a property page CLSID.
 
 <h3><a id="Notes_to_Callers"></a><a id="notes_to_callers"></a><a id="NOTES_TO_CALLERS"></a>Notes to Callers</h3>
-The caller must release the memory pointed to by the <b>pElems</b> member of <a href="/windows/desktop/api/ocidl/ns-ocidl-cauuid">CAUUID</a>, using <a href="/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a> when it is no longer needed.
+The caller must release the memory pointed to by the <b>pElems</b> member of <a href="/windows/win32/api/ocidl/ns-ocidl-cauuid">CAUUID</a>, using <a href="/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree">CoTaskMemFree</a> when it is no longer needed.
 
 <h3><a id="Notes_to_Implementers"></a><a id="notes_to_implementers"></a><a id="NOTES_TO_IMPLEMENTERS"></a>Notes to Implementers</h3>
-E_NOTIMPL is not allowed as a return value, because an object with no property pages should not expose the <a href="/windows/desktop/api/ocidl/nn-ocidl-ispecifypropertypages">ISpecifyPropertyPages</a> interface.
+E_NOTIMPL is not allowed as a return value, because an object with no property pages should not expose the <a href="/windows/win32/api/ocidl/nn-ocidl-ispecifypropertypages">ISpecifyPropertyPages</a> interface.
 
 ## -see-also
 
-<a href="/windows/desktop/api/ocidl/nn-ocidl-ispecifypropertypages">ISpecifyPropertyPages</a>
+<a href="/windows/win32/api/ocidl/nn-ocidl-ispecifypropertypages">ISpecifyPropertyPages</a>


### PR DESCRIPTION
Deleted text that, in my opinion, creates confusion. The "must be initialized and filled" part seems to imply that the caller is supposed to initialize and fill the structure.