### PR TITLE
Clarify IContextMenu::QueryContextMenu return value

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
@@ -198,7 +198,7 @@ This value is not available.
 
 Type: <b>HRESULT</b>
 
-If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 20 and you add three items to the menu with command identifiers of 5, 7, and 8, the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
+If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 5 and you add three items to the menu with command identifiers of 4, 7, and 8, the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
 
 ## -remarks
 

--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
@@ -198,7 +198,7 @@ This value is not available.
 
 Type: <b>HRESULT</b>
 
-If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 5 and you add three items to the menu with command identifiers of 5, 7, and 8, the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
+If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 20 and you add three items to the menu with command identifiers of 5, 7, and 8, the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
 
 ## -remarks
 

--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-icontextmenu-querycontextmenu.md
@@ -198,7 +198,7 @@ This value is not available.
 
 Type: <b>HRESULT</b>
 
-If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 5 and you add three items to the menu with command identifiers of 4, 7, and 8, the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
+If successful, returns an <b>HRESULT</b> value that has its severity value set to SEVERITY_SUCCESS and its code value set to the offset of the largest command identifier that was assigned, plus one. For example, if <i>idCmdFirst</i> is set to 5 and you add three items to the menu with command identifiers of 5, 7, and 8 (zero based identifiers + idCmdFirst), the return value should be MAKE_HRESULT(SEVERITY_SUCCESS, 0, 8 - 5 + 1). Otherwise, it returns a COM error value.
 
 ## -remarks
 


### PR DESCRIPTION
It is very unhelpful to use 5 for both idCmdFirst and the menu id in the example!

I don't guarantee that my understanding of this calculation is correct. Please ask Raymond Chen to verify if the -5 in the example is supposed to be idCmdFirst or the lowest menu id.