### PR TITLE
Clarify the behavior of the `PKCS12_NO_PERSIST_KEY` flag.

### DIFF
--- a/sdk-api-src/content/wincrypt/nf-wincrypt-pfximportcertstore.md
+++ b/sdk-api-src/content/wincrypt/nf-wincrypt-pfximportcertstore.md
@@ -175,7 +175,7 @@ Do not persist the key. Specify this flag when you do not want to persist the ke
 
 <div class="alert"><b>Note</b> Some other considerations:
 
-* When using PKCS12_NO_PERSIST_KEY, the property CERT_KEY_CONTEXT_PROP_ID is set internally on the certificate, and CERT_KEY_CONTEXT_PROP_ID contains the NCRYPT_KEY_HANDLE.
+* When using PKCS12_NO_PERSIST_KEY, the property CERT_KEY_CONTEXT_PROP_ID is set internally on the certificate, and contains the key.
 
 * If the PKCS12_NO_PERSIST_KEY is not used, the CERT_KEY_PROV_INFO_PROP_ID property is set.
 


### PR DESCRIPTION
The documentation mentions that `CERT_KEY_CONTEXT_PROP_ID` contains an `NCRYPT_KEY_HANDLE`, but it was observed locally that the kind of the key (NCrypt or `HCRYPTPROV`) depends on whether the `PKCS12_(ALWAYS|PREFER)_CNG_KSP` flags are being set.