### PR TITLE
FindWindow does not set the last error

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-findwindowa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-findwindowa.md
@@ -91,7 +91,7 @@ Type: <b>HWND</b>
 
 If the function succeeds, the return value is a handle to the window that has the specified class name and window name.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+This function does not modify the last error value.
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-findwindowa.md
+++ b/sdk-api-src/content/winuser/nf-winuser-findwindowa.md
@@ -91,7 +91,7 @@ Type: <b>HWND</b>
 
 If the function succeeds, the return value is a handle to the window that has the specified class name and window name.
 
-This function does not modify the last error value.
+If the function fails, the return value is <b>NULL</b>. This function does not modify the last error value.
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-findwindoww.md
+++ b/sdk-api-src/content/winuser/nf-winuser-findwindoww.md
@@ -91,7 +91,7 @@ Type: <b>HWND</b>
 
 If the function succeeds, the return value is a handle to the window that has the specified class name and window name.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is <b>NULL</b>. This function does not modify the last error value.
 
 ## -remarks
 


### PR DESCRIPTION
proven by this test

```cpp
    TEST_METHOD(DoesFindWindowSetLastError)
    {
        SetLastError(ERROR_TXF_METADATA_ALREADY_PRESENT);
        auto window = FindWindowW(L"Windows.UI.Core.CoreWindow", L"Start");
        auto err = GetLastError();
        cpp_unit::Assert::IsTrue(window != nullptr);
        cpp_unit::Assert::IsTrue(err == ERROR_TXF_METADATA_ALREADY_PRESENT);

        SetLastError(ERROR_TXF_METADATA_ALREADY_PRESENT);
        window = FindWindowW(L"Non existent", L"window");
        err = GetLastError();
        cpp_unit::Assert::IsTrue(window == nullptr);
        cpp_unit::Assert::IsTrue(err == ERROR_TXF_METADATA_ALREADY_PRESENT);
    }
```