### PR TITLE
Update nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuin…

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -50,7 +50,7 @@ api_name:
 Sets all of the elements in an unordered-access view (UAV) to the specified float values.
 
 > [!IMPORTANT]
-> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as Dispatch() calls. To ensure ordering, barrier calls must be issued before and/or after the ClearUnorderedAccessView*() call as needed.  It might appear on some drivers that such barriers aren't necessary but implicit barriers are not a spec guarantee so can't be relied upon.  This is in contrast to ClearDepthStencilView() and ClearRenderTargetView() which like Draw*() commands, respect command list ordering.
+> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as **Dispatch** calls. To ensure ordering, barrier calls must be issued before and/or after the **ClearUnorderedAccessViewXxx** call as needed. It might appear on some drivers that such barriers aren't necessary. But implicit barriers are not a spec guarantee; so they can't be relied upon. This is in contrast to **ClearDepthStencilView** and **ClearRenderTargetView** which (like **DrawXxx** commands), respect command list ordering.
 
 ## -parameters
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewfloat.md
@@ -49,6 +49,9 @@ api_name:
 
 Sets all of the elements in an unordered-access view (UAV) to the specified float values.
 
+> [!IMPORTANT]
+> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as Dispatch() calls. To ensure ordering, barrier calls must be issued before and/or after the ClearUnorderedAccessView*() call as needed.  It might appear on some drivers that such barriers aren't necessary but implicit barriers are not a spec guarantee so can't be relied upon.  This is in contrast to ClearDepthStencilView() and ClearRenderTargetView() which like Draw*() commands, respect command list ordering.
+
 ## -parameters
 
 ### -param ViewGPUHandleInCurrentHeap

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
@@ -50,7 +50,7 @@ api_name:
 Sets all the elements in a unordered-access view (UAV) to the specified integer values.
 
 > [!IMPORTANT]
-> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as Dispatch() calls. To ensure ordering, barrier calls must be issued before and/or after the ClearUnorderedAccessView*() call as needed.  It might appear on some drivers that such barriers aren't necessary but implicit barriers are not a spec guarantee so can't be relied upon.  This is in contrast to ClearDepthStencilView() and ClearRenderTargetView() which like Draw*() commands, respect command list ordering.
+> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as **Dispatch** calls. To ensure ordering, barrier calls must be issued before and/or after the **ClearUnorderedAccessViewXxx** call as needed. It might appear on some drivers that such barriers aren't necessary. But implicit barriers are not a spec guarantee; so they can't be relied upon. This is in contrast to **ClearDepthStencilView** and **ClearRenderTargetView** which (like **DrawXxx** commands), respect command list ordering.
 
 ## -parameters
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
@@ -49,6 +49,9 @@ api_name:
 
 Sets all the elements in a unordered-access view (UAV) to the specified integer values.
 
+> [!IMPORTANT]
+> This behaves like a compute operation in that it isn't ordered with respect to surrounding work such as Dispatch() calls. To ensure ordering, barrier calls must be issued before and/or after the ClearUnorderedAccessView*() call as needed.  It might appear on some drivers that such barriers aren't necessary but implicit barriers are not a spec guarantee so can't be relied upon.  This is in contrast to ClearDepthStencilView() and ClearRenderTargetView() which like Draw*() commands, respect command list ordering.
+
 ## -parameters
 
 ### -param ViewGPUHandleInCurrentHeap
@@ -62,7 +65,7 @@ A [D3D12_GPU_DESCRIPTOR_HANDLE](./ns-d3d12-d3d12_gpu_descriptor_handle.md) that 
 Type: [in] **[D3D12_CPU_DESCRIPTOR_HANDLE](./ns-d3d12-d3d12_cpu_descriptor_handle.md)**
 
 A [D3D12_CPU_DESCRIPTOR_HANDLE](./ns-d3d12-d3d12_cpu_descriptor_handle.md) in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
-          
+
 > [!IMPORTANT]
 > This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers that implement the clear as a fixed-function hardware operation (rather than as a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in **WRITE_BACK** memory (similar to **D3D12_HEAP_TYPE_UPLOAD** heap types), and CPU reads from this type of memory are prohibitively slow.
 


### PR DESCRIPTION
…t.md

Clarify that barriers may be needed around ClearUAV*() calls to enforce ordering.