### PR TITLE
Add info about required attribute in effect registration XML for analysis effects

### DIFF
--- a/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1analysistransform.md
+++ b/sdk-api-src/content/d2d1effectauthor/nn-d2d1effectauthor-id2d1analysistransform.md
@@ -59,4 +59,4 @@ The <b>ID2D1AnalysisTransform</b> interface inherits from the <a href="/windows/
 
 ## -remarks
 
- This interface can be implemented by an <a href="/windows/desktop/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1computetransform">ID2D1ComputeTransform</a>.
+This interface can be implemented by an <a href="/windows/desktop/api/d2d1effectauthor/nn-d2d1effectauthor-id2d1computetransform">ID2D1ComputeTransform</a>. The analysis transform must be the output node of an effect's transform graph, and the effect's registration XML must include the `type="Analysis"` attribute on the root `<Effect>` node.


### PR DESCRIPTION
Analysis transforms are not really documented (like at all 😂😭) and there are no examples from Microsoft on how to implement them. 

However I was able to find some examples in a GitHub repo by @i2ali : https://github.com/i2ali/RAD

I was finally able to get my own analysis transform/effect working when I noticed this key line in the registration XML for an analysis effect in that repo: https://github.com/i2ali/RAD/blob/d0105b96a1e7ea34c1632ebc2b94c2ac3a90b781/RADv3/Effects/DebugImageData.cpp#L320

`<Effect type="Analysis">`

The `type="Analysis"` attribute was the key.

I think this would be very useful to include in the documentation! The documentation for Direct2D's custom effects and their registration XML do not include any information on this, and it was the one thing I couldn't figure out after hours and hours of debugging. I have no idea how @i2ali figured this out, but I'm glad they did.