### PR TITLE
Update nf-fileapi-gettemppath2a.md

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
@@ -20,7 +20,7 @@ req.lib: Kernel32.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 11 Build 22000
+req.target-min-winverclnt: Windows 10 Build 19044
 req.target-min-winversvr: Windows Server Build 20348
 req.target-type: 
 req.type-library: 

--- a/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
@@ -20,7 +20,7 @@ req.lib: Kernel32.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
+req.target-min-winverclnt: Windows 11 Build 22000
 req.target-min-winversvr: Windows Server Build 20348
 req.target-type: 
 req.type-library: 


### PR DESCRIPTION
"Windows 10 build 20348" doesn't exist and it looks confusing.