### PR TITLE
winsock: Fix WSAStartup parameter description

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-wsastartup.md
+++ b/sdk-api-src/content/winsock/nf-winsock-wsastartup.md
@@ -47,17 +47,13 @@ api_name:
  - WSAStartup
 ---
 
-# WSAStartup function
-
-
 ## -description
 
-The 
-<b>WSAStartup</b> function initiates use of the Winsock DLL by a process.
+The <b>WSAStartup</b> function initiates use of the Winsock DLL by a process.
 
 ## -parameters
 
-### -param wVersionRequested [in]
+### -param wVersionRequired [in]
 
 The highest version of Windows Sockets specification that the caller can use. The high-order byte specifies the minor version number; the low-order byte specifies the major version number.
 

--- a/sdk-api-src/content/winsock/nf-winsock-wsastartup.md
+++ b/sdk-api-src/content/winsock/nf-winsock-wsastartup.md
@@ -57,19 +57,14 @@ The
 
 ## -parameters
 
-### -param wVersionRequired
+### -param wVersionRequested [in]
 
-TBD
+The highest version of Windows Sockets specification that the caller can use. The high-order byte specifies the minor version number; the low-order byte specifies the major version number.
 
 ### -param lpWSAData [out]
 
 A pointer to the 
 <a href="/windows/desktop/api/winsock/ns-winsock-wsadata">WSADATA</a> data structure that is to receive details of the Windows Sockets implementation.
-
-
-#### - wVersionRequested [in]
-
-The highest version of Windows Sockets specification that the caller can use. The high-order byte specifies the minor version number; the low-order byte specifies the major version number.
 
 ## -returns
 


### PR DESCRIPTION
winsock: Fix WSAStartup parameter description

- Replace wVersionRequired with wVersionRequested.

Prior to this change wVersionRequired had a description of TBD and wVersionRequested had the correct description though was not rendered.

Both are different names of the same parameter depending on which SDK is used. The function prototype is extracted from an SDK which uses wVersionRequired but IMO "required" is the wrong name to use. It is properly noted as the "requested" version numerous times throughout the documentation.

This change makes the tradeoff that rather than be consistent with what name the renderer has extracted from the SDK (ie wVersionRequired), instead use the name that is most correct (ie wVersionRequested).

Recent SDKs (including the latest) and even an old Windows 7 SDK have wVersionRequested. I couldn't find which SDK has wVersionRequired.

A complete fix for this issue would be to get the renderer to extract the function prototype from the latest version of the SDK.

Ref: https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsastartup

Closes #xxxxx
