### PR TITLE
Update nf-wow64apiset-wow64revertwow64fsredirection.md

### DIFF
--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
@@ -63,7 +63,7 @@ Any data allocation on behalf of the <a href="/windows/desktop/api/wow64apiset/n
 
 ## -parameters
 
-### -param OlValue
+### -param OldValue [in]
 
 The WOW64 file system redirection value. This value is obtained from the <a href="/windows/desktop/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection">Wow64DisableWow64FsRedirection</a> function.
 


### PR DESCRIPTION
fix documentation of Wow64RevertWow64FsRedirection param

This should be OldValue [in] which is reflected in original version https://github.com/MicrosoftDocs/sdk-api/commit/c59c21b25257e780426831d5777ffcf1c89343f7#diff-e16bf57fbe7232482325e817f081d23d7e060c5f42470bf7eecf4c67bd8e6b08R71

https://learn.microsoft.com/windows/win32/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection