### PR TITLE
Update nf-d3d11-id3d11videocontext-decoderbeginframe.md

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11videocontext-decoderbeginframe.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11videocontext-decoderbeginframe.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:d3d11.ID3D11VideoContext.DecoderBeginFrame
 title: ID3D11VideoContext::DecoderBeginFrame (d3d11.h)
-description: Starts a decoding operation to decode a video frame. (ID3D11VideoContext.DecoderBeginFrame)
+description: Starts a decoding operation to decode a video frame.
 helpviewer_keywords: ["DecoderBeginFrame","DecoderBeginFrame method [Media Foundation]","DecoderBeginFrame method [Media Foundation]","ID3D11VideoContext interface","ID3D11VideoContext interface [Media Foundation]","DecoderBeginFrame method","ID3D11VideoContext.DecoderBeginFrame","ID3D11VideoContext::DecoderBeginFrame","d3d11/ID3D11VideoContext::DecoderBeginFrame","mf.id3d11videocontext_decoderbeginframe"]
 old-location: mf\id3d11videocontext_decoderbeginframe.htm
 tech.root: mf


### PR DESCRIPTION
Remove the redundant function name to avoid confusion.