### PR TITLE
Document that `GetUserProfileDirectory` sets the size of the path written on success

### DIFF
--- a/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectorya.md
+++ b/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectorya.md
@@ -78,6 +78,8 @@ Specifies the size of the <i>lpProfileDir</i> buffer, in <b>TCHARs</b>.
 
 If the buffer specified by <i>lpProfileDir</i> is not large enough or <i>lpProfileDir</i> is <b>NULL</b>, the function fails and this parameter receives the necessary buffer size, including the terminating null character.
 
+If the function succeeds then this parameter receives the number of <b>TCHARs</b> written to <i>lpProfileDir</i>, including the terminating null character.
+
 ## -returns
 
 Type: <b>BOOL</b>

--- a/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectorya.md
+++ b/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectorya.md
@@ -84,7 +84,9 @@ If the function succeeds then this parameter receives the number of <b>TCHARs</b
 
 Type: <b>BOOL</b>
 
-<b>TRUE</b> if successful; otherwise, <b>FALSE</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function succeeds, the return value is nonzero.
+
+If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 ## -remarks
 

--- a/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectoryw.md
+++ b/sdk-api-src/content/userenv/nf-userenv-getuserprofiledirectoryw.md
@@ -78,6 +78,8 @@ Specifies the size of the <i>lpProfileDir</i> buffer, in <b>TCHARs</b>.
 
 If the buffer specified by <i>lpProfileDir</i> is not large enough or <i>lpProfileDir</i> is <b>NULL</b>, the function fails and this parameter receives the necessary buffer size, including the terminating null character.
 
+If the function succeeds then this parameter receives the number of <b>TCHARs</b> written to <i>lpProfileDir</i>, including the terminating null character.
+
 ## -returns
 
 Type: <b>BOOL</b>


### PR DESCRIPTION
It was discovered that this undocumented behaviour was being relied on by [a long deprecated Rust stdlib function](https://doc.rust-lang.org/std/env/fn.home_dir.html).

In confirming this behaviour applied to both `GetUserProfileDirectoryW` and `GetUserProfileDirectoryA`, I found that the `A` function, unlike the `W` function, was not returning `TRUE` on success. Instead it also returns the size written to the buffer. I'm not sure if that part should be documented so I just changed the success case to nonzero and failure to zero.