### PR TITLE
Update StackFrame(_ex) pages

### DIFF
--- a/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe.md
+++ b/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe.md
@@ -62,7 +62,7 @@ Represents a stack frame.
 ### -field AddrPC
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the program counter. 
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a> structure that specifies the program counter. 
 
 
 
@@ -76,12 +76,12 @@ An
 ### -field AddrReturn
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the return address.
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a> structure that specifies the return address.
 
 ### -field AddrFrame
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the frame pointer. 
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a> structure that specifies the frame pointer. 
 
 
 
@@ -95,7 +95,7 @@ An
 ### -field AddrStack
 
 An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the stack pointer. 
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a> structure that specifies the stack pointer. 
 
 
 
@@ -126,17 +126,17 @@ This member is <b>TRUE</b> if this is a virtual frame.
 ### -field Reserved
 
 This member is used internally by the 
-<a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk">StackWalk64</a> function.
+<a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk">StackWalk</a> function.
 
 ### -field KdHelp
 
 A 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP64</a> structure that specifies helper data for walking kernel callback frames.
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP</a> structure that specifies helper data for walking kernel callback frames.
 
 ### -field AddrBStore
 
 <b>Intel Itanium:  </b>An 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the backing store (RsBSP).
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a> structure that specifies the backing store (RsBSP).
 
 ## -remarks
 
@@ -150,24 +150,24 @@ This structure supersedes the <b>STACKFRAME</b> structure. For more information,
 #define LPSTACKFRAME LPSTACKFRAME64
 #else
 typedef struct _tagSTACKFRAME {
-    ADDRESS     AddrPC;
-    ADDRESS     AddrReturn;
-    ADDRESS     AddrFrame;
-    ADDRESS     AddrStack;
-    PVOID       FuncTableEntry;
-    DWORD       Params[4];
-    BOOL        Far;
-    BOOL        Virtual; 
+    ADDRESS     AddrPC;               // program counter
+    ADDRESS     AddrReturn;           // return address
+    ADDRESS     AddrFrame;            // frame pointer
+    ADDRESS     AddrStack;            // stack pointer
+    PVOID       FuncTableEntry;       // pointer to pdata/fpo or NULL
+    DWORD       Params[4];            // possible arguments to the function
+    BOOL        Far;                  // WOW far call
+    BOOL        Virtual;              // is this a virtual frame?
     DWORD       Reserved[3];
     KDHELP      KdHelp;
-    ADDRESS     AddrBStore; 
+    ADDRESS     AddrBStore;           // backing store pointer
 } STACKFRAME, *LPSTACKFRAME;
 #endif
 ```
 
 ## -see-also
 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a>
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS</a>
 
 
 
@@ -179,8 +179,8 @@ typedef struct _tagSTACKFRAME {
 
 
 
-<a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP64</a>
+<a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP</a>
 
 
 
-<a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk">StackWalk64</a>
+<a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk">StackWalk</a>

--- a/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe_ex.md
+++ b/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe_ex.md
@@ -172,26 +172,4 @@ Unknown.
 ## -remarks
 
 This structure supersedes the <b>STACKFRAME64</b> structure. For more information, see 
-<a href="/windows/desktop/Debug/updated-platform-support">Updated Platform Support</a>. <b>STACKFRAME_EX</b> is defined as follows in Dbghelp.h. 
-
-
-```cpp
-typedef struct _tagSTACKFRAME_EX {
-    // First, STACKFRAME64 structure
-    ADDRESS64   AddrPC;            // program counter
-    ADDRESS64   AddrReturn;        // return address
-    ADDRESS64   AddrFrame;         // frame pointer
-    ADDRESS64   AddrStack;         // stack pointer
-    ADDRESS64   AddrBStore;        // backing store pointer
-    PVOID       FuncTableEntry;    // pointer to pdata/fpo or NULL
-    DWORD64     Params[4];         // possible arguments to the function
-    BOOL        Far;               // WOW far call
-    BOOL        Virtual;           // is this a virtual frame?
-    DWORD64     Reserved[3];
-    KDHELP64    KdHelp;
-
-    // Extended STACKFRAME fields
-    DWORD       StackFrameSize;
-    DWORD       InlineFrameContext;
-} STACKFRAME_EX, *LPSTACKFRAME_EX;
-```
+<a href="/windows/desktop/Debug/updated-platform-support">Updated Platform Support</a>.

--- a/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe_ex.md
+++ b/sdk-api-src/content/dbghelp/ns-dbghelp-stackframe_ex.md
@@ -60,7 +60,7 @@ Represents an extended stack frame.
 
 ### -field AddrPC
 
-An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies the program 
+An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies the program 
       counter.
       
 
@@ -72,12 +72,12 @@ An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> struc
 
 ### -field AddrReturn
 
-An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies 
+An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies 
       the return address.
 
 ### -field AddrFrame
 
-An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies 
+An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies 
       the frame pointer.
       
 
@@ -89,7 +89,7 @@ An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> struc
 
 ### -field AddrStack
 
-An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies 
+An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies 
       the stack pointer.
       
 
@@ -101,7 +101,7 @@ An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> struc
 
 ### -field AddrBStore
 
-<b>Intel Itanium:  </b>An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address">ADDRESS64</a> structure that specifies 
+<b>Intel Itanium:  </b>An <a href="/windows/desktop/api/dbghelp/ns-dbghelp-address64">ADDRESS64</a> structure that specifies 
         the backing store (RsBSP).
 
 ### -field FuncTableEntry
@@ -123,12 +123,12 @@ This member is <b>TRUE</b> if this is a virtual frame.
 
 ### -field Reserved
 
-This member is used internally by the <a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalkex">StackWalkEx</a> 
+This member is used internally by the <a href="/windows/desktop/api/dbghelp/nf-dbghelp-stackwalk64">StackWalk64</a> 
       function.
 
 ### -field KdHelp
 
-A <a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp">KDHELP64</a> structure that specifies helper data for 
+A <a href="/windows/desktop/api/dbghelp/ns-dbghelp-kdhelp64">KDHELP64</a> structure that specifies helper data for 
       walking kernel callback frames.
 
 ### -field StackFrameSize
@@ -139,10 +139,59 @@ Set to <code>sizeof(STACKFRAME_EX)</code>.
 
 Specifies the type of the inline frame context.
 
+<table>
+<tr>
+<th>Value</th>
+<th>Meaning</th>
+</tr>
+
+<tr>
+<td width="40%"><a id="inline_frame_context_init"></a><a id="INLINE_FRAME_CONTEXT_INIT"></a><dl>
+<dt><b>INLINE_FRAME_CONTEXT_INIT</b></dt>
+<dt>0</dt>
+</dl>
+</td>
+<td width="60%">
+Unknown.
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="inline_frame_context_ignore"></a><a id="INLINE_FRAME_CONTEXT_IGNORE"></a><dl>
+<dt><b>INLINE_FRAME_CONTEXT_IGNORE</b></dt>
+<dt>0xffffffff</dt>
+</dl>
+</td>
+<td width="60%">
+Unknown.
+</td>
+</tr>
+
+</table>
+
+## -remarks
+
+This structure supersedes the <b>STACKFRAME64</b> structure. For more information, see 
+<a href="/windows/desktop/Debug/updated-platform-support">Updated Platform Support</a>. <b>STACKFRAME_EX</b> is defined as follows in Dbghelp.h. 
 
 
-#### INLINE_FRAME_CONTEXT_INIT (0)
+```cpp
+typedef struct _tagSTACKFRAME_EX {
+    // First, STACKFRAME64 structure
+    ADDRESS64   AddrPC;            // program counter
+    ADDRESS64   AddrReturn;        // return address
+    ADDRESS64   AddrFrame;         // frame pointer
+    ADDRESS64   AddrStack;         // stack pointer
+    ADDRESS64   AddrBStore;        // backing store pointer
+    PVOID       FuncTableEntry;    // pointer to pdata/fpo or NULL
+    DWORD64     Params[4];         // possible arguments to the function
+    BOOL        Far;               // WOW far call
+    BOOL        Virtual;           // is this a virtual frame?
+    DWORD64     Reserved[3];
+    KDHELP64    KdHelp;
 
-
-
-#### INLINE_FRAME_CONTEXT_IGNORE (0xffffffff)
+    // Extended STACKFRAME fields
+    DWORD       StackFrameSize;
+    DWORD       InlineFrameContext;
+} STACKFRAME_EX, *LPSTACKFRAME_EX;
+```


### PR DESCRIPTION
Looks like the 2 pages were copypasted from the 64bit version without adjusting its contents correctly. This PR fixes that.

Affected pages:
* https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-stackframe
* https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-stackframe_ex

The c++ code example was directly coped from the windows header files.