### PR TITLE
Fix HTML entities in code blocks in Direct3D docs

### DIFF
--- a/sdk-api-src/content/d3d10/ns-d3d10-d3d10_rasterizer_desc.md
+++ b/sdk-api-src/content/d3d10/ns-d3d10-d3d10_rasterizer_desc.md
@@ -102,10 +102,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <b
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-cd3d11_rasterizer_desc-cd3d11_rasterizer_desc(d3d11_fill_mode_d3d11_cull_mode_bool_int_float_float_bool_bool_bool_bool).md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-cd3d11_rasterizer_desc-cd3d11_rasterizer_desc(d3d11_fill_mode_d3d11_cull_mode_bool_int_float_float_bool_bool_bool_bool).md
@@ -103,10 +103,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <i
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 

--- a/sdk-api-src/content/d3d11/ns-d3d11-d3d11_rasterizer_desc.md
+++ b/sdk-api-src/content/d3d11/ns-d3d11-d3d11_rasterizer_desc.md
@@ -102,10 +102,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <b
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 

--- a/sdk-api-src/content/d3d11_1/ns-d3d11_1-cd3d11_rasterizer_desc1.md
+++ b/sdk-api-src/content/d3d11_1/ns-d3d11_1-cd3d11_rasterizer_desc1.md
@@ -88,10 +88,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <b
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 

--- a/sdk-api-src/content/d3d11_1/ns-d3d11_1-d3d11_rasterizer_desc1.md
+++ b/sdk-api-src/content/d3d11_1/ns-d3d11_1-d3d11_rasterizer_desc1.md
@@ -102,10 +102,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <b
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 

--- a/sdk-api-src/content/d3d11_3/ns-d3d11_3-cd3d11_rasterizer_desc2.md
+++ b/sdk-api-src/content/d3d11_3/ns-d3d11_3-cd3d11_rasterizer_desc2.md
@@ -105,12 +105,16 @@ Specifies whether to enable clipping based on distance.
 The hardware always performs x and y clipping of rasterized coordinates. When <b>DepthClipEnable</b> is set to the default–<b>TRUE</b>, the hardware also clips the z value (that is, the hardware performs the last step of the following algorithm).
 
 
-<pre class="syntax" xml:space="preserve"><code>
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
-</code></pre>
+
+``` syntax
+
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
+
+```
+
 When you set <b>DepthClipEnable</b> to <b>FALSE</b>, the hardware skips the z clipping (that is, the last step in the preceding algorithm). However, the hardware still performs the "0 &lt; w" clipping. When z clipping is disabled, improper depth ordering at the pixel level might result. However, when z clipping is disabled, stencil shadow implementations are simplified. In other words, you can avoid complex special-case handling for geometry that goes beyond the back clipping plane.
 
 

--- a/sdk-api-src/content/d3d11_3/ns-d3d11_3-d3d11_rasterizer_desc2.md
+++ b/sdk-api-src/content/d3d11_3/ns-d3d11_3-d3d11_rasterizer_desc2.md
@@ -84,10 +84,10 @@ The hardware always performs x and y clipping of rasterized coordinates. When <b
 
 ``` syntax
 
-0 &lt; w
--w &lt;= x &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
--w &lt;= y &lt;= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
-0 &lt;= z &lt;= w
+0 < w
+-w <= x <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+-w <= y <= w (or arbitrarily wider range if implementation uses a guard band to reduce clipping burden)
+0 <= z <= w
 
 ```
 


### PR DESCRIPTION
![image](https://github.com/MicrosoftDocs/sdk-api/assets/3995549/11965d3a-c8c6-4f87-abcf-fdac8f3dcf52)

- https://learn.microsoft.com/en-us/windows/win32/api/d3d10/ns-d3d10-d3d10_rasterizer_desc
- https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-cd3d11_rasterizer_desc-cd3d11_rasterizer_desc(d3d11_fill_mode_d3d11_cull_mode_bool_int_float_float_bool_bool_bool_bool)
- https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ns-d3d11-d3d11_rasterizer_desc?redirectedfrom=MSDN
- https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/ns-d3d11_1-cd3d11_rasterizer_desc1
- https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/ns-d3d11_1-d3d11_rasterizer_desc1
- https://learn.microsoft.com/en-us/windows/win32/api/d3d11_3/ns-d3d11_3-d3d11_rasterizer_desc2
