### PR TITLE
attempt at adding return type to getitemcount

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-listview_getitemcount.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-listview_getitemcount.md
@@ -59,3 +59,9 @@ Gets the number of items in a list-view control. You can use this macro or send 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HWND</a></b>
 
 A handle to the list-view control.
+
+## -returns
+
+Type: int
+
+Returns the count of items in the listview.


### PR DESCRIPTION
all of the ListView_* macros are missing a return type. I don't know if there is a simple way to automate this based on the header. But this at least does it for one function. 