### PR TITLE
Update ns-shellapi-shellexecuteinfoa.md

### DIFF
--- a/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
@@ -134,7 +134,7 @@ For further discussion on when this flag is necessary, see the Remarks section.<
 </tr>
 <tr valign="top">
 <td>SEE_MASK_FLAG_NO_UI (0x00000400)</td>
-<td>Do not display any user interface (UI) including error dialogs, security warnings or other user interface that would normally be presented without this option.</td>
+<td>Do not display user interface (UI) error dialogs that would normally be presented without this option. Security prompts are exempted and will still be shown.</td>
 </tr>
 <tr valign="top">
 <td>SEE_MASK_UNICODE (0x00004000)


### PR DESCRIPTION
The behavior of the SEE_MASK_FLAG_NO_UI option was changed by SmartScreen (my team) in the April 2024 security update.

(Note that the old docs were never correct anyway; the legacy security prompts shown when SmartScreen was off always ignored this flag, and we've now just changed SmartScreen to be consistent).