### PR TITLE
Clarify that the scRGB color space isn't a output/monitor color space despite being supported on swap chains

### DIFF
--- a/sdk-api-src/content/dxgi1_6/ns-dxgi1_6-dxgi_output_desc1.md
+++ b/sdk-api-src/content/dxgi1_6/ns-dxgi1_6-dxgi_output_desc1.md
@@ -92,9 +92,7 @@ The number of bits per color channel for the active wire format of the display a
 
 Type: <b><a href="/windows/desktop/api/dxgicommon/ne-dxgicommon-dxgi_color_space_type">DXGI_COLOR_SPACE_TYPE</a></b>
 
-The current advanced color capabilities of the display attached to this output. Specifically, whether its capable of reproducing color and luminance values outside of the sRGB color space.
-	    A value of `DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709` indicates that the display is limited to SDR/sRGB; A value of `DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020` indicates that the display supports
-	    advanced color capabilities. Note that `DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709` is currently not a color space displays use, it's simply an intermediary swap chain color space.
+The current advanced color capabilities of the display attached to this output. Specifically, whether it's capable of reproducing color and luminance values outside of the sRGB color space. A value of **DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709** indicates that the display is limited to SDR/sRGB. A value of **DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020** indicates that the display supports advanced color capabilities. **DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709** is currently not a color space that displays use; it's simply an intermediary swap-chain color space.
 
 For detailed luminance and color capabilities, see additional members of this struct.
 

--- a/sdk-api-src/content/dxgi1_6/ns-dxgi1_6-dxgi_output_desc1.md
+++ b/sdk-api-src/content/dxgi1_6/ns-dxgi1_6-dxgi_output_desc1.md
@@ -93,8 +93,8 @@ The number of bits per color channel for the active wire format of the display a
 Type: <b><a href="/windows/desktop/api/dxgicommon/ne-dxgicommon-dxgi_color_space_type">DXGI_COLOR_SPACE_TYPE</a></b>
 
 The current advanced color capabilities of the display attached to this output. Specifically, whether its capable of reproducing color and luminance values outside of the sRGB color space.
-	    A value of DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709 indicates that the display is limited to SDR/sRGB; A value of DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020 indicates that the display supports
-	    advanced color capabilities.
+	    A value of `DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709` indicates that the display is limited to SDR/sRGB; A value of `DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020` indicates that the display supports
+	    advanced color capabilities. Note that `DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709` is currently not a color space displays use, it's simply an intermediary swap chain color space.
 
 For detailed luminance and color capabilities, see additional members of this struct.
 


### PR DESCRIPTION
I think this was a bit confusing, because if you are using for HDR10, you can check the output (adapter) for `DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020` compatibility and set the swap chain to that color space too, but if you want to use scRGB HDR, then you still have to check for `DXGI_COLOR_SPACE_RGB_FULL_G2048_NONE_P2020` on the output, but then set `DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709` on the swap chain.