### PR TITLE
Specify which offset _interlockedbittestandset uses

### DIFF
--- a/sdk-api-src/content/winnt/nf-winnt-_interlockedbittestandset.md
+++ b/sdk-api-src/content/winnt/nf-winnt-_interlockedbittestandset.md
@@ -60,7 +60,7 @@ A pointer to a variable.
 
 ### -param Offset [in]
 
-The bit position to be tested.
+The bit position to be tested. The offset is from the least-significant bit position, with zero testing the least-significant bit, and 31 testing the most-significant bit.
 
 ## -returns
 


### PR DESCRIPTION
Update the documentation to explain the offset is from the least-significant bit, and that it's zero-indexed, so 0 is the least-significant bit, and 31 is the most significant bit.
The documentation for related APIs should also probably be updated, but I wanted to get feedback on this change first.