### PR TITLE
Update nf-processthreadsapi-getthreadcontext.md 

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
@@ -95,4 +95,4 @@ If you call **GetThreadContext** for the current thread, the function returns su
 - [GetXStateFeaturesMask](../winbase/nf-winbase-getxstatefeaturesmask.md)
 - [SetThreadContext](../processthreadsapi/nf-processthreadsapi-setthreadcontext.md)
 - [SuspendThread](../processthreadsapi/nf-processthreadsapi-suspendthread.md)
-- [Wow64GetThreadContext](../wow64apiset/nf-wow64apiset-wow64getthreadcontext)
+- [Wow64GetThreadContext](../wow64apiset/nf-wow64apiset-wow64getthreadcontext.md)

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreadcontext.md
@@ -95,4 +95,4 @@ If you call **GetThreadContext** for the current thread, the function returns su
 - [GetXStateFeaturesMask](../winbase/nf-winbase-getxstatefeaturesmask.md)
 - [SetThreadContext](../processthreadsapi/nf-processthreadsapi-setthreadcontext.md)
 - [SuspendThread](../processthreadsapi/nf-processthreadsapi-suspendthread.md)
-- [Wow64GetThreadContext](../winbase/nf-winbase-wow64getthreadcontext.md)
+- [Wow64GetThreadContext](../wow64apiset/nf-wow64apiset-wow64getthreadcontext)


### PR DESCRIPTION
fixing broken link to wow64getThreadContext

https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadcontext

The Link for wow64getThreadContext in the `see also` section was broken in this page