### PR TITLE
Update nf-winbase-writeprivateprofilestringw.md

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-writeprivateprofilestringw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-writeprivateprofilestringw.md
@@ -77,7 +77,7 @@ A <b>null</b>-terminated string to be written to the file. If this parameter is 
 
 The name of the initialization file.
 
-If the file was created using Unicode characters, the function writes Unicode characters to the file. Otherwise, the function writes ANSI characters.
+If the file already exists and consists of Unicode characters, the function writes Unicode characters to the file. Otherwise, the function writes ANSI characters.
 
 ## -returns
 


### PR DESCRIPTION
Fix wording according to the @oldnewthing blog post [Can INI files be Unicode? Yes, they can, but it has to be your idea](https://devblogs.microsoft.com/oldnewthing/20240606-00/?p=109861)