### PR TITLE
Change required agility sdk version for Enhanced Barriers

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist7-barrier.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist7-barrier.md
@@ -46,7 +46,7 @@ api_name:
 
 Adds a collection of barriers into a graphics command list recording.
 
-Requires the DirectX 12 Agility SDK 1.7 or later.
+Requires the DirectX 12 Agility SDK 1.608 or later.
 
 ## -parameters
 


### PR DESCRIPTION
Enhanced Barriers no longer require the preview version of the Agility SDK which is 1.7.
instead the released non-preview version of 1.608 is the first version that supports them.

According to: https://devblogs.microsoft.com/directx/directx12agility/