### PR TITLE
Update ns-evntrace-classic_event_id.md - link to NT Logger Constants

### DIFF
--- a/sdk-api-src/content/evntrace/ns-evntrace-classic_event_id.md
+++ b/sdk-api-src/content/evntrace/ns-evntrace-classic_event_id.md
@@ -94,14 +94,18 @@ Reserved.
 
 Useful values for the GUID and Type fields can be determined from consulting
 the WMI classes in the `root\wmi` namespace. These values may also be located
-in `wmicore.mof` where they are originally defined.
+in `wmicore.mof` where they are originally defined. Many of them can also be found [here](/windows/win32/etw/nt-kernel-logger-constants).
 
 For example, to enable the [read](/windows/desktop/ETW/diskio-typegroup1)
 event type for [disk IO](/windows/desktop/ETW/diskio) events, set **GUID**
 to `3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 10.
+
+Or to enable the [context switch](/windows/win32/etw/cswitch) event type for [thread](/windows/win32/etw/thread-v2) events, set **GUID** to `3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 36.
 
 ## -see-also
 
 [TraceSetInformation](/windows/desktop/ETW/tracesetinformation)
 
 [TRACE_QUERY_INFO_CLASS](/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class)
+
+[NT Kernel Logger Constants](/windows/win32/etw/nt-kernel-logger-constants)

--- a/sdk-api-src/content/evntrace/ns-evntrace-classic_event_id.md
+++ b/sdk-api-src/content/evntrace/ns-evntrace-classic_event_id.md
@@ -18,7 +18,7 @@ helpviewer_keywords:
 old-location: etw\classic_event_id.htm
 tech.root: ETW
 ms.assetid: cbd77002-466b-40e6-85a5-cd872aef7d51
-ms.date: 12/05/2018
+ms.date: 10/21/2024
 ms.keywords:
   "*PCLASSIC_EVENT_ID, CLASSIC_EVENT_ID, CLASSIC_EVENT_ID structure [ETW],
   PCLASSIC_EVENT_ID, PCLASSIC_EVENT_ID structure pointer [ETW],
@@ -69,10 +69,7 @@ api_name:
 
 ## -description
 
-Identifies the kernel event for which you want to enable call stack tracing.
-Used with the
-[TraceStackTracingInfo](/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class)
-class of
+Identifies the kernel event for which you want to enable call stack tracing. Used with the [TraceStackTracingInfo](/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class) class of
 [TraceSetInformation](/windows/win32/api/evntrace/nf-evntrace-tracesetinformation).
 
 ## -struct-fields
@@ -83,8 +80,7 @@ The GUID that identifies the kernel event class.
 
 ### -field Type
 
-The event type that identifies the event within the kernel event class to
-enable.
+The event type that identifies the event within the kernel event class to enable.
 
 ### -field Reserved
 
@@ -92,15 +88,13 @@ Reserved.
 
 ## -remarks
 
-Useful values for the GUID and Type fields can be determined from consulting
-the WMI classes in the `root\wmi` namespace. These values may also be located
-in `wmicore.mof` where they are originally defined. Many of them can also be found [here](/windows/win32/etw/nt-kernel-logger-constants).
+Useful values for the EventGuid and Type fields can be determined from consulting the WMI classes in the `root\wmi` namespace. You can also find these values in `wmicore.mof` (where they are originally defined), or see [NT Kernel Logger Constants](/windows/win32/etw/nt-kernel-logger-constants).
 
-For example, to enable the [read](/windows/desktop/ETW/diskio-typegroup1)
-event type for [disk IO](/windows/desktop/ETW/diskio) events, set **GUID**
-to `3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 10.
+### Examples
 
-Or to enable the [context switch](/windows/win32/etw/cswitch) event type for [thread](/windows/win32/etw/thread-v2) events, set **GUID** to `3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 36.
+To enable the [read](/windows/desktop/ETW/diskio-typegroup1) event type for [disk IO](/windows/desktop/ETW/diskio) events, set **GUID** to `3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 10.
+
+To enable the [context switch](/windows/win32/etw/cswitch) event type for [thread](/windows/win32/etw/thread-v2) events, set **GUID** to `3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c` and **Type** to 36.
 
 ## -see-also
 


### PR DESCRIPTION
In my experience, it's a lot easier to find the useful valid GUIDs in the MSDN 'NT Logger Constants' page than browsing WMI.