### PR TITLE
Document that DXGI_SCALING_NONE is valid with DXGI_SWAP_EFFECT_FLIP_DISCARD

### DIFF
--- a/sdk-api-src/content/dxgi1_2/ne-dxgi1_2-dxgi_scaling.md
+++ b/sdk-api-src/content/dxgi1_2/ne-dxgi1_2-dxgi_scaling.md
@@ -74,7 +74,7 @@ Note that with legacy Win32 window swapchains, this works the same as DXGI_SCALI
 
 ## -remarks
 
-The DXGI_SCALING_NONE value is supported only for flip presentation model swap chains that you create with the <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a> value. You pass these values in a call to <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd">IDXGIFactory2::CreateSwapChainForHwnd</a>, <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcorewindow">IDXGIFactory2::CreateSwapChainForCoreWindow</a>, or  <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcomposition">IDXGIFactory2::CreateSwapChainForComposition</a>. 
+The DXGI_SCALING_NONE value is supported only for flip presentation model swap chains that you create with the <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a> or <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_DISCARD</a> value. You pass these values in a call to <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd">IDXGIFactory2::CreateSwapChainForHwnd</a>, <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcorewindow">IDXGIFactory2::CreateSwapChainForCoreWindow</a>, or  <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcomposition">IDXGIFactory2::CreateSwapChainForComposition</a>. 
 
 DXGI_SCALING_ASPECT_RATIO_STRETCH will prefer to use a horizontal fill, otherwise it will use a vertical fill, using the following logic.
 

--- a/sdk-api-src/content/dxgi1_2/ne-dxgi1_2-dxgi_scaling.md
+++ b/sdk-api-src/content/dxgi1_2/ne-dxgi1_2-dxgi_scaling.md
@@ -45,9 +45,6 @@ api_name:
  - DXGI_SCALING
 ---
 
-# DXGI_SCALING enumeration
-
-
 ## -description
 
 Identifies resize behavior when the back-buffer size does not match the size of the target output.
@@ -56,13 +53,13 @@ Identifies resize behavior when the back-buffer size does not match the size of 
 
 ### -field DXGI_SCALING_STRETCH:0
 
-Directs DXGI to make the back-buffer contents scale to fit the presentation target size. This is the implicit behavior of DXGI when you call the <a href="/windows/desktop/api/dxgi/nf-dxgi-idxgifactory-createswapchain">IDXGIFactory::CreateSwapChain</a> method.
+Directs DXGI to make the back-buffer contents scale to fit the presentation target size. This is the implicit behavior of DXGI when you call the <a href="/windows/win32/api/dxgi/nf-dxgi-idxgifactory-createswapchain">IDXGIFactory::CreateSwapChain</a> method.
 
 ### -field DXGI_SCALING_NONE:1
 
 Directs DXGI to make the back-buffer contents appear without any scaling when the presentation target size is not equal to the back-buffer size. The top edges of the back buffer and presentation target are aligned together. If the WS_EX_LAYOUTRTL style is associated with the <a href="/windows/desktop/WinProg/windows-data-types">HWND</a> handle to the target output window, the right edges of the back buffer and presentation target are aligned together; otherwise, the left edges are aligned together. All target area outside the back buffer is filled with window background color.
 
-This value specifies that all target areas outside the back buffer of a swap chain are filled with the background color that you specify in a call to <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgiswapchain1-setbackgroundcolor">IDXGISwapChain1::SetBackgroundColor</a>.
+This value specifies that all target areas outside the back buffer of a swap chain are filled with the background color that you specify in a call to <a href="/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgiswapchain1-setbackgroundcolor">IDXGISwapChain1::SetBackgroundColor</a>.
 
 ### -field DXGI_SCALING_ASPECT_RATIO_STRETCH:2
 
@@ -74,7 +71,7 @@ Note that with legacy Win32 window swapchains, this works the same as DXGI_SCALI
 
 ## -remarks
 
-The DXGI_SCALING_NONE value is supported only for flip presentation model swap chains that you create with the <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a> or <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_DISCARD</a> value. You pass these values in a call to <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd">IDXGIFactory2::CreateSwapChainForHwnd</a>, <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcorewindow">IDXGIFactory2::CreateSwapChainForCoreWindow</a>, or  <a href="/windows/desktop/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcomposition">IDXGIFactory2::CreateSwapChainForComposition</a>. 
+The DXGI_SCALING_NONE value is supported only for flip presentation model swap chains that you create with the <a href="/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a> or <a href="/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_DISCARD</a> value. You pass these values in a call to <a href="/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforhwnd">IDXGIFactory2::CreateSwapChainForHwnd</a>, <a href="/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcorewindow">IDXGIFactory2::CreateSwapChainForCoreWindow</a>, or  <a href="/windows/win32/api/dxgi1_2/nf-dxgi1_2-idxgifactory2-createswapchainforcomposition">IDXGIFactory2::CreateSwapChainForComposition</a>. 
 
 DXGI_SCALING_ASPECT_RATIO_STRETCH will prefer to use a horizontal fill, otherwise it will use a vertical fill, using the following logic.
 
@@ -115,4 +112,4 @@ Note that <i>outputWidth</i> and <i>outputHeight</i> are the pixel sizes of the 
 
 
 
-<a href="/windows/desktop/api/dxgi1_2/ns-dxgi1_2-dxgi_swap_chain_desc1">DXGI_SWAP_CHAIN_DESC1</a>
+<a href="/windows/win32/api/dxgi1_2/ns-dxgi1_2-dxgi_swap_chain_desc1">DXGI_SWAP_CHAIN_DESC1</a>


### PR DESCRIPTION
The original documentation suggests that DXGI_SCALING_NONE cannot be used with DXGI_SWAP_EFFECT_FLIP_DISCARD, only with DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL.

DXGI_SCALING_NONE is used with DXGI_SWAP_EFFECT_FLIP_DISCARD in many places, including Microsoft’s own code, for example:

 - https://github.com/microsoft/DirectX-Graphics-Samples/blob/b5f92e2251ee83db4d4c795b3cba5d470c52eaf8/MiniEngine/Core/Display.cpp#L242-L243
 - https://github.com/microsoft/DirectStorage/blob/60a909f351d18293aeae1af7e24fc38519ebe118/Samples/BulkLoadDemo/Core/Display.cpp#L242-L243
 - https://github.com/godotengine/godot/blob/d3352813ea44447bfbf135efdec23acc4d1d3f89/drivers/d3d12/d3d12_context.cpp#L777-L780

So it should probably be documented to be allowed.