### PR TITLE
Fix `GetOverlappedResultEx` mentioning behaviour on unsupported systems

### DIFF
--- a/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
+++ b/sdk-api-src/content/ioapiset/nf-ioapiset-getoverlappedresultex.md
@@ -90,9 +90,7 @@ If <i>dwMilliseconds</i> is nonzero and the operation is still in progress, the 
 
 If <i>dwMilliseconds</i> is <b>INFINITE</b>, the function returns only when the object is signaled or an I/O completion routine or APC is queued.
 
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value includes time spent in low-power states. For example, the timeout continues counting down while the computer is asleep.
-
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not continue counting down while the computer is asleep.
+The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not continue counting down while the computer is asleep.
 
 ### -param bAlertable [in]
 


### PR DESCRIPTION
`dwMilliseconds` in the `Parameters` section of `GetOverlappedResultEx` mentions differences in behaviour between `Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2` and `Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016` when the function was first added in `Windows 8` and `Windows Server 2012`.

I have tested on both Windows 7 Service Pack 1 and Windows Server 2008 R2 Service Pack 1 and can confirm that the API does not exist in either.

The text was likely copied from `GetQueuedCompletionStatus` which does support the older systems in https://github.com/MicrosoftDocs/sdk-api/commit/259e6f31856dd2d6dcdb0f9f8ec41bb4ff0dbcc1#diff-9ceb6ee9bcc7dcc73c3de5a168787f699389f156d4404b215f79ff2fdd27684eR93

Instead just explain the "new" behaviour as that's the behaviour on all supported systems.