### PR TITLE
Update ID3D12VideoEncodeCommandList2::ResolveEncoderOutputMetadata

### DIFF
--- a/sdk-api-src/content/d3d12video/nf-d3d12video-id3d12videoencodecommandlist2-resolveencoderoutputmetadata.md
+++ b/sdk-api-src/content/d3d12video/nf-d3d12video-id3d12videoencodecommandlist2-resolveencoderoutputmetadata.md
@@ -48,11 +48,11 @@ Resolves the output metadata from a call to [ID3D12VideoEncodeCommandList2::Enco
 
 ### -param pInputArguments
 
-A pointer to a [D3D12_VIDEO_ENCODER_OUTPUT_METADATA](ns-d3d12video-d3d12_video_encoder_output_metadata.md) representing the opaque output metadata results from **EncodeFrame**.
+A pointer to a [D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS](ns-d3d12video-d3d12_video_encoder_resolve_metadata_input_arguments.md), containing a pointer to the opaque [D3D12_VIDEO_ENCODER_OUTPUT_METADATA](ns-d3d12video-d3d12_video_encoder_output_metadata.md) received from a previous call to **EncodeFrame**.
 
 ### -param pOutputArguments
 
-A pointer to a [D3D12_VIDEO_ENCODER_OUTPUT_METADATA](ns-d3d12video-d3d12_video_encoder_output_metadata.md) output parameter that receivesthe resolved, readable metadata.
+A pointer to a [D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS](ns-d3d12video-d3d12_video_encoder_resolve_metadata_output_arguments.md), containing a pointer to the [D3D12_VIDEO_ENCODER_OUTPUT_METADATA](ns-d3d12video-d3d12_video_encoder_output_metadata.md) where the resolved, readable metadata will be written.
 
 ## -remarks
 


### PR DESCRIPTION
Include links to the actual parameter-types, to bring the API design/intent closer to the reader.

Some API involving `D3D12_VIDEO_ENCODER_OUTPUT_METADATA` will omit links to the literal parameter types, because the literal parameter type is of little-interest; a (`*dest` + `offset`) wrapper-struct.

This is sensible in some scenarios for the sake of brevity, but confusing for this specific API because of parameter semantics:
- `D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS`
  - An input containing an opaque, HW-layout `OUTPUT_METADATA`
- `D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS`
  - An output containing an `OUTPUT_METADATA`, where resolved data is written
    - Resolved data is derived from the input `OUTPUT_METADATA`


From this API doc, [`D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS`](https://learn.microsoft.com/en-us/windows/win32/api/d3d12video/ns-d3d12video-d3d12_video_encoder_resolve_metadata_output_arguments) should be  reachable because it includes directly related squiggles.