### PR TITLE
Update nf-realtimeapiset-queryunbiasedinterrupttimeprecise.md

### DIFF
--- a/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttimeprecise.md
+++ b/sdk-api-src/content/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttimeprecise.md
@@ -22,7 +22,7 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.lib
+req.lib: mincore.lib
 req.dll: Kernel32.dll
 req.irql: 
 targetos: Windows


### PR DESCRIPTION
Update the required import library to `mincore.lib` as this symbol is declared and available. Spotted by Alastair Houghton!