### PR TITLE
Fix for a typo in ne-dxcore_interface-dxcoresegmentgroup.md

### DIFF
--- a/sdk-api-src/content/dxcore_interface/ne-dxcore_interface-dxcoresegmentgroup.md
+++ b/sdk-api-src/content/dxcore_interface/ne-dxcore_interface-dxcoresegmentgroup.md
@@ -45,7 +45,7 @@ Defines constants that specify an adapter's memory segment grouping.
 
 ## -enum-fields
 
-### -field Local:1
+### -field Local:0
 
 Specifies a grouping of segments that is considered local to the adapter, and represents the fastest memory available to the GPU. Your application should target the local segment group as the target size for its working set.
 


### PR DESCRIPTION
Fix for a typo in ne-dxcore_interface-dxcoresegmentgroup.md

Local and NonLocal used to have the same value.