### PR TITLE
DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC fix pseudocode ns-directml-dml_fill_value_sequence_operator_desc.md

### DIFF
--- a/sdk-api-src/content/directml/ns-directml-dml_fill_value_sequence_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_fill_value_sequence_operator_desc.md
@@ -46,9 +46,8 @@ api_name:
 Fills a tensor with a sequence. This operator performs the following pseudocode.
 
 ```
-for each coordinate in OutputTensor
-    OutputTensor[coordinate] = Value
-    Value += Delta
+for each elementIndex in OutputTensor
+    OutputTensor[elementIndex] = Value + elementIndex * Delta
 endfor
 ```
 


### PR DESCRIPTION
Fix pseudocode as it does not incrementally add delta to the starting value but rather directly multiplies it.

\*I've made the same change locally in dmldocs.