### PR TITLE
Update nf-threadpoolapiset-setthreadpoolwait.md

### DIFF
--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
@@ -69,7 +69,9 @@ A handle.
 
 If this parameter is NULL, the wait object will cease to queue new callbacks (but callbacks already queued will still occur).
 
-If this parameter is not NULL, it must refer to a valid waitable object.
+If this parameter is not NULL, it must refer to a valid waitable object. 
+
+Mutext is not supported. If handle to a mutex is passed in then thread pool will raise STATUS_THREADPOOL_HANDLE_EXCEPTION exception and ExceptionRecord.ExceptionInformation[0] will be equal to STATUS_INVALID_PARAMETER_3.
 
 If this handle is closed while the wait is still pending, the function's behavior is undefined. If the wait is still pending and the handle must be closed, use <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait">CloseThreadpoolWait</a> to cancel the wait and then close the handle.
 

--- a/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
+++ b/sdk-api-src/content/threadpoolapiset/nf-threadpoolapiset-setthreadpoolwait.md
@@ -71,7 +71,7 @@ If this parameter is NULL, the wait object will cease to queue new callbacks (bu
 
 If this parameter is not NULL, it must refer to a valid waitable object. 
 
-Mutext is not supported. If handle to a mutex is passed in then thread pool will raise STATUS_THREADPOOL_HANDLE_EXCEPTION exception and ExceptionRecord.ExceptionInformation[0] will be equal to STATUS_INVALID_PARAMETER_3.
+Mutex is not supported. If a handle to a mutex is passed in, the thread pool raises a STATUS_THREADPOOL_HANDLE_EXCEPTION exception and ExceptionRecord.ExceptionInformation[0] will be equal to STATUS_INVALID_PARAMETER_3.
 
 If this handle is closed while the wait is still pending, the function's behavior is undefined. If the wait is still pending and the handle must be closed, use <a href="/windows/desktop/api/threadpoolapiset/nf-threadpoolapiset-closethreadpoolwait">CloseThreadpoolWait</a> to cancel the wait and then close the handle.
 


### PR DESCRIPTION
An obscure error conditions that took a bit of time to understand with access to Windows sources. Folks that do not have access to sources will be confused why passing a valid handle is raising an exception.  Constraint is hardcoded in NtAssociateWaitCompletionPacket %SDXROOT%\xbox\lnm\ntos\io\iomgr\complete.c

    DispatcherObject = ObGetAssociatedWaitObject(TargetObject);
    if ((DispatcherObject == NULL) ||
        (KOBJECT_TYPE((PKEVENT)DispatcherObject) == MutantObject)) {

        Status = STATUS_INVALID_PARAMETER_3;
        goto Exit;
    }