### PR TITLE
Update nf-libloaderapi-getmodulefilenamew.md

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
@@ -87,7 +87,7 @@ The string returned will use the same format that was specified when the module 
 
 ### -param nSize [in]
 
-The size of the <i>lpFilename</i> buffer, in <b>TCHARs</b>.
+The size of the <i>lpFilename</i> buffer, in <b>WCHARs</b>.
 
 ## -returns
 


### PR DESCRIPTION
Changed TCHAR to WCHAR as it precisely reflects the purpose. If someone uses GetModuleFileNameW manually in non-unicode code it may be incorrect.