### PR TITLE
Update ns-evntcons-event_header_extended_data_item.md -add PMC Counter info

### DIFF
--- a/sdk-api-src/content/evntcons/ns-evntcons-event_header_extended_data_item.md
+++ b/sdk-api-src/content/evntcons/ns-evntcons-event_header_extended_data_item.md
@@ -130,6 +130,17 @@ The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-e
 
 </td>
 </tr>
+</tr>
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_PMC_COUNTERS"></a><a id="event_header_ext_type_pmc_counters"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_PMC_COUNTERS</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-evntcons-event_extended_item_pmc_counters">EVENT_EXTENDED_ITEM_PMC_COUNTERS</a> structure that contains the current PMC Counter values. To enable this feature, the valid PMC counters for the CPU must be set via <a href="/windows/win32/api/evntrace/nf-evntrace-tracesetinformation">TraceSetInformation</a>, with valid <b>Source</b> values found by calling <a href="/windows/win32/api/evntrace/nf-evntrace-tracequeryinformation">TraceQueryInformation</a> with <a href="/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class">TraceProfileSourceListInfo</a>.
+
+</td>
+</tr>
 <tr>
 <td width="40%"><a id="EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL"></a><a id="event_header_ext_type_event_schema_tl"></a><dl>
 <dt><b>EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL</b></dt>

--- a/sdk-api-src/content/evntcons/ns-evntcons-event_header_extended_data_item.md
+++ b/sdk-api-src/content/evntcons/ns-evntcons-event_header_extended_data_item.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["*PEVENT_HEADER_EXTENDED_DATA_ITEM","EVENT_HEADER_EXTENDED
 old-location: etw\event_header_extended_data_item.htm
 tech.root: ETW
 ms.assetid: 130dc14b-7488-48ab-a31d-310c0f4ee13f
-ms.date: 08/04/2022
+ms.date: 10/22/2024
 ms.keywords: '*PEVENT_HEADER_EXTENDED_DATA_ITEM, EVENT_HEADER_EXTENDED_DATA_ITEM, EVENT_HEADER_EXTENDED_DATA_ITEM structure [ETW], EVENT_HEADER_EXT_TYPE_EVENT_KEY, EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL, EVENT_HEADER_EXT_TYPE_INSTANCE_INFO, EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY, EVENT_HEADER_EXT_TYPE_PROV_TRAITS, EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID, EVENT_HEADER_EXT_TYPE_SID, EVENT_HEADER_EXT_TYPE_STACK_TRACE32, EVENT_HEADER_EXT_TYPE_STACK_TRACE64, EVENT_HEADER_EXT_TYPE_TS_ID, PEVENT_HEADER_EXTENDED_DATA_ITEM, PEVENT_HEADER_EXTENDED_DATA_ITEM structure pointer [ETW], _EVENT_HEADER_EXTENDED_DATA_ITEM, base.event_header_extended_data_item, etw.event_header_extended_data_item, relogger/EVENT_HEADER_EXTENDED_DATA_ITEM, relogger/PEVENT_HEADER_EXTENDED_DATA_ITEM'
 req.header: evntcons.h
 req.include-header: Evntcons.h
@@ -63,13 +63,86 @@ Reserved.
 
 ### -field ExtType
 
-Type of extended data. The following are possible values.
+The type of extended data. The following examples are some possible values.
 
 <table>
 <tr>
 <th>Value</th>
 <th>Meaning</th>
 </tr>
+
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_EVENT_KEY"></a><a id="event_header_ext_type_event_key"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_EVENT_KEY</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an EVENT_EXTENDED_ITEM_EVENT_KEY structure containing a unique event identifier that is a 64-bit scalar.
+
+The <b>EnableProperty</b> EVENT_ENABLE_PROPERTY_EVENT_KEY needs to be passed in for the <a href="/windows/desktop/ETW/enabletrace">EnableTrace</a> call for a given provider to enable this feature.
+
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL"></a><a id="event_header_ext_type_event_schema_tl"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an extended header item that contains TraceLogging event metadata information.
+
+</td>
+</tr>
+
+
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_INSTANCE_INFO"></a><a id="event_header_ext_type_instance_info"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_INSTANCE_INFO</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an <a href="/windows/desktop/api/evntcons/ns-evntcons-event_extended_item_instance">EVENT_EXTENDED_ITEM_INSTANCE</a> structure that contains the activity identifier if you called <a href="/windows/desktop/ETW/traceeventinstance">TraceEventInstance</a> to write the event.
+
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_PMC_COUNTERS"></a><a id="event_header_ext_type_pmc_counters"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_PMC_COUNTERS</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-evntcons-event_extended_item_pmc_counters">EVENT_EXTENDED_ITEM_PMC_COUNTERS</a> structure that contains the current PMC Counter values. To enable this feature, the valid PMC counters for the CPU must be set via <a href="/windows/win32/api/evntrace/nf-evntrace-tracesetinformation">TraceSetInformation</a>, with valid <b>Source</b> values found by calling <a href="/windows/win32/api/evntrace/nf-evntrace-tracequeryinformation">TraceQueryInformation</a> with <a href="/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class">TraceProfileSourceListInfo</a>.
+
+</td>
+</tr>
+
+
+<tr>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY"></a><a id="event_header_ext_type_process_start_key"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an EVENT_EXTENDED_ITEM_PROCESS_START_KEY structure that contains a unique process identifier (unique across the boot session). This identifier is a 64-bit scalar. 
+
+The <b>EnableProperty</b> EVENT_ENABLE_PROPERTY_PROCESS_START_KEY needs to be passed in for the <a href="/windows/desktop/ETW/enabletrace">EnableTrace</a> call for a given provider to enable this feature. 
+
+</td>
+</tr>
+
+<tr>
+<td width="40%"><a id="_EVENT_HEADER_EXT_TYPE_PROV_TRAITS"></a><a id="_event_header_ext_type_prov_traits"></a><dl>
+<dt><b>	EVENT_HEADER_EXT_TYPE_PROV_TRAITS</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <b>DataPtr</b> member points to an extended header item that  contains provider traits data, for example traits set through <a href="/windows/desktop/api/evntprov/nf-evntprov-eventsetinformation">EventSetInformation(EventProviderSetTraits)</a> or specified through <a href="/windows/desktop/api/evntprov/ns-evntprov-event_data_descriptor">EVENT_DATA_DESCRIPTOR_TYPE_PROVIDER_METADATA</a>.
+
+</td>
+</tr>
+
 <tr>
 <td width="40%"><a id="EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID"></a><a id="event_header_ext_type_related_activityid"></a><dl>
 <dt><b>EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID</b></dt>
@@ -87,26 +160,6 @@ The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-e
 </td>
 <td width="60%">
 The <b>DataPtr</b> member points to a <a href="/windows/desktop/api/winnt/ns-winnt-sid">SID</a> structure that contains the security identifier (SID) of the user that logged the event. ETW includes the SID if you set the <i>EnableProperty</i> parameter of <a href="/windows/desktop/ETW/enabletraceex-func">EnableTraceEx</a> to EVENT_ENABLE_PROPERTY_SID.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_TS_ID"></a><a id="event_header_ext_type_ts_id"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_TS_ID</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an <a href="/windows/desktop/api/evntcons/ns-evntcons-event_extended_item_ts_id">EVENT_EXTENDED_ITEM_TS_ID</a> structure that contains the terminal session identifier. ETW includes the terminal session identifier if you set the <i>EnableProperty</i> parameter of <a href="/windows/desktop/ETW/enabletraceex-func">EnableTraceEx</a> to EVENT_ENABLE_PROPERTY_TS_ID.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_INSTANCE_INFO"></a><a id="event_header_ext_type_instance_info"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_INSTANCE_INFO</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an <a href="/windows/desktop/api/evntcons/ns-evntcons-event_extended_item_instance">EVENT_EXTENDED_ITEM_INSTANCE</a> structure that contains the activity identifier if you called <a href="/windows/desktop/ETW/traceeventinstance">TraceEventInstance</a> to write the event.
 
 </td>
 </tr>
@@ -131,60 +184,20 @@ The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-e
 </td>
 </tr>
 </tr>
+
+
 <tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_PMC_COUNTERS"></a><a id="event_header_ext_type_pmc_counters"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_PMC_COUNTERS</b></dt>
+<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_TS_ID"></a><a id="event_header_ext_type_ts_id"></a><dl>
+<dt><b>EVENT_HEADER_EXT_TYPE_TS_ID</b></dt>
 </dl>
 </td>
 <td width="60%">
-The <b>DataPtr</b> member points to an <a href="/windows/win32/api/evntcons/ns-evntcons-event_extended_item_pmc_counters">EVENT_EXTENDED_ITEM_PMC_COUNTERS</a> structure that contains the current PMC Counter values. To enable this feature, the valid PMC counters for the CPU must be set via <a href="/windows/win32/api/evntrace/nf-evntrace-tracesetinformation">TraceSetInformation</a>, with valid <b>Source</b> values found by calling <a href="/windows/win32/api/evntrace/nf-evntrace-tracequeryinformation">TraceQueryInformation</a> with <a href="/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class">TraceProfileSourceListInfo</a>.
+The <b>DataPtr</b> member points to an <a href="/windows/desktop/api/evntcons/ns-evntcons-event_extended_item_ts_id">EVENT_EXTENDED_ITEM_TS_ID</a> structure that contains the terminal session identifier. ETW includes the terminal session identifier if you set the <i>EnableProperty</i> parameter of <a href="/windows/desktop/ETW/enabletraceex-func">EnableTraceEx</a> to EVENT_ENABLE_PROPERTY_TS_ID.
 
 </td>
 </tr>
-<tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL"></a><a id="event_header_ext_type_event_schema_tl"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_EVENT_SCHEMA_TL</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an extended header item that contains TraceLogging event metadata information.
 
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="_EVENT_HEADER_EXT_TYPE_PROV_TRAITS"></a><a id="_event_header_ext_type_prov_traits"></a><dl>
-<dt><b>	EVENT_HEADER_EXT_TYPE_PROV_TRAITS</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an extended header item that  contains provider traits data, for example traits set through <a href="/windows/desktop/api/evntprov/nf-evntprov-eventsetinformation">EventSetInformation(EventProviderSetTraits)</a> or specified through <a href="/windows/desktop/api/evntprov/ns-evntprov-event_data_descriptor">EVENT_DATA_DESCRIPTOR_TYPE_PROVIDER_METADATA</a>.
 
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_EVENT_KEY"></a><a id="event_header_ext_type_event_key"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_EVENT_KEY</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an EVENT_EXTENDED_ITEM_EVENT_KEY structure containing a unique event identifier that is a 64-bit scalar.
-
-The <b>EnableProperty</b> EVENT_ENABLE_PROPERTY_EVENT_KEY needs to be passed in for the <a href="/windows/desktop/ETW/enabletrace">EnableTrace</a> call for a given provider to enable this feature.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY"></a><a id="event_header_ext_type_process_start_key"></a><dl>
-<dt><b>EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>DataPtr</b> member points to an EVENT_EXTENDED_ITEM_PROCESS_START_KEY structure that contains a unique process identifier (unique across the boot session). This identifier is a 64-bit scalar. 
-
-The <b>EnableProperty</b> EVENT_ENABLE_PROPERTY_PROCESS_START_KEY needs to be passed in for the <a href="/windows/desktop/ETW/enabletrace">EnableTrace</a> call for a given provider to enable this feature. 
-
-</td>
-</tr>
 </table>
 
 ### -field Linkage


### PR DESCRIPTION
evntcons.h provides more values than this documentation shows, and I only added PMC Counters since that's what I've tried. Also, there's a long list of requirements to get the PMC counters out that I didn't mention here, but in the spirit of the document I tried to stay brief.

For example, **EVENT_TRACE_PROPERTIES_V2** needs to have its **Wnode.ClientContext = 3** and **LogFileMode = EVENT_TRACE_REAL_TIME_MODE | EVENT_TRACE_SYSTEM_LOGGER_MODE**. And **TraceSetInformation(TracePmcEventListInfo)** needs to be called with a supported GUID where the **EnableFlags** is also set for the valid **EventType**s. And the **EVENT_TRACE_LOGFILEW** needs to have **ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP | PROCESS_TRACE_MODE_REAL_TIME**