### PR TITLE
Fix incorrect documentation link for D3D11_TEXTURE2D_DESC1

### DIFF
--- a/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11device3-createtexture2d1.md
+++ b/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11device3-createtexture2d1.md
@@ -57,9 +57,9 @@ Creates a <a href="/windows/desktop/direct3d11/overviews-direct3d-11-resources-t
 
 ### -param pDesc1 [in]
 
-Type: <b>const <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-cd3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a>*</b>
+Type: <b>const <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a>*</b>
 
-A pointer to a <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-cd3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a> structure that describes a 2D texture resource. To create a typeless resource that can be interpreted at runtime into different, compatible formats, specify a typeless format in the texture description. To generate mipmap levels automatically, set the number of mipmap levels to 0.
+A pointer to a <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-d3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a> structure that describes a 2D texture resource. To create a typeless resource that can be interpreted at runtime into different, compatible formats, specify a typeless format in the texture description. To generate mipmap levels automatically, set the number of mipmap levels to 0.
 
 ### -param pInitialData [in, optional]
 

--- a/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11device3-createtexture2d1.md
+++ b/sdk-api-src/content/d3d11_3/nf-d3d11_3-id3d11device3-createtexture2d1.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["CreateTexture2D1","CreateTexture2D1 method [Direct3D 11]"
 old-location: direct3d11\id3d11device3_createtexture2d1.htm
 tech.root: direct3d11
 ms.assetid: 50C5789A-2C8E-49CB-9348-639CF8B971EC
-ms.date: 12/05/2018
+ms.date: 02/12/2024
 ms.keywords: CreateTexture2D1, CreateTexture2D1 method [Direct3D 11], CreateTexture2D1 method [Direct3D 11],ID3D11Device3 interface, ID3D11Device3 interface [Direct3D 11],CreateTexture2D1 method, ID3D11Device3.CreateTexture2D1, ID3D11Device3::CreateTexture2D1, d3d11_3/ID3D11Device3::CreateTexture2D1, direct3d11.id3d11device3_createtexture2d1
 req.header: d3d11_3.h
 req.include-header: 
@@ -46,26 +46,23 @@ api_name:
  - ID3D11Device3.CreateTexture2D1
 ---
 
-# ID3D11Device3::CreateTexture2D1
-
-
 ## -description
 
-Creates a <a href="/windows/desktop/direct3d11/overviews-direct3d-11-resources-textures-intro">2D texture</a>.
+Creates a <a href="/windows/win32/direct3d11/overviews-direct3d-11-resources-textures-intro">2D texture</a>.
 
 ## -parameters
 
 ### -param pDesc1 [in]
 
-Type: <b>const <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a>*</b>
+Type: <b>const <a href="/windows/win32/api/d3d11_3/ns-d3d11_3-d3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a>*</b>
 
-A pointer to a <a href="/windows/desktop/api/d3d11_3/ns-d3d11_3-d3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a> structure that describes a 2D texture resource. To create a typeless resource that can be interpreted at runtime into different, compatible formats, specify a typeless format in the texture description. To generate mipmap levels automatically, set the number of mipmap levels to 0.
+A pointer to a <a href="/windows/win32/api/d3d11_3/ns-d3d11_3-d3d11_texture2d_desc1">D3D11_TEXTURE2D_DESC1</a> structure that describes a 2D texture resource. To create a typeless resource that can be interpreted at runtime into different, compatible formats, specify a typeless format in the texture description. To generate mipmap levels automatically, set the number of mipmap levels to 0.
 
 ### -param pInitialData [in, optional]
 
-Type: <b>const <a href="/windows/desktop/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a>*</b>
+Type: <b>const <a href="/windows/win32/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a>*</b>
 
- A pointer to an array of <a href="/windows/desktop/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a> structures that describe subresources for the 2D texture resource. Applications can't specify <b>NULL</b> for <i>pInitialData</i> when creating IMMUTABLE resources (see <a href="/windows/desktop/api/d3d11/ne-d3d11-d3d11_usage">D3D11_USAGE</a>). If the resource is multisampled, <i>pInitialData</i> must be <b>NULL</b> because multisampled resources can't be initialized with data when they're created.
+ A pointer to an array of <a href="/windows/win32/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a> structures that describe subresources for the 2D texture resource. Applications can't specify <b>NULL</b> for <i>pInitialData</i> when creating IMMUTABLE resources (see <a href="/windows/win32/api/d3d11/ne-d3d11-d3d11_usage">D3D11_USAGE</a>). If the resource is multisampled, <i>pInitialData</i> must be <b>NULL</b> because multisampled resources can't be initialized with data when they're created.
 
 If you don't pass anything to <i>pInitialData</i>, the initial content of the memory for the resource is undefined. In this case, you need to write the resource content some other way before the resource is read.
 
@@ -77,21 +74,21 @@ For more info about this array size, see Remarks.
 
 ### -param ppTexture2D [out, optional]
 
-Type: <b><a href="/windows/desktop/api/d3d11_3/nn-d3d11_3-id3d11texture2d1">ID3D11Texture2D1</a>**</b>
+Type: <b><a href="/windows/win32/api/d3d11_3/nn-d3d11_3-id3d11texture2d1">ID3D11Texture2D1</a>**</b>
 
-A pointer to a memory block that receives a pointer to a <a href="/windows/desktop/api/d3d11_3/nn-d3d11_3-id3d11texture2d1">ID3D11Texture2D1</a> interface for the created texture. Set this parameter to <b>NULL</b> to validate the other input parameters (the method will return <b>S_FALSE</b> if the other input parameters pass validation).
+A pointer to a memory block that receives a pointer to a <a href="/windows/win32/api/d3d11_3/nn-d3d11_3-id3d11texture2d1">ID3D11Texture2D1</a> interface for the created texture. Set this parameter to <b>NULL</b> to validate the other input parameters (the method will return <b>S_FALSE</b> if the other input parameters pass validation).
 
 ## -returns
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
-If the method succeeds, the return code is <b>S_OK</b>. See <a href="/windows/desktop/direct3d11/d3d11-graphics-reference-returnvalues">Direct3D 11 Return Codes</a> for failing error codes.
+If the method succeeds, the return code is <b>S_OK</b>. See <a href="/windows/win32/direct3d11/d3d11-graphics-reference-returnvalues">Direct3D 11 Return Codes</a> for failing error codes.
 
 ## -remarks
 
 <b>CreateTexture2D1</b> creates a 2D texture resource, which can contain a number of 2D subresources. The number of subresources is specified in the texture description. All textures in a resource must have the same format, size, and number of mipmap levels.
 
-All resources are made up of one or more subresources. To load data into the texture, applications can supply the data initially as an array of <a href="/windows/desktop/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a> structures pointed to by <i>pInitialData</i>, or they can use one of the D3DX texture functions such as <a href="/windows/desktop/direct3d11/d3dx11createtexturefromfile">D3DX11CreateTextureFromFile</a>.
+All resources are made up of one or more subresources. To load data into the texture, applications can supply the data initially as an array of <a href="/windows/win32/api/d3d11/ns-d3d11-d3d11_subresource_data">D3D11_SUBRESOURCE_DATA</a> structures pointed to by <i>pInitialData</i>, or they can use one of the D3DX texture functions such as <a href="/windows/win32/direct3d11/d3dx11createtexturefromfile">D3DX11CreateTextureFromFile</a>.
 
 For a 32 x 32 texture with a full mipmap chain, the <i>pInitialData</i> array has the following 6 elements:
 
@@ -110,4 +107,4 @@ For a 32 x 32 texture with a full mipmap chain, the <i>pInitialData</i> array ha
 
 ## -see-also
 
-<a href="/windows/desktop/api/d3d11_3/nn-d3d11_3-id3d11device3">ID3D11Device3</a>
+<a href="/windows/win32/api/d3d11_3/nn-d3d11_3-id3d11device3">ID3D11Device3</a>


### PR DESCRIPTION
The link for `D3D11_TEXTURE2D_DESC1` was pointing to the helper structure `CD3D11_TEXTURE2D_DESC1` instead of the proper documentation for the D3D structure.