### PR TITLE
Fix incorrect definition of nf-winerror-hresult_code.md

### DIFF
--- a/sdk-api-src/content/winerror/nf-winerror-hresult_code.md
+++ b/sdk-api-src/content/winerror/nf-winerror-hresult_code.md
@@ -64,7 +64,7 @@ This macro is defined as follows:
 
 
 ``` syntax
-#define HRESULT_CODE(hr)    ((hr) &amp; 0xFFFF)
+#define HRESULT_CODE(hr)    ((hr) & 0xFFFF)
 ```
 
 


### PR DESCRIPTION
There is no need to use HTML escaping here.