### PR TITLE
Update nf-d3d12-id3d12device5-getraytracingaccelerationstructureprebuildinfo.md

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-getraytracingaccelerationstructureprebuildinfo.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-getraytracingaccelerationstructureprebuildinfo.md
@@ -62,7 +62,7 @@ The implementation is allowed to look at all the CPU parameters in this struct a
 
 ### -param pInfo [out]
 
-The result of the query.
+A <a href="../d3d12/ns-d3d12-d3d12_raytracing_acceleration_structure_prebuild_info.md">D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO</a>. The result of the query.
 
 ## -remarks
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-getraytracingaccelerationstructureprebuildinfo.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device5-getraytracingaccelerationstructureprebuildinfo.md
@@ -45,9 +45,6 @@ api_name:
  - ID3D12Device5.GetRaytracingAccelerationStructurePrebuildInfo
 ---
 
-# ID3D12Device5::GetRaytracingAccelerationStructurePrebuildInfo
-
-
 ## -description
 
 Query the driver for resource requirements to build an acceleration structure.
@@ -62,7 +59,7 @@ The implementation is allowed to look at all the CPU parameters in this struct a
 
 ### -param pInfo [out]
 
-A <a href="../d3d12/ns-d3d12-d3d12_raytracing_acceleration_structure_prebuild_info.md">D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO</a>. The result of the query.
+The result of the query (in a [D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO](./ns-d3d12-d3d12_raytracing_acceleration_structure_prebuild_info.md) structure).
 
 ## -remarks
 


### PR DESCRIPTION
Added link to the definition of the D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO struct.