### PR TITLE
Update nf-shlwapi-strformatbytesizeex.md

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-strformatbytesizeex.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-strformatbytesizeex.md
@@ -107,9 +107,7 @@ The following table illustrates how this function converts a numeric value into 
 <td>1.99 GB</td>
 </tr>
 </table>
- 
 
-In Windows 10, size is reported in base 10 rather than  base 2. For example, 1 KB is 1000 bytes rather than 1024.
 
 ## -see-also
 


### PR DESCRIPTION
Removed confusing sentence:

> In Windows 10, size is reported in base 10 rather than base 2. For example, 1 KB is 1000 bytes rather than 1024.

The statement is only true for marketing materials ([Link](https://answers.microsoft.com/en-us/windows/forum/all/windows-10-file-explorer-unit-confusion/fed69f40-c448-4028-a011-cb0780215a63)).
