### PR TITLE
Fixed ERROR_INVALID_PARAMETER description error

### DIFF
--- a/sdk-api-src/content/windns/nf-windns-dnsqueryex.md
+++ b/sdk-api-src/content/windns/nf-windns-dnsqueryex.md
@@ -106,7 +106,7 @@ The call was successful.
 </dl>
 </td>
 <td width="60%">
-Either the <i>pQueryRequest</i> or <i>pQueryRequest</i> parameters are uninitialized or contain the wrong version. 
+Either the <i>pQueryRequest</i> or <i>pQueryResults</i> parameters are uninitialized or contain the wrong version. 
 
 </td>
 </tr>


### PR DESCRIPTION
The current ERROR_INVALID_PARAMETER description curently says "pQueryRequest or pQueryRequest", which is obviously a mistake. Seems like it was meant to be be "pQueryRequest or pQueryResults", as pQueryResults is the only other parameter which contains a version