### PR TITLE
Document return type for GetNextWindow()

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getnextwindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getnextwindow.md
@@ -97,6 +97,10 @@ Returns a handle to the window above the given window.
 </tr>
 </table>
 
+## -returns
+
+Type: <b>HWND</b>
+
 ## -remarks
 
 This function is implemented as a call to the <a href="/windows/desktop/api/winuser/nf-winuser-getwindow">GetWindow</a> function.


### PR DESCRIPTION
Put return type **_HWND_** instead of **_void_**.

Current **_void_** and _Return value **None**_ look incorrect:
![image](https://github.com/user-attachments/assets/56595eda-cb16-4d41-a339-0db89df91a7c)
