### PR TITLE
[DWrite] Set the right min supported client/server

### DIFF
--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_automatic_font_axes.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_automatic_font_axes.md
@@ -10,8 +10,8 @@ req.construct-type: enumeration
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_axis_attributes.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_axis_attributes.md
@@ -10,8 +10,8 @@ req.construct-type: enumeration
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_axis_tag.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_axis_tag.md
@@ -10,8 +10,8 @@ req.construct-type: enumeration
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_family_model.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_family_model.md
@@ -10,8 +10,8 @@ req.construct-type: enumeration
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_line_gap_usage.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_line_gap_usage.md
@@ -11,8 +11,8 @@ ms.keywords: DWRITE_FONT_LINE_GAP_USAGE, DWRITE_FONT_LINE_GAP_USAGE enumeration 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_property_id.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_property_id.md
@@ -11,8 +11,8 @@ ms.keywords: DWRITE_FONT_PROPERTY_ID, DWRITE_FONT_PROPERTY_ID enumeration [Direc
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_source_type.md
+++ b/sdk-api-src/content/dwrite_3/ne-dwrite_3-dwrite_font_source_type.md
@@ -10,8 +10,8 @@ req.construct-type: enumeration
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-dwrite_make_font_axis_tag.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-dwrite_make_font_axis_tag.md
@@ -9,8 +9,8 @@ ms.keywords: DWRITE_MAKE_FONT_AXIS_TAG, DWRITE_MAKE_FONT_AXIS_TAG macro [Direct 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontcollectionfromfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontcollectionfromfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontfacereference.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontfacereference.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontresource.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontresource.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontsetbuilder.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createfontsetbuilder.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createtextformat.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-createtextformat.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-getsystemfontcollection.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-getsystemfontcollection.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-getsystemfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory6-getsystemfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory7-getsystemfontcollection.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory7-getsystemfontcollection.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory7-getsystemfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefactory7-getsystemfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefont3-getlocality.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefont3-getlocality.md
@@ -11,8 +11,8 @@ ms.keywords: GetLocality, GetLocality method [Direct Write], GetLocality method 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection1-getfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection1-getfontset.md
@@ -11,8 +11,8 @@ ms.keywords: GetFontSet, GetFontSet method [Direct Write], GetFontSet method [Di
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontfamily.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontfamily.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontfamilymodel.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontfamilymodel.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getmatchingfonts.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection2-getmatchingfonts.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection3-getexpirationevent.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontcollection3-getexpirationevent.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadlistener-downloadcompleted.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadlistener-downloadcompleted.md
@@ -11,8 +11,8 @@ ms.keywords: DownloadCompleted, DownloadCompleted method [Direct Write], Downloa
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-addlistener.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-addlistener.md
@@ -11,8 +11,8 @@ ms.keywords: AddListener, AddListener method [Direct Write], AddListener method 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-begindownload.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-begindownload.md
@@ -11,8 +11,8 @@ ms.keywords: BeginDownload, BeginDownload method [Direct Write], BeginDownload m
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-canceldownload.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-canceldownload.md
@@ -11,8 +11,8 @@ ms.keywords: CancelDownload, CancelDownload method [Direct Write], CancelDownloa
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-getgenerationcount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-getgenerationcount.md
@@ -11,8 +11,8 @@ ms.keywords: GetGenerationCount, GetGenerationCount method [Direct Write], GetGe
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-isempty.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-isempty.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontDownloadQueue interface [Direct Write],IsEmpty method, I
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-removelistener.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontdownloadqueue-removelistener.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontDownloadQueue interface [Direct Write],RemoveListener me
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-equals.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-equals.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontaxisvaluecount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontaxisvaluecount.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontaxisvalues.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontaxisvalues.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontresource.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-getfontresource.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-hasvariations.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontface5-hasvariations.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-createfontface.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-createfontface.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-getfontaxisvaluecount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-getfontaxisvaluecount.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-getfontaxisvalues.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfacereference1-getfontaxisvalues.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfamily2-getfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfamily2-getfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfamily2-getmatchingfonts.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontfamily2-getmatchingfonts.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontlist2-getfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontlist2-getfontset.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-createfontface.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-createfontface.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-createfontfacereference.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-createfontfacereference.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisnames.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisnames.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisvaluenamecount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisvaluenamecount.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisvaluenames.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getaxisvaluenames.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getdefaultfontaxisvalues.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getdefaultfontaxisvalues.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxisattributes.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxisattributes.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxiscount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxiscount.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxisranges.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontaxisranges.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontfaceindex.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontfaceindex.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontfile.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-getfontfile.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-hasvariations.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontresource-hasvariations.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-createfontface.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-createfontface.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-createfontresource.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-createfontresource.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfontindices(dwrite_font_axis_rangeconst_uint32_bool_uint32_uint32_uint32).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfontindices(dwrite_font_axis_rangeconst_uint32_bool_uint32_uint32_uint32).md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfontindices.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfontindices.md
@@ -14,8 +14,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(dwrite_font_axis_rangeconst_uint32_bool_idwritefontset1).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(dwrite_font_axis_rangeconst_uint32_bool_idwritefontset1).md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(dwrite_font_propertyconst_uint32_bool_idwritefontset1).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(dwrite_font_propertyconst_uint32_bool_idwritefontset1).md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(uint32const_uint32_idwritefontset1).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfilteredfonts(uint32const_uint32_idwritefontset1).md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfirstfontresources.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfirstfontresources.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontaxisranges(uint32_dwrite_font_axis_range_uint32_uint32).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontaxisranges(uint32_dwrite_font_axis_range_uint32_uint32).md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontaxisranges.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontaxisranges.md
@@ -14,8 +14,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontfacereference.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontfacereference.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontlocality.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getfontlocality.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getmatchingfonts.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset1-getmatchingfonts.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset2-getexpirationevent.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset2-getexpirationevent.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcename.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcename.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcenamelength.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcenamelength.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcetype.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontset3-getfontsourcetype.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontfacereference(idwritefontfacereference).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontfacereference(idwritefontfacereference).md
@@ -11,8 +11,8 @@ ms.keywords: AddFontFaceReference, AddFontFaceReference method [Direct Write], A
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontfacereference(idwritefontfacereference_dwrite_font_propertyconst_uint32).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontfacereference(idwritefontfacereference_dwrite_font_propertyconst_uint32).md
@@ -11,8 +11,8 @@ ms.keywords: AddFontFaceReference, AddFontFaceReference method [Direct Write], A
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-addfontset.md
@@ -11,8 +11,8 @@ ms.keywords: AddFontSet, AddFontSet method [Direct Write], AddFontSet method [Di
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-createfontset.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder-createfontset.md
@@ -11,8 +11,8 @@ ms.keywords: CreateFontSet, CreateFontSet method [Direct Write], CreateFontSet m
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder2-addfont.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder2-addfont.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder2-addfontfile.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritefontsetbuilder2-addfontfile.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-createfontfromlogfont.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-createfontfromlogfont.md
@@ -11,8 +11,8 @@ ms.keywords: CreateFontFromLOGFONT, CreateFontFromLOGFONT method [Direct Write],
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getfontsignature(idwritefont_fontsignature).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getfontsignature(idwritefont_fontsignature).md
@@ -11,8 +11,8 @@ ms.keywords: GetFontSignature, GetFontSignature method [Direct Write], GetFontSi
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getfontsignature(idwritefontface_fontsignature).md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getfontsignature(idwritefontface_fontsignature).md
@@ -11,8 +11,8 @@ ms.keywords: GetFontSignature, GetFontSignature method [Direct Write], GetFontSi
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getmatchingfontsbylogfont.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritegdiinterop1-getmatchingfontsbylogfont.md
@@ -11,8 +11,8 @@ ms.keywords: GetMatchingFontsByLOGFONT, GetMatchingFontsByLOGFONT method [Direct
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat2-getlinespacing.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat2-getlinespacing.md
@@ -11,8 +11,8 @@ ms.keywords: GetLineSpacing, GetLineSpacing method [Direct Write], GetLineSpacin
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat2-setlinespacing.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat2-setlinespacing.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteTextFormat2 interface [Direct Write],SetLineSpacing method, 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getautomaticfontaxes.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getautomaticfontaxes.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getfontaxisvaluecount.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getfontaxisvaluecount.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getfontaxisvalues.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-getfontaxisvalues.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-setautomaticfontaxes.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-setautomaticfontaxes.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-setfontaxisvalues.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextformat3-setfontaxisvalues.md
@@ -10,8 +10,8 @@ req.construct-type: function
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-getlinemetrics.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-getlinemetrics.md
@@ -11,8 +11,8 @@ ms.keywords: GetLineMetrics, GetLineMetrics method [Direct Write], GetLineMetric
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-getlinespacing.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-getlinespacing.md
@@ -11,8 +11,8 @@ ms.keywords: GetLineSpacing, GetLineSpacing method [Direct Write], GetLineSpacin
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-invalidatelayout.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-invalidatelayout.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteTextLayout3 interface [Direct Write],InvalidateLayout method
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-setlinespacing.md
+++ b/sdk-api-src/content/dwrite_3/nf-dwrite_3-idwritetextlayout3-setlinespacing.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteTextLayout3 interface [Direct Write],SetLineSpacing method, 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefactory6.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefactory6.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefactory7.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefactory7.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection1.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection1.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontCollection1, IDWriteFontCollection1 interface [Direct Wr
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection2.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection3.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontcollection3.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontdownloadlistener.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontdownloadlistener.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontDownloadListener, IDWriteFontDownloadListener interface 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontdownloadqueue.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontdownloadqueue.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontDownloadQueue, IDWriteFontDownloadQueue interface [Direc
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontface5.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontface5.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfacereference1.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfacereference1.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfallback1.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfallback1.md
@@ -15,8 +15,8 @@ req.include-header:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: 
 req.unicode-ansi: 
 topic_type:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfamily2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontfamily2.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontlist2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontlist2.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontresource.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontresource.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset1.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset1.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset2.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17134
+req.target-min-winversvr: Windows 10 Build 17134
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset3.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontset3.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 17763
+req.target-min-winversvr: Windows 10 Build 17763
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontsetbuilder.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontsetbuilder.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteFontSetBuilder, IDWriteFontSetBuilder interface [Direct Writ
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontsetbuilder2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritefontsetbuilder2.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritegdiinterop1.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritegdiinterop1.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteGdiInterop1, IDWriteGdiInterop1 interface [Direct Write], ID
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2016 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextformat2.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextformat2.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteTextFormat2, IDWriteTextFormat2 interface [Direct Write], ID
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextformat3.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextformat3.md
@@ -17,8 +17,8 @@ req.lib: Dwrite.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: Windows
 req.unicode-ansi: 
 f1_keywords:

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextlayout3.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextlayout3.md
@@ -11,8 +11,8 @@ ms.keywords: IDWriteTextLayout3, IDWriteTextLayout3 interface [Direct Write], ID
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextlayout4.md
+++ b/sdk-api-src/content/dwrite_3/nn-dwrite_3-idwritetextlayout4.md
@@ -15,8 +15,8 @@ req.include-header:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: 
-req.target-min-winversvr: 
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.target-type: 
 req.unicode-ansi: 
 topic_type:

--- a/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_font_axis_range.md
+++ b/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_font_axis_range.md
@@ -10,8 +10,8 @@ req.construct-type: structure
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_font_axis_value.md
+++ b/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_font_axis_value.md
@@ -10,8 +10,8 @@ req.construct-type: structure
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 10 Build 16299
+req.target-min-winversvr: Windows 10 Build 16299
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_line_metrics1.md
+++ b/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_line_metrics1.md
@@ -11,8 +11,8 @@ ms.keywords: DWRITE_LINE_METRICS1, DWRITE_LINE_METRICS1 structure [Direct Write]
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7, Windows Vista with SP2 and Platform Update for Windows Vista [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2, Windows Server 2008 with SP2 and Platform Update for Windows Server 2008 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_line_spacing.md
+++ b/sdk-api-src/content/dwrite_3/ns-dwrite_3-dwrite_line_spacing.md
@@ -11,8 +11,8 @@ ms.keywords: DWRITE_LINE_SPACING, DWRITE_LINE_SPACING structure [Direct Write], 
 req.header: dwrite_3.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8 and Platform Update for Windows 7 [desktop apps only]
-req.target-min-winversvr: Windows Server 2012 and Platform Update for Windows Server 2008 R2 [desktop apps only]
+req.target-min-winverclnt: Windows 10 [desktop apps only]
+req.target-min-winversvr: Windows Server 2016 [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
This PR resolve the issue https://github.com/MicrosoftDocs/feedback/issues/3984

Note that there is still these interface that doesn't have any version:
- [DWRITE_CONTAINER_TYPE](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/ne-dwrite_3-dwrite_container_type)
- [IDWriteAsyncResult](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwriteasyncresult)
- [IDWriteColorGlyphRunEnumerator1](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritecolorglyphrunenumerator1)
- [IDWriteFactory4](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritefactory4)
- [IDWriteFactory5](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritefactory5)
- [IDWriteFontFace4](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritefontface4)
- [IDWriteFontSetBuilder1](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritefontsetbuilder1)
- [IDWriteInMemoryFontFileLoader](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwriteinmemoryfontfileloader)
- [IDWriteRemoteFontFileLoader](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwriteremotefontfileloader)
- [IDWriteRemoteFontFileStream](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwriteremotefontfilestream)
- [IDWriteStringList](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritestringlist)
- [DWRITE_COLOR_GLYPH_RUN1](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/ns-dwrite_3-dwrite_color_glyph_run1)
- [DWRITE_FILE_FRAGMENT](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/ns-dwrite_3-dwrite_file_fragment)
- [DWRITE_FONT_PROPERTY](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/ns-dwrite_3-dwrite_font_property)
- [DWRITE_GLYPH_IMAGE_DATA](https://learn.microsoft.com/en-us/windows/win32/api/dwrite_3/ns-dwrite_3-dwrite_glyph_image_data)

I couldn't find any documentation that could confirm in which version those where introduced.