### PR TITLE
Update nf-d3d11-id3d11devicecontext-copysubresourceregion.md

### DIFF
--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-copysubresourceregion.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicecontext-copysubresourceregion.md
@@ -119,6 +119,7 @@ If the resources are buffers, all coordinates are in bytes; if the resources are
 <li>Must have compatible DXGI formats (identical or from the same type group). For example, a DXGI_FORMAT_R32G32B32_FLOAT texture can be copied to a DXGI_FORMAT_R32G32B32_UINT texture since both of these formats are in the DXGI_FORMAT_R32G32B32_TYPELESS group. <b>CopySubresourceRegion</b> can copy between a few format types. For more info, see <a href="/windows/desktop/direct3d10/d3d10-graphics-programming-guide-resources-block-compression">Format Conversion using Direct3D 10.1</a>.</li>
 <li>May not be currently mapped.</li>
 </ul>
+
 **CopySubresourceRegion** only supports copy; it doesn't support any stretch, color key, or blend. **CopySubresourceRegion** can reinterpret the resource data between a few format types. For more info, see [Format conversion using Direct3D 10.1](/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#format-conversion-using-direct3d-101).
 
 If your app needs to copy an entire resource, we recommend to use <a href="/windows/desktop/api/d3d11/nf-d3d11-id3d11devicecontext-copyresource">ID3D11DeviceContext::CopyResource</a> instead.


### PR DESCRIPTION
Adding a newline after UL list to enable markup for the following paragraph.