### PR TITLE
Remove outdated limitation for `GetPrivateProfileSection`

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesection.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesection.md
@@ -73,6 +73,8 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
+**Note:** In earlier Windows versions, the maximum profile section size is 32,767 characters. Windows 7 and newer versions don't have this limitation.
+
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.

--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesection.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesection.md
@@ -73,9 +73,6 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
-
-The maximum profile section size is 32,767 characters.
-
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.

--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectiona.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectiona.md
@@ -73,6 +73,8 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
+**Note:** In earlier Windows versions, the maximum profile section size is 32,767 characters. Windows 7 and newer versions don't have this limitation.
+
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.

--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectiona.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectiona.md
@@ -73,9 +73,6 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
-
-The maximum profile section size is 32,767 characters.
-
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.

--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectionw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectionw.md
@@ -73,6 +73,8 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
+**Note:** In earlier Windows versions, the maximum profile section size is 32,767 characters. Windows 7 and newer versions don't have this limitation.
+
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.

--- a/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectionw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getprivateprofilesectionw.md
@@ -73,9 +73,6 @@ A pointer to a buffer that receives the key name and value pairs associated with
 
 The size of the buffer pointed to by the <i>lpReturnedString</i> parameter, in characters. 
 
-
-The maximum profile section size is 32,767 characters.
-
 ### -param lpFileName [in]
 
 The name of the initialization file. If this parameter does not contain a full path to the file, the system searches for the file in the Windows directory.


### PR DESCRIPTION
Tested back to Windows 7, there's on such limitation. It was probably relevant in very old versions.

BTW not sure why there's the three files - A, W and just [getprivateprofilesection.md](https://github.com/MicrosoftDocs/sdk-api/pull/1929/files#diff-cdf934c98420125f2d83e4aaae933876198e947e944863b1be6cb4d4e80c29f1). I assume the third file can be removed.

BTW there's a similar limitation for `GetProfileSection`, I didn't check whether it's still relevant, and it's a useless function nowadays anyway.