### PR TITLE
MapViewOfFile - Clearer doc on matching VirtualAlloc allocation granularity

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-mapviewoffile.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-mapviewoffile.md
@@ -211,9 +211,9 @@ A high-order <b>DWORD</b> of the file offset where the view begins.
 ### -param dwFileOffsetLow [in]
 
 A low-order <b>DWORD</b> of the file offset where the view is to begin. The combination 
-       of the high and low offsets must specify an offset within the file mapping. They must also match the  memory 
-       allocation granularity of the system. That is, the offset must be a multiple of the allocation granularity. To 
-       obtain the memory allocation granularity of the system, use the 
+       of the high and low offsets must specify an offset within the file mapping. They must also match the virtual memory 
+       allocation granularity of the system. That is, the offset must be a multiple of the VirtualAlloc allocation granularity. To 
+       obtain the VirtualAlloc memory allocation granularity of the system, use the 
        <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a> function, which fills in the members of 
        a <a href="/windows/desktop/api/sysinfoapi/ns-sysinfoapi-system_info">SYSTEM_INFO</a> structure.
 


### PR DESCRIPTION
The previous doc was too vague. In Windows you can allocate memory in smaller chunks than VirtualAlloc granularity (in general). However, to use this MapViewOfFile API it specifically needs to be a multiple of VirtualAlloc granularity. The same info can be found by following the links, but this makes it clearer