### PR TITLE
Update ns-shellapi-shellexecuteinfow.md

### DIFF
--- a/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfow.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfow.md
@@ -134,7 +134,7 @@ For further discussion on when this flag is necessary, see the Remarks section.<
 </tr>
 <tr valign="top">
 <td>SEE_MASK_FLAG_NO_UI (0x00000400)</td>
-<td>Do not display any user interface (UI) including error dialogs, security warnings or other user interface that would normally be presented without this option.</td>
+<td>Do not display user interface (UI) error dialogs that would normally be presented without this option. Security prompts are exempted and will still be shown.</td>
 </tr>
 <tr valign="top">
 <td>SEE_MASK_UNICODE (0x00004000)


### PR DESCRIPTION
Correct documentation for NO_UI flag in the "W" version of this article after having fixed the "A" version this morning.

There probably should be a bot that recommends changing the "A" and "W" versions of the docs in the same PR.