### PR TITLE
HeapSummary: Fix return value description

### DIFF
--- a/sdk-api-src/content/heapapi/nf-heapapi-heapsummary.md
+++ b/sdk-api-src/content/heapapi/nf-heapapi-heapsummary.md
@@ -63,7 +63,7 @@ Receives a pointer to a [Heap_Summary](ns-heapapi-heap_summary.md) structure rep
 
 ## -returns
 
-Returns S_OK on success.
+Returns TRUE on success, FALSE on failure.
 
 ## -remarks
 


### PR DESCRIPTION
It was claimed the function returns `S_OK` on success (which is an HRESULT); however HeapSummary() returns a `BOOL `instead: it returns `TRUE` in case of success and `FALSE` in case of failure.
This has been verified on Windows 10.0.26063.1, as well as in older versions (Windows 7 and 2003)