### PR TITLE
Fix reversed descriptions for Direct2D Morphology effect's Erode/Dilate

### DIFF
--- a/sdk-api-src/content/d2d1effects/ne-d2d1effects-d2d1_morphology_mode.md
+++ b/sdk-api-src/content/d2d1effects/ne-d2d1effects-d2d1_morphology_mode.md
@@ -56,10 +56,10 @@ The mode for the <a href="/windows/desktop/Direct2D/morphology">Morphology effec
 
 ### -field D2D1_MORPHOLOGY_MODE_ERODE:0
 
-The maximum value from each RGB channel in the kernel is used.
+The minimum value from each RGB channel in the kernel is used.
 
 ### -field D2D1_MORPHOLOGY_MODE_DILATE:1
 
-The minimum value from each RGB channel in the kernel is used.
+The maximum value from each RGB channel in the kernel is used.
 
 ### -field D2D1_MORPHOLOGY_MODE_FORCE_DWORD:0xffffffff


### PR DESCRIPTION
(See also the matching PR over in the `win32` repository: https://github.com/MicrosoftDocs/win32/pull/1820)

Erode performs a `min` calculation, while Dilate performs a `max` calculation. These descriptions are currently reversed.

See also: https://en.wikipedia.org/wiki/Erosion_(morphology)

> In other words the erosion of a point is the **minimum** of the points in its neighborhood

And https://en.wikipedia.org/wiki/Dilation_(morphology)

> Thus, dilation is a particular case of order statistics filters, returning the **maximum** value within a moving window