### PR TITLE
add "openas" into lpVerb verbs list

### DIFF
--- a/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfoa.md
@@ -205,6 +205,7 @@ The following verbs are commonly used:
 - **print**: Prints the document file specified by <b>lpFile</b>. If <b>lpFile</b> is not a document file, the function will fail.
 - **properties**: Displays the file or folder's properties.
 - **runas**: Launches an application as Administrator. User Account Control (UAC) will prompt the user for consent to run the application elevated or enter the credentials of an administrator account used to run the application.
+- **openas**: Displays the "Open With" dialog, allowing the user to select an application to open the specified file.
 
 ### -field lpFile
 


### PR DESCRIPTION
I am writing to request an update to the technical documentation concerning the `lpVerb` parameter. Specifically, I would like to suggest the inclusion of the `openas` verb in the list of commonly used options.

In my recent project development, I utilized the `openas` verb for the "Open With" operation, which allows users to choose an application to open a file. This functionality is essential for our application's flexibility and user experience. As per our development specifications, it is required that all APIs and parameters employed must be supported and documented officially.

The existing documentation already provides comprehensive details on commonly used verbs such as `edit`, `open`, `explore`, and others. Adding `openas` to this list would not only align with the documentation's completeness but also support developers who rely on these resources for accurate and authoritative information.