### PR TITLE
Clarify behavior of relative due time in waitable timers

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["SetWaitableTimer","SetWaitableTimer function","_win32_set
 old-location: base\setwaitabletimer.htm
 tech.root: base
 ms.assetid: 237e22dc-696d-473f-8bb5-c28f7c7c75b2
-ms.date: 12/05/2018
+ms.date: 08/20/2024
 ms.keywords: SetWaitableTimer, SetWaitableTimer function, _win32_setwaitabletimer, base.setwaitabletimer, synchapi/SetWaitableTimer, winbase/SetWaitableTimer
 req.header: synchapi.h
 req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2

--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
@@ -78,9 +78,9 @@ The time after which the state of the timer is to be set to signaled, in 100 nan
 <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure. Positive values indicate absolute time. Be sure to use a UTC-based absolute time, as the system uses UTC-based time internally. Negative values indicate relative time. The actual timer accuracy depends on the capability of your hardware. For more information about UTC-based time, see 
 <a href="/windows/desktop/SysInfo/system-time">System Time</a>.
 
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
+**Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:** If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
 
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
+**Windows 8 and newer, Windows Server 2012 and newer:** If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
 
 ### -param lPeriod [in]
 

--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimer.md
@@ -78,6 +78,10 @@ The time after which the state of the timer is to be set to signaled, in 100 nan
 <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure. Positive values indicate absolute time. Be sure to use a UTC-based absolute time, as the system uses UTC-based time internally. Negative values indicate relative time. The actual timer accuracy depends on the capability of your hardware. For more information about UTC-based time, see 
 <a href="/windows/desktop/SysInfo/system-time">System Time</a>.
 
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
+
 ### -param lPeriod [in]
 
 The period of the timer, in milliseconds. If <i>lPeriod</i> is zero, the timer is signaled once. If <i>lPeriod</i> is greater than zero, the timer is periodic. A periodic timer automatically reactivates each time the period elapses, until the timer is canceled using the 

--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimerex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimerex.md
@@ -73,6 +73,10 @@ The time after which the state of the timer is to be set to signaled, in 100 nan
 <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure. Positive values indicate absolute time. Be sure to use a UTC-based absolute time, as the system uses UTC-based time internally. Negative values indicate relative time. The actual timer accuracy depends on the capability of your hardware. For more information about UTC-based time, see 
 <a href="/windows/desktop/SysInfo/system-time">System Time</a>.
 
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
+
 ### -param lPeriod [in]
 
 The period of the timer, in milliseconds. If <i>lPeriod</i> is zero, the timer is signaled once. If <i>lPeriod</i> is greater than zero, the timer is periodic. A periodic timer automatically reactivates each time the period elapses, until the timer is canceled using the 

--- a/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimerex.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-setwaitabletimerex.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["SetWaitableTimerEx","SetWaitableTimerEx function","base.s
 old-location: base\setwaitabletimerex.htm
 tech.root: base
 ms.assetid: 2facde72-6e04-4a2f-9ee6-059f36932539
-ms.date: 12/05/2018
+ms.date: 08/20/2024
 ms.keywords: SetWaitableTimerEx, SetWaitableTimerEx function, base.setwaitabletimerex, synchapi/SetWaitableTimerEx, winbase/SetWaitableTimerEx
 req.header: synchapi.h
 req.include-header: Windows.h
@@ -73,9 +73,9 @@ The time after which the state of the timer is to be set to signaled, in 100 nan
 <a href="/windows/desktop/api/minwinbase/ns-minwinbase-filetime">FILETIME</a> structure. Positive values indicate absolute time. Be sure to use a UTC-based absolute time, as the system uses UTC-based time internally. Negative values indicate relative time. The actual timer accuracy depends on the capability of your hardware. For more information about UTC-based time, see 
 <a href="/windows/desktop/SysInfo/system-time">System Time</a>.
 
-<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
+**Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:** If relative time is specified, the timer includes time spent in low-power states. For example, the timer continues counting down while the computer is asleep.
 
-<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
+**Windows 8 and newer, Windows Server 2012 and newer:** If relative time is specified, the timer does not include time spent in low-power states. For example, the timer does not continue counting down while the computer is asleep.
 
 ### -param lPeriod [in]
 


### PR DESCRIPTION
The relative due time skips the time spent in low-power states, at least on Windows 10 22H2 and on Windows 11. This was somewhat surprising to me and my colleagues, hence the suggestion to document it explicitly.

I can't confirm if it's really the case that the behavior of relative timers changed between Windows 7 and Windows 8. However, a significant number of Win32 APIs with relative timeouts similarly changed behavior since Windows 8 and are documented as such. Examples include WaitForSingleObject or GetQueuedCompletionStatus. I assume that waitable timers were affected by the same change in Windows 8 and only the docs update was missed. I mostly copied the existing wording from the APIs that already document this behavior.