### PR TITLE
Winsock2 function documentation fixes

### DIFF
--- a/sdk-api-src/content/winsock2/nf-winsock2-wsaaddresstostringa.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsaaddresstostringa.md
@@ -11,7 +11,7 @@ ms.keywords: WSAAddressToString, WSAAddressToString function [Winsock], WSAAddre
 req.header: winsock2.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1, Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP, Windows 8.1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
@@ -155,7 +155,7 @@ If the <i>lpsaAddress</i> parameter points to an IPv6 socket address (the addres
 If the length of the buffer pointed to by the <i>lpszAddressString</i> parameter is not large enough to receive the string representation of the socket address, <b>WSAAddressToString</b> returns 
 								<a href="/windows/desktop/WinSock/windows-sockets-error-codes-2">WSAEFAULT</a>. 
 
-Support for IPv6 addresses using the <b>WSAAddressToString</b> function was added on Windows XP with Service Pack 1 (SP1)and later. IPv6 must also be installed on the local computer for the <b>WSAAddressToString</b> function to support IPv6 addresses. 
+Support for IPv6 addresses using the <b>WSAAddressToString</b> function was added on Windows XP with Service Pack 1 (SP1) and later. IPv6 must also be installed on the local computer for the <b>WSAAddressToString</b> function to support IPv6 addresses. 
 
 <b>Windows Phone 8:</b> The <b>WSAAddressToStringW</b> function is supported for Windows Phone Store apps on Windows Phone 8 and later.
 

--- a/sdk-api-src/content/winsock2/nf-winsock2-wsaaddresstostringw.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsaaddresstostringw.md
@@ -11,7 +11,7 @@ ms.keywords: WSAAddressToString, WSAAddressToString function [Winsock], WSAAddre
 req.header: winsock2.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1, Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP, Windows 8.1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
@@ -155,7 +155,7 @@ If the <i>lpsaAddress</i> parameter points to an IPv6 socket address (the addres
 If the length of the buffer pointed to by the <i>lpszAddressString</i> parameter is not large enough to receive the string representation of the socket address, <b>WSAAddressToString</b> returns 
 								<a href="/windows/desktop/WinSock/windows-sockets-error-codes-2">WSAEFAULT</a>. 
 
-Support for IPv6 addresses using the <b>WSAAddressToString</b> function was added on Windows XP with Service Pack 1 (SP1)and later. IPv6 must also be installed on the local computer for the <b>WSAAddressToString</b> function to support IPv6 addresses. 
+Support for IPv6 addresses using the <b>WSAAddressToString</b> function was added on Windows XP with Service Pack 1 (SP1) and later. IPv6 must also be installed on the local computer for the <b>WSAAddressToString</b> function to support IPv6 addresses. 
 
 <b>Windows Phone 8:</b> The <b>WSAAddressToStringW</b> function is supported for Windows Phone Store apps on Windows Phone 8 and later.
 

--- a/sdk-api-src/content/winsock2/nf-winsock2-wsastringtoaddressw.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsastringtoaddressw.md
@@ -11,7 +11,7 @@ ms.keywords: WSAStringToAddress, WSAStringToAddress function [Winsock], WSAStrin
 req.header: winsock2.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1, Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP, Windows 8.1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
@@ -150,7 +150,7 @@ The
 <b>WSAStringToAddress</b> function fails (and returns WSAEINVAL) if the <b>sin_family</b> member of the <a href="/windows/desktop/WinSock/sockaddr-2">SOCKADDR_IN</a> structure, which is passed in the <i>lpAddress</i> parameter in the form of a 
 <b>sockaddr</b> structure, is not set to AF_INET or AF_INET6. 
 
-Support for IPv6 addresses using the <b>WSAStringToAddress</b> function was added on Windows XP with Service Pack 1 (SP1)and later. IPv6 must also be installed on the local computer for the <b>WSAStringToAddress</b> function to support IPv6 addresses. 
+Support for IPv6 addresses using the <b>WSAStringToAddress</b> function was added on Windows XP with Service Pack 1 (SP1) and later. IPv6 must also be installed on the local computer for the <b>WSAStringToAddress</b> function to support IPv6 addresses. 
 
 <b>Windows Phone 8:</b> This  function is supported for Windows Phone Store apps on Windows Phone 8 and later.
 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfo.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfo.md
@@ -11,7 +11,7 @@ ms.keywords: GetAddrInfoA, _win32_getaddrinfo_2, getaddrinfo, getaddrinfo functi
 req.header: ws2tcpip.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1, Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP, Windows 8.1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfoexa.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfoexa.md
@@ -11,7 +11,7 @@ ms.keywords: GetAddrInfoEx, GetAddrInfoEx function [Winsock], GetAddrInfoExA, Ge
 req.header: ws2tcpip.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfoexw.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfoexw.md
@@ -11,7 +11,7 @@ ms.keywords: GetAddrInfoEx, GetAddrInfoEx function [Winsock], GetAddrInfoExA, Ge
 req.header: ws2tcpip.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2008 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfow.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-getaddrinfow.md
@@ -11,7 +11,7 @@ ms.keywords: GetAddrInfoW, GetAddrInfoW function [Winsock], winsock.getaddrinfow
 req.header: ws2tcpip.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1, Windows Vista [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows XP, Windows 8.1 [desktop apps \| UWP apps]
 req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 


### PR DESCRIPTION
many of the longstanding winsock2 / ws2_32 function docs have incorrect info in the minimum client version field. Many of the functions that have been around since XP show a minimum client version of Vista in the docs. Some correctly show XP.

I also found the listing of Desktop | UWP to be somewhat confusing.
![image](https://github.com/MicrosoftDocs/sdk-api/assets/5124946/7ed7ca05-b376-45b0-b0cd-75cbeb69a8c7)

It seems like the min UWP platform (Windows 8.1) should be listed as the second item?

this PR fixes the min client ver listed for the most common functions, and ones that describe being supported by XP in the docs. (I confirmed these functions are present in XP ws2_32).

There may be other functions with incorrect minimum client version info, and more systematic updates and fixes may be good.

[NO_TRAIN]::