### PR TITLE
Fix FLOWSPEC vs QOS confusion.

### DIFF
--- a/sdk-api-src/content/winsock2/nf-winsock2-wsaconnect.md
+++ b/sdk-api-src/content/winsock2/nf-winsock2-wsaconnect.md
@@ -78,12 +78,12 @@ A pointer to the user data that is to be transferred back from the other socket 
 
 ### -param lpSQOS [in]
 
-A pointer to the <a href="/windows/desktop/api/qos/ns-qos-flowspec">FLOWSPEC</a> structures for socket <i>s</i>, one for each direction.
+A pointer to the <a href="/windows/desktop/api/winsock2/ns-winsock2-qos">QOS</a> structure for socket <i>s</i>.
 
 ### -param lpGQOS [in]
 
 Reserved for future use with socket groups. A pointer to the 
-<a href="/windows/desktop/api/qos/ns-qos-flowspec">FLOWSPEC</a> structures for the socket group (if applicable). This parameter should be <b>NULL</b>.
+<a href="/windows/desktop/api/winsock2/ns-winsock2-qos">QOS</a> structure for the socket group (if applicable). This parameter should be <b>NULL</b>.
 
 ## -returns
 


### PR DESCRIPTION
The current documentation is talking about the `QOS` parameter in introduction summary, but about the `FLOWSPEC` parameter later on in place where the parameter is described, this is confusing. But the header files are talking about the `QOS` parameter. Upon further inspection the documentation is talking about the pointer pointing to two consecutive `FLOWSPEC` parameters followed by single user data parameter. Guess what, the `QOS` structure is exactly that. Thus, by accepting the change proposed in this PR, the documentation will be in sync with the header files. And the documentation will be more correct, more consistent, more useful and less confusing for the end user.