### PR TITLE
ne-objbase-coinit.md: fix COINIT_MULTITHREADED

### DIFF
--- a/sdk-api-src/content/objbase/ne-objbase-coinit.md
+++ b/sdk-api-src/content/objbase/ne-objbase-coinit.md
@@ -56,13 +56,13 @@ Determines the concurrency model used for incoming calls to objects created by t
 
 ## -enum-fields
 
-### -field COINIT_MULTITHREADED:0x0
-
-Initializes the thread for multithreaded object concurrency (see Remarks).
-
 ### -field COINIT_APARTMENTTHREADED:0x2
 
 Initializes the thread for apartment-threaded object concurrency (see Remarks).
+
+### -field COINIT_MULTITHREADED:0x0
+
+Initializes the thread for multithreaded object concurrency (see Remarks).
 
 ### -field COINIT_DISABLE_OLE1DDE:0x4
 

--- a/sdk-api-src/content/objbase/ne-objbase-coinit.md
+++ b/sdk-api-src/content/objbase/ne-objbase-coinit.md
@@ -56,13 +56,13 @@ Determines the concurrency model used for incoming calls to objects created by t
 
 ## -enum-fields
 
+### -field COINIT_MULTITHREADED:0x0
+
+Initializes the thread for multithreaded object concurrency (see Remarks).
+
 ### -field COINIT_APARTMENTTHREADED:0x2
 
 Initializes the thread for apartment-threaded object concurrency (see Remarks).
-
-### -field COINIT_MULTITHREADED
-
-Initializes the thread for multithreaded object concurrency (see Remarks).
 
 ### -field COINIT_DISABLE_OLE1DDE:0x4
 


### PR DESCRIPTION
COINIT_MULTITHREADED was listed after COINIT_APARTMENTTHREADED without an initializer which according to the C language would make it have a value of 0x3 which is incorrect. The actually value is 0x0 (via the COINITBASE_MULTITHREADED enum value)