### PR TITLE
Clearer _DENY_SHADER_RESOURCE 'bandwidth' wording

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_flags.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_resource_flags.md
@@ -91,7 +91,7 @@ The following restrictions and interactions apply:
 
 ### -field D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE:0x8
 
-Disallows a shader resource view from being created for the resource, as well as disables the resource from transitioning into the state of [D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states) or **D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE**. Some adapter architectures experience increased bandwidth for depth stencil textures when shader resource views are precluded. If a texture is rarely used for shader resources, then it might be worth having two textures around and copying between them. One texture would have this flag, while the other wouldn't. Your application should set this flag when depth stencil textures will never be used from shader resource views.
+Disallows a shader resource view from being created for the resource, as well as disables the resource from transitioning into the state of [D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_states) or **D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE**. Some adapter architectures gain bandwidth capacity for depth stencil textures when shader resource views are precluded. If a texture is rarely used for shader resources, then it might be worth having two textures around and copying between them. One texture would have this flag, while the other wouldn't. Your application should set this flag when depth stencil textures will never be used from shader resource views.
 
 The following restrictions and interactions apply:
 <ul>


### PR DESCRIPTION
'experience increased bandwidth' could equally be 'gain bandwidth capacity' or the complete opposite, 'suffer from increased bandwidth use'.  This makes it clearer that it's the former.

Relates to [issue #D3D12_RESOURCE_FLAG_DENY](https://github.com/microsoft/DirectX-Specs/issues/171)