### PR TITLE
Update nf-wow64apiset-wow64revertwow64fsredirection.md

### DIFF
--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
@@ -67,7 +67,7 @@ Any data allocation on behalf of the <a href="/windows/desktop/api/wow64apiset/n
 
 The WOW64 file system redirection value. This value is obtained from the <a href="/windows/desktop/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection">Wow64DisableWow64FsRedirection</a> function.
 
-Note: this value is _sic_, defined in `wow64apiset.h`.
+This value is defined in `wow64apiset.h`.
 
 ## -returns
 

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-wow64revertwow64fsredirection.md
@@ -63,9 +63,11 @@ Any data allocation on behalf of the <a href="/windows/desktop/api/wow64apiset/n
 
 ## -parameters
 
-### -param OldValue [in]
+### -param OlValue [in]
 
 The WOW64 file system redirection value. This value is obtained from the <a href="/windows/desktop/api/wow64apiset/nf-wow64apiset-wow64disablewow64fsredirection">Wow64DisableWow64FsRedirection</a> function.
+
+Note: this value is _sic_, defined in `wow64apiset.h`.
 
 ## -returns
 


### PR DESCRIPTION
This PR updates #1771 to retain the literal argument variable name from `wow64apiset.h`.

[NO_TRAIN]::