### PR TITLE
Update nf-processthreadsapi-getthreaddescription.md

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreaddescription.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getthreaddescription.md
@@ -89,7 +89,7 @@ The following example gets the description for a thread,  prints the description
 HRESULT hr = GetThreadDescription(ThreadHandle, &data);
 if (SUCCEEDED(hr))
 {   
-    wprintf(“%ls\n”, data);
+    wprintf(L"%ls\n", data);
     LocalFree(data);
 }
 ```


### PR DESCRIPTION
Fix `wprintf` taking a `wchar_t` format string. Fix quotes.