### PR TITLE
Document TlsGetValue2

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
@@ -75,6 +75,8 @@ The data stored in a TLS slot can have a value of 0 because it still has its ini
 
 Functions that return indications of failure call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError</a> when they fail. They generally do not call <b>SetLastError</b> when they succeed. The <b>TlsGetValue</b> function is an exception to this general rule. The <b>TlsGetValue</b> function calls <b>SetLastError</b> to clear a thread's last error when it succeeds. That allows checking for the error-free retrieval of zero values.
 
+Since <b>TlsGetValue</b> always sets a thread's last error, some application (e.g., custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error and <b>SetLastError</b> afterwards to restore the saved last error. This may incur non-trivial performance cost on certain CPUs. To mitigate this issue, applications may call <b>TlsGetValue2</b> available on Windows 11 24H2 or later. <b>TlsGetValue2</b> is identical to <b>TlsGetValue</b> except that it doesn't touch a thread's last error.
+
 ## -remarks
 
 <b>Windows Phone 8.1:</b> This function is supported for Windows Phone Store apps on Windows Phone 8.1 and later. When a Windows Phone Store app calls this function, it is replaced with an inline call to <b>FlsGetValue</b>. Refer to <a href="/windows/desktop/api/fibersapi/nf-fibersapi-flsgetvalue">FlsGetValue</a> for function documentation.

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
@@ -75,8 +75,6 @@ The data stored in a TLS slot can have a value of 0 because it still has its ini
 
 Functions that return indications of failure call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError</a> when they fail. They generally do not call <b>SetLastError</b> when they succeed. The <b>TlsGetValue</b> function is an exception to this general rule. The <b>TlsGetValue</b> function calls <b>SetLastError</b> to clear a thread's last error when it succeeds. That allows checking for the error-free retrieval of zero values.
 
-Since <b>TlsGetValue</b> always sets a thread's last error, some application (e.g., custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error and <b>SetLastError</b> afterwards to restore the saved last error. This may incur non-trivial performance cost on certain CPUs. To mitigate this issue, applications may call <b>TlsGetValue2</b> available on Windows 11 24H2 or later. <b>TlsGetValue2</b> is identical to <b>TlsGetValue</b> except that it doesn't touch a thread's last error.
-
 ## -remarks
 
 <b>Windows Phone 8.1:</b> This function is supported for Windows Phone Store apps on Windows Phone 8.1 and later. When a Windows Phone Store app calls this function, it is replaced with an inline call to <b>FlsGetValue</b>. Refer to <a href="/windows/desktop/api/fibersapi/nf-fibersapi-flsgetvalue">FlsGetValue</a> for function documentation.
@@ -88,6 +86,8 @@ Since <b>TlsGetValue</b> always sets a thread's last error, some application (e.
 TLS indexes are typically allocated by the [TlsAlloc](nf-processthreadsapi-tlsalloc.md) function during process or DLL initialization. After a TLS index is allocated, each thread of the process can use it to access its own TLS slot for that index. A thread specifies a TLS index in a call to [TlsSetValue](nf-processthreadsapi-tlssetvalue.md) to store a value in its slot. The thread specifies the same index in a subsequent call to <b>TlsGetValue</b> to retrieve the stored value.
 
 <b>TlsGetValue</b> was implemented with speed as the primary goal. The function performs minimal parameter validation and error checking. In particular, it succeeds if <i>dwTlsIndex</i> is in the range 0 through (<b>TLS_MINIMUM_AVAILABLE</b>– 1). It is up to the programmer to ensure that the index is valid and that the thread calls [TlsSetValue](nf-processthreadsapi-tlssetvalue.md) before calling <b>TlsGetValue</b>.
+
+Since <b>TlsGetValue</b> always sets a thread's last error, some application (e.g., custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error and <b>SetLastError</b> afterwards to restore the saved last error. This may incur non-trivial performance cost on certain CPUs. To mitigate this issue, applications may call <b>TlsGetValue2</b> available on Windows 11 24H2 or later. <b>TlsGetValue2</b> is identical to <b>TlsGetValue</b> except that it never sets a thread's last error. Applications calling <b>TlsGetValue2</b> should avoid using 0 as a valid value, because <b>GetLastError</b> cannot be called to tell if <b>TlsGetValue2</b> fails.
 
 #### Examples
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
@@ -87,7 +87,9 @@ TLS indexes are typically allocated by the [TlsAlloc](nf-processthreadsapi-tlsal
 
 <b>TlsGetValue</b> was implemented with speed as the primary goal. The function performs minimal parameter validation and error checking. In particular, it succeeds if <i>dwTlsIndex</i> is in the range 0 through (<b>TLS_MINIMUM_AVAILABLE</b>– 1). It is up to the programmer to ensure that the index is valid and that the thread calls [TlsSetValue](nf-processthreadsapi-tlssetvalue.md) before calling <b>TlsGetValue</b>.
 
-Since <b>TlsGetValue</b> always sets a thread's last error, some application (e.g., custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error and <b>SetLastError</b> afterwards to restore the saved last error. This may incur non-trivial performance cost on certain CPUs. To mitigate this issue, applications may call <b>TlsGetValue2</b> available on Windows 11 24H2 or later. <b>TlsGetValue2</b> is identical to <b>TlsGetValue</b> except that it never sets a thread's last error. Applications calling <b>TlsGetValue2</b> should avoid using 0 as a valid value, because <b>GetLastError</b> cannot be called to tell if <b>TlsGetValue2</b> fails.
+<b>TlsGetValue</b> always sets a thread's last error. In some cases, an application (such as those with custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error (followed by <b>SetLastError</b> to restore the saved error). Unfortunately, this can incur a non-trivial performance cost on certain CPUs. 
+
+**Windows 11 24H2 and later:** The <b>TlsGetValue2</b> function was introduced, which is identical to <b>TlsGetValue</b> except that it doesn't set the thread's last error. Applications calling <b>TlsGetValue2</b> should avoid using 0 as a valid value, because <b>GetLastError</b> cannot be called to check if <b>TlsGetValue2</b> failed.
 
 #### Examples
 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-tlsgetvalue.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["TlsGetValue","TlsGetValue function","_win32_tlsgetvalue",
 old-location: base\tlsgetvalue.htm
 tech.root: processthreadsapi
 ms.assetid: 82bd5ff6-ff0b-42b7-9ece-e9e8531eb5fb
-ms.date: 02/02/2024
+ms.date: 08/07/2024
 ms.keywords: TlsGetValue, TlsGetValue function, _win32_tlsgetvalue, base.tlsgetvalue, processthreadsapi/TlsGetValue, winbase/TlsGetValue
 req.header: processthreadsapi.h
 req.include-header: Windows.h on Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
@@ -77,8 +77,6 @@ Functions that return indications of failure call <a href="/windows/desktop/api/
 
 ## -remarks
 
-<b>Windows Phone 8.1:</b> This function is supported for Windows Phone Store apps on Windows Phone 8.1 and later. When a Windows Phone Store app calls this function, it is replaced with an inline call to <b>FlsGetValue</b>. Refer to <a href="/windows/desktop/api/fibersapi/nf-fibersapi-flsgetvalue">FlsGetValue</a> for function documentation.
-
 <b>Windows 8.1</b>, <b>Windows Server 2012 R2</b>, and <b>Windows 10, version 1507</b>: This function is supported for Windows Store apps on Windows 8.1, Windows Server 2012 R2, and Windows 10, version 1507. When a Windows Store app calls this function, it is replaced with an inline call to <b>FlsGetValue</b>. Refer to <a href="/windows/desktop/api/fibersapi/nf-fibersapi-flsgetvalue">FlsGetValue</a> for function documentation.
 
 <b>Windows 10, version 1511</b> and <b>Windows 10, version 1607</b>: This function is fully supported for Universal Windows Platform (UWP) apps, and is no longer replaced with an inline call to <b>FlsGetValue</b>.
@@ -89,13 +87,15 @@ TLS indexes are typically allocated by the [TlsAlloc](nf-processthreadsapi-tlsal
 
 <b>TlsGetValue</b> always sets a thread's last error. In some cases, an application (such as those with custom heaps that support malloc) may need to call <b>GetLastError</b> before calling <b>TlsGetValue</b> to save the thread's last error (followed by <b>SetLastError</b> to restore the saved error). Unfortunately, this can incur a non-trivial performance cost on certain CPUs. 
 
-**Windows 11 24H2 and later:** The <b>TlsGetValue2</b> function was introduced, which is identical to <b>TlsGetValue</b> except that it doesn't set the thread's last error. Applications calling <b>TlsGetValue2</b> should avoid using 0 as a valid value, because <b>GetLastError</b> cannot be called to check if <b>TlsGetValue2</b> failed.
+**Windows 11 24H2 and later:** Use the [**TlsGetValue2**](/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsgetvalue2) function, which is identical to <b>TlsGetValue</b> except that it doesn't set the thread's last error. Applications calling <b>TlsGetValue2</b> should avoid using 0 as a valid value because <b>GetLastError</b> cannot be called to check if <b>TlsGetValue2</b> failed.
 
 #### Examples
 
 For an example, see <a href="/windows/desktop/ProcThread/using-thread-local-storage">Using Thread Local Storage</a> or <a href="/windows/desktop/Dlls/using-thread-local-storage-in-a-dynamic-link-library">Using Thread Local Storage in a Dynamic-Link Library</a>.
 
 ## -see-also
+
+[**TlsGetValue2**](/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsgetvalue2)
 
 [Process and Thread Functions](/windows/win32/ProcThread/process-and-thread-functions)
 


### PR DESCRIPTION
Windows 11 24H2 starts supporting TlsGetValue2, which is identical to TlsGetValue except that it never touches a thread's last error.