### PR TITLE
Add note from MS14-019 to CreateProcessA

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -85,7 +85,7 @@ The <i>lpApplicationName</i> parameter can be <b>NULL</b>. In that case, the mod
 
 If the executable module is a 16-bit application, <i>lpApplicationName</i> should be <b>NULL</b>, and the string pointed to by <i>lpCommandLine</i> should specify the executable module as well as its arguments.
 
-To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file. In https://msrc.microsoft.com/blog/2014/04/ms14-019-fixing-a-binary-hijacking-via-cmd-or-bat-file/ the security advises against this.
+To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file. In https://msrc.microsoft.com/blog/2014/04/ms14-019-fixing-a-binary-hijacking-via-cmd-or-bat-file/ the MSRC engineering team advises against this.
 
 ### -param lpCommandLine [in, out, optional]
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -85,7 +85,10 @@ The <i>lpApplicationName</i> parameter can be <b>NULL</b>. In that case, the mod
 
 If the executable module is a 16-bit application, <i>lpApplicationName</i> should be <b>NULL</b>, and the string pointed to by <i>lpCommandLine</i> should specify the executable module as well as its arguments.
 
-To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file. In https://msrc.microsoft.com/blog/2014/04/ms14-019-fixing-a-binary-hijacking-via-cmd-or-bat-file/ the MSRC engineering team advises against this.
+To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file.
+
+> [!IMPORTANT]
+> The MSRC engineering team advises against this. See [MS14-019 – Fixing a binary hijacking via .cmd or .bat file](https://msrc.microsoft.com/blog/2014/04/ms14-019-fixing-a-binary-hijacking-via-cmd-or-bat-file/) for more details.
 
 ### -param lpCommandLine [in, out, optional]
 
@@ -192,8 +195,8 @@ Handles in
 <a href="/windows/desktop/api/processthreadsapi/ns-processthreadsapi-startupinfoa">STARTUPINFO</a> or <a href="/windows/desktop/api/winbase/ns-winbase-startupinfoexa">STARTUPINFOEX</a> must be closed with 
 <a href="/windows/desktop/api/handleapi/nf-handleapi-closehandle">CloseHandle</a> when they are no longer needed.
 
-<div class="alert"><b>Important</b>  The caller is responsible for ensuring that the standard handle fields in <a href="/windows/desktop/api/processthreadsapi/ns-processthreadsapi-startupinfoa">STARTUPINFO</a>  contain valid handle values. These fields are copied unchanged to the child process without validation, even when the <b>dwFlags</b> member specifies <b>STARTF_USESTDHANDLES</b>. Incorrect values can cause the child process to misbehave or crash. Use the <a href="/windows-hardware/drivers/devtest/application-verifier">Application Verifier</a> runtime verification tool to detect invalid handles. </div>
-<div> </div>
+> [!IMPORTANT]
+> The caller is responsible for ensuring that the standard handle fields in <a href="/windows/desktop/api/processthreadsapi/ns-processthreadsapi-startupinfoa">STARTUPINFO</a>  contain valid handle values. These fields are copied unchanged to the child process without validation, even when the <b>dwFlags</b> member specifies <b>STARTF_USESTDHANDLES</b>. Incorrect values can cause the child process to misbehave or crash. Use the <a href="/windows-hardware/drivers/devtest/application-verifier">Application Verifier</a> runtime verification tool to detect invalid handles.
 
 ### -param lpProcessInformation [out]
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-createprocessa.md
@@ -85,7 +85,7 @@ The <i>lpApplicationName</i> parameter can be <b>NULL</b>. In that case, the mod
 
 If the executable module is a 16-bit application, <i>lpApplicationName</i> should be <b>NULL</b>, and the string pointed to by <i>lpCommandLine</i> should specify the executable module as well as its arguments.
 
-To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file.
+To run a batch file, you must start the command interpreter; set <i>lpApplicationName</i> to cmd.exe and set <i>lpCommandLine</i> to the following arguments: /c plus the name of the batch file. In https://msrc.microsoft.com/blog/2014/04/ms14-019-fixing-a-binary-hijacking-via-cmd-or-bat-file/ the security advises against this.
 
 ### -param lpCommandLine [in, out, optional]
 


### PR DESCRIPTION
It seemed confusing that this state that batch files must be started with cmd.exe, while the security team stated that creates a possible vulnerability (MS14-019). What is actually the correct advice here?