### PR TITLE
Update nf-projectedfslib-prjstopvirtualizing.md

### DIFF
--- a/sdk-api-src/content/projectedfslib/nf-projectedfslib-prjstopvirtualizing.md
+++ b/sdk-api-src/content/projectedfslib/nf-projectedfslib-prjstopvirtualizing.md
@@ -58,7 +58,3 @@ Stops a running ProjFS virtualization instance, making it unavailable to service
 
 An opaque handle for the virtualization instance.
 
-## -returns
-
-If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
-


### PR DESCRIPTION
The function type is void, which cannot return any other value than void.