### PR TITLE
Document use of `DXGI_OUTDUPL_FLAG` in `IDXGIOutput5::DuplicateOutput1()`

### DIFF
--- a/sdk-api-src/content/dxgi1_5/nf-dxgi1_5-idxgioutput5-duplicateoutput1.md
+++ b/sdk-api-src/content/dxgi1_5/nf-dxgi1_5-idxgioutput5-duplicateoutput1.md
@@ -62,9 +62,9 @@ A pointer to the Direct3D device interface that you can use to process the deskt
 
 ### -param Flags
 
-Type: <b>UINT</b>
+Type: <b>DXGI_OUTDUPL_FLAG</b>
 
-Reserved for future use; must be zero.
+A bitfield of <b>DXGI_OUTDUPL_FLAG</b> enumeration values describing the kind of capture surface to create.
 
 ### -param SupportedFormatsCount [in]
 

--- a/sdk-api-src/content/dxgi1_5/nf-dxgi1_5-idxgioutput5-duplicateoutput1.md
+++ b/sdk-api-src/content/dxgi1_5/nf-dxgi1_5-idxgioutput5-duplicateoutput1.md
@@ -62,7 +62,7 @@ A pointer to the Direct3D device interface that you can use to process the deskt
 
 ### -param Flags
 
-Type: <b>DXGI_OUTDUPL_FLAG</b>
+Type: <b>UINT</b>
 
 A bitfield of <b>DXGI_OUTDUPL_FLAG</b> enumeration values describing the kind of capture surface to create.
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/DirectX-Headers/issues/128, cc @jenatali

This function is known to take values from the `DXGI_OUTDUPL_FLAG` enumeration.

Note that the type is still `UINT` (can we please change that without ABI repercussions), and there's no documentation page for `DXGI_OUTDUPL_FLAG` yet.