### PR TITLE
improve CoreInput docs

### DIFF
--- a/sdk-api-src/content/corewindow/nf-corewindow-createcontrolinput.md
+++ b/sdk-api-src/content/corewindow/nf-corewindow-createcontrolinput.md
@@ -50,17 +50,17 @@ api_name:
 
 ## -description
 
-Creates a <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object in the caller’s UI thread.
+Creates a <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object in the caller’s UI thread.
 
 ## -parameters
 
 ### -param riid [in]
 
-Interface ID of the object. Must to be set to the UUID for  <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>, which is 9F488807-4580-4BE8-BE68-92A9311713BB.
+Interface ID of the object. Must to be set to the UUID for <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>, the default interface of <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>, which is `9F488807-4580-4BE8-BE68-92A9311713BB`.
 
 ### -param ppv [out]
 
-Pointer to receive the <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object.
+Pointer to receive the <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object.
 
 ## -returns
 
@@ -68,10 +68,14 @@ If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>H
 
 ## -remarks
 
-This API must be called from the UI thread to create <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object. The object created using this API can be used only in that thread in which it was created. 
+This API must be called from the UI thread to create <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object. The object created using this API can be used only in that thread in which it was created.
 
-If the call is successful, the  caller can call <b>QueryInterface</b> on the returned <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object to obtain the <a href="/windows/desktop/api/corewindow/nn-corewindow-icoreinputinterop">ICoreInputInterop</a> object that created it.
+If the call is successful, the caller can call <b>QueryInterface</b> on the returned <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object to obtain the <a href="/windows/desktop/api/corewindow/nn-corewindow-icoreinputinterop">ICoreInputInterop</a> object that created it.
 
 ## -see-also
 
 <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>
+
+
+
+<a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>

--- a/sdk-api-src/content/corewindow/nf-corewindow-createcontrolinputex.md
+++ b/sdk-api-src/content/corewindow/nf-corewindow-createcontrolinputex.md
@@ -50,21 +50,21 @@ api_name:
 
 ## -description
 
-Creates a <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object in a worker thread or the UI thread.
+Creates a <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object in a worker thread or the UI thread.
 
 ## -parameters
 
 ### -param pCoreWindow [in]
 
-Pointer to the parent <a href="https://msdn.microsoft.com/60b1c8c6-c136-4c4c-8e46-69a792d58ed0">CoreWindow</a> to which the <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object will be attached. This parameter can’t be NULL.
+Pointer to the parent <a href="https://msdn.microsoft.com/60b1c8c6-c136-4c4c-8e46-69a792d58ed0">CoreWindow</a> to which the <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object will be attached. This parameter can’t be NULL.
 
 ### -param riid [in]
 
-Interface ID of the object. Must to be set to the UUID for  <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>, which is 9F488807-4580-4BE8-BE68-92A9311713BB.
+Interface ID of the object. Must to be set to the UUID for <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>, the default interface of <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>, which is `9F488807-4580-4BE8-BE68-92A9311713BB`.
 
 ### -param ppv [out]
 
-Pointer to receive the <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object.
+Pointer to receive the <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a> object.
 
 ## -returns
 
@@ -72,9 +72,9 @@ If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>H
 
 ## -remarks
 
-This API must be called from the UI thread or worker thread to create <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object. The object created using this API can be used only in that thread in which it was created. 
+This API must be called from the UI thread or worker thread to create <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object. The object created using this API can be used only in that thread in which it was created.
 
-If the call is successful, the  caller can call <b>QueryInterface</b> on the returned <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object to obtain the <a href="/windows/desktop/api/corewindow/nn-corewindow-icoreinputinterop">ICoreInputInterop</a> object that created it.
+If the call is successful, the caller can call <b>QueryInterface</b> on the returned <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a> object to obtain the <a href="/windows/desktop/api/corewindow/nn-corewindow-icoreinputinterop">ICoreInputInterop</a> object that created it.
 
 This API will fail if the following scenarios occur:
 
@@ -86,3 +86,7 @@ This API will fail if the following scenarios occur:
 ## -see-also
 
 <a href="/uwp/api/windows.ui.core.icoreinputsourcebase">ICoreInputSourceBase</a>
+
+
+
+<a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>

--- a/sdk-api-src/content/corewindow/nf-corewindow-icoreinputinterop-setinputsource.md
+++ b/sdk-api-src/content/corewindow/nf-corewindow-icoreinputinterop-setinputsource.md
@@ -50,13 +50,15 @@ api_name:
 
 ## -description
 
-Sets the input source for an app's <a href="/dotnet/api/microsoft.toolkit.win32.ui.controls.interop.winrt.coreindependentinputsource?view=win-comm-toolkit-dotnet-stable&preserve-view=true">CoreIndependentInputSource</a> or <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>.
+Sets the input source for an app's <a href="/uwp/api/windows.ui.core.coreindependentinputsource">CoreIndependentInputSource</a> or <a href="/uwp/api/windows.ui.core.corecomponentinputsource">CoreComponentInputSource</a>.
 
 ## -parameters
 
 ### -param value [in]
 
 Pointer to the base COM interface of the input source.
+
+The input source can be either <a href="/windows/desktop/api/dcomp/nn-dcomp-idcompositionvisual2">IDCompositionVisual2</a> or <a href="/uwp/api/windows.ui.composition.visual">Windows.UI.Composition.Visual</a>
 
 ## -returns
 
@@ -68,7 +70,7 @@ If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRE
 
 
 
-<a href="/dotnet/api/microsoft.toolkit.win32.ui.controls.interop.winrt.coreindependentinputsource?view=win-comm-toolkit-dotnet-stable&preserve-view=true">CoreIndependentInputSource</a>
+<a href="/uwp/api/windows.ui.core.coreindependentinputsource">CoreIndependentInputSource</a>
 
 
 


### PR DESCRIPTION
Changes:
- Indicate that `CreateCoreInput`/`CreateCoreInputEx` return a `CoreComponentInputSource` object
- Fix href to `CoreComponentInputSource` docs page
- List allowed input source types for `ICoreInputInterop::SetInputSource`