### PR TITLE
Document RmGetList returning ERROR_ACCESS_DENIED

### DIFF
--- a/sdk-api-src/content/restartmanager/nf-restartmanager-rmgetlist.md
+++ b/sdk-api-src/content/restartmanager/nf-restartmanager-rmgetlist.md
@@ -151,7 +151,7 @@ One or more arguments are not correct. This error value is returned by the Resta
 </dl>
 </td>
 <td width="60%">
-An operation was unable  to read or write to the registry.
+An operation was unable to read or write to the registry.
 
 </td>
 </tr>
@@ -176,6 +176,18 @@ A Restart Manager operation could not complete because not enough memory was ava
 </td>
 <td width="60%">
 No Restart Manager session exists for the handle supplied.
+
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>ERROR_ACCESS_DENIED</b></dt>
+<dt>5</dt>
+</dl>
+</td>
+<td width="60%">
+A path registered to the Restart Manager session is a directory.
 
 </td>
 </tr>


### PR DESCRIPTION
If one calls `RmRegisterResources` with a directory path, `RmGetList` will fail subsequently with `ERROR_ACCESS_DENIED`.

I first found this 8 years ago and based on some use of RM I had this week, it seems that Windows has not changed.

https://blog.yaakov.online/failed-experiment-what-processes-have-a-lock-on-this-folder/