### PR TITLE
Clarify ExpandEnvironmentStrings size limitation

### DIFF
--- a/sdk-api-src/content/processenv/nf-processenv-expandenvironmentstringsa.md
+++ b/sdk-api-src/content/processenv/nf-processenv-expandenvironmentstringsa.md
@@ -91,7 +91,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-The size of the <i>lpSrc</i> and <i>lpDst</i> buffers is limited to 32K.
+**Windows Server 2003 and Windows XP:** The size of the <i>lpSrc</i> and <i>lpDst</i> buffers is limited to 32K.
 
 To replace folder names in a fully qualified path with their associated environment-variable strings, use the <a href="/windows/desktop/api/shlwapi/nf-shlwapi-pathunexpandenvstringsa">PathUnExpandEnvStrings</a> function.
 

--- a/sdk-api-src/content/processenv/nf-processenv-expandenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-expandenvironmentstringsw.md
@@ -91,7 +91,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-The size of the <i>lpSrc</i> and <i>lpDst</i> buffers is limited to 32K.
+**Windows Server 2003 and Windows XP:** The size of the <i>lpSrc</i> and <i>lpDst</i> buffers is limited to 32K.
 
 To replace folder names in a fully qualified path with their associated environment-variable strings, use the <a href="/windows/desktop/api/shlwapi/nf-shlwapi-pathunexpandenvstringsa">PathUnExpandEnvStrings</a> function.
 


### PR DESCRIPTION
The clarification is based on the following:

* The documentation of `SetEnvironmentVariableW `:
https://github.com/MicrosoftDocs/sdk-api/blob/c64608f244137cb2f5ab9fa89411736a224c5d89/sdk-api-src/content/processenv/nf-processenv-setenvironmentvariablew.md?plain=1#L74
* A test that demonstrates `ExpandEnvironmentStrings` working with buffers with size >80K:
https://godbolt.org/z/x49dWbfzY
* The Wine implementation [shows that](https://github.com/wine-mirror/wine/blob/6a512200f4719ea6b0be6de83cac632112a38b36/dlls/kernelbase/process.c#L1490) `ExpandEnvironmentStringsW` calls `RtlExpandEnvironmentStrings_U`, but in modern Windows versions, `ExpandEnvironmentStringsW` calls `RtlExpandEnvironmentStrings` which doesn't use the `UNICODE_STRING` struct and has no string size limitation.