### PR TITLE
Fix the incorrect InterfaceImpl token documentation.

### DIFF
--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-enuminterfaceimpls.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-enuminterfaceimpls.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Enumerates MethodDef tokens representing interface implementations.
+Enumerates InterfaceImpl tokens representing interface implementations.
 
 ## -parameters
 
@@ -60,11 +60,11 @@ A pointer to the enumerator.
 
 ### -param td [in]
 
-The token of the TypeDef whose MethodDef tokens representing interface implementations are to be enumerated.
+The token of the TypeDef whose InterfaceImpl tokens representing interface implementations are to be enumerated.
 
 ### -param rImpls [out]
 
-The array used to store the MethodDef tokens.
+The array used to store the InterfaceImpl tokens.
 
 ### -param cMax [in]
 
@@ -87,7 +87,7 @@ The actual number of tokens returned in <i>rImpls</i>.
 </tr>
 <tr>
 <td><b>S_FALSE</b></td>
-<td>There are no MethodDef tokens to enumerate. In this case, <i>pcImpls</i> is 0 (zero).
+<td>There are no InterfaceImpl tokens to enumerate. In this case, <i>pcImpls</i> is 0 (zero).
  
 
 </td>

--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
@@ -50,25 +50,29 @@ api_name:
 
 ## -description
 
-Gets a pointer to the metadata tokens for the Type that implements the specified method, and for the interface that declares that method.
+Gets a pointer to the metadata tokens for the implementater-implementee relationship between two types.
 
 ## -parameters
 
 ### -param tkInterfaceImpl [in]
 
-The metadata token representing the method to return the class and interface tokens for.
+The metadata token representing the interface implementation relationship.
 
 ### -param ptkClass [out]
 
-The metadata token representing the class that implements the method.
+The metadata token representing the implementer: the class or interface that implements the interface <b>ptkIface</b>.
 
 ### -param ptkIface [out]
 
-The metadata token representing the interface that defines the implemented method.
+The metadata token representing the implementee: the interface that is implemented by <b>ptkClass</b>.
 
 ## -returns
 
 If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
+## -remarks
+
+The <b>InterfaceImpl</b> token represents one of the n:1 relationships between an implementee and the implementer.
 
 ## -see-also
 

--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
@@ -72,7 +72,7 @@ If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRE
 
 ## -remarks
 
-The <b>InterfaceImpl</b> token represents one of the n:1 relationships between an implementee and the implementer.
+The <b>InterfaceImpl</b> token represents a single mapping between an implementing type and an implemented interface, as stored in the <b>InterfaceImpl</b> table.
 
 ## -see-also
 

--- a/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
+++ b/sdk-api-src/content/rometadataapi/nf-rometadataapi-imetadataimport-getinterfaceimplprops.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Gets a pointer to the metadata tokens for the implementater-implementee relationship between two types.
+Gets a pointer to the metadata tokens for the implementer-implementee relationship between two types.
 
 ## -parameters
 


### PR DESCRIPTION
The token's documentation was incorrect. The token represents an implementer-implementee relationship, and has nothing to do with any particular MethodDef.