### PR TITLE
Fix WinHttpCrackUrl documentation.

### DIFF
--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpcrackurl.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpcrackurl.md
@@ -177,7 +177,7 @@ Even when  WinHTTP is used in asynchronous mode (that is, when <b>WINHTTP_FLAG_A
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
 The required components are indicated by members of the 
-<a href="/windows/win32/api/winhttp/ns-winhttp-url_components">URL_COMPONENTS</a> structure. Each component has a pointer to the value and has a member that stores the length of the stored value. If both the value and the length for a component are equal to zero, that component is not returned. If the pointer to the value of the component is not <b>NULL</b> and the value of its corresponding length member is nonzero, the address of the first character of the corresponding component in the 
+<a href="/windows/win32/api/winhttp/ns-winhttp-url_components">URL_COMPONENTS</a> structure. Each component has a pointer to the value and has a member that stores the length of the stored value. If both the value and the length for a component are equal to zero, that component is not returned. If the pointer to the value of the component is <b>NULL</b> and the value of its corresponding length member is nonzero, the address of the first character of the corresponding component in the 
 <i>pwszUrl</i> string is stored in the pointer, and the length of the component is stored in the length member.
 
 If the pointer contains the address of the user-supplied buffer, the length member must contain the size of the buffer. The 


### PR DESCRIPTION
Fix explanation of how WinHttpCrackUrl treats NULL components with non-zero lengths.

The current explanation conflicts with the following paragraph which explains the behavior of copying into a user-supplied buffer when the pointer is non-NULL.

It also conflicts with the example code which uses the function as this change would describe, with NULL component pointers and non-zero lengths.