### PR TITLE
[WaitForSingleObject.md] clarify that "no timeout" means "Win32/INFINITE"

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobject.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-waitforsingleobject.md
@@ -167,7 +167,7 @@ The
 <li>Thread</li>
 <li>Waitable timer</li>
 </ul>
-Use caution when calling the wait functions and code that directly or indirectly creates windows. If a thread creates any windows, it must process messages. Message broadcasts are sent to all windows in the system. A thread that uses a wait function with no time-out interval may cause the system to become deadlocked. Two examples of code that indirectly creates windows are DDE and the <a href="/windows/desktop/api/objbase/nf-objbase-coinitialize">CoInitialize</a> function. Therefore, if you have a thread that creates windows, use 
+Use caution when calling the wait functions and code that directly or indirectly creates windows. If a thread creates any windows, it must process messages. Message broadcasts are sent to all windows in the system. A thread that uses a wait function with an <b>INFINITE</b> time-out interval may cause the system to become deadlocked. Two examples of code that indirectly creates windows are DDE and the <a href="/windows/desktop/api/objbase/nf-objbase-coinitialize">CoInitialize</a> function. Therefore, if you have a thread that creates windows, use 
 <a href="/windows/desktop/api/winuser/nf-winuser-msgwaitformultipleobjects">MsgWaitForMultipleObjects</a> or 
 <a href="/windows/desktop/api/winuser/nf-winuser-msgwaitformultipleobjectsex">MsgWaitForMultipleObjectsEx</a>, rather than 
 <b>WaitForSingleObject</b>.


### PR DESCRIPTION
Copyedit, as noted in the title.

Clarifying that "no timeout" means "Win32/INFINITE", not zero.

