### PR TITLE
Update nf-bcrypt-bcryptduplicatekey.md

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
@@ -63,7 +63,7 @@ The handle of the key to duplicate. This must be a handle to a symmetric key.
 
 A pointer to a <b>BCRYPT_KEY_HANDLE</b> variable that receives the handle of the duplicate key. This handle is used in subsequent functions that require a key, such as <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptencrypt">BCryptEncrypt</a>. This handle must be released when it is no longer needed by passing it to the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptdestroykey">BCryptDestroyKey</a> function.
 
-### -param pbKeyObject [out, optional]
+### -param pbKeyObject [out]
 
 A pointer to a buffer that receives the duplicate key object. The <i>cbKeyObject</i> parameter contains the size of this buffer. The required size of this buffer can be obtained by calling the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgetproperty">BCryptGetProperty</a> function to get the <b>BCRYPT_OBJECT_LENGTH</b> property. This will provide the size of the key object for the specified algorithm.
 

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
@@ -63,15 +63,19 @@ The handle of the key to duplicate. This must be a handle to a symmetric key.
 
 A pointer to a <b>BCRYPT_KEY_HANDLE</b> variable that receives the handle of the duplicate key. This handle is used in subsequent functions that require a key, such as <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptencrypt">BCryptEncrypt</a>. This handle must be released when it is no longer needed by passing it to the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptdestroykey">BCryptDestroyKey</a> function.
 
-### -param pbKeyObject [out]
+### -param pbKeyObject [out, optional]
 
 A pointer to a buffer that receives the duplicate key object. The <i>cbKeyObject</i> parameter contains the size of this buffer. The required size of this buffer can be obtained by calling the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgetproperty">BCryptGetProperty</a> function to get the <b>BCRYPT_OBJECT_LENGTH</b> property. This will provide the size of the key object for the specified algorithm.
 
 This memory can only be freed after the <i>phNewKey</i> key handle is destroyed.
 
+If the value of this parameter is <b>NULL</b> and the value of the <i>cbKeyObject</i> parameter is zero, the memory for the duplicate key object is allocated by this function and freed by <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptdestroykey">BCryptDestroyKey</a>. <b>Windows 7:  </b>This memory management functionality is available beginning with Windows 7.
+
 ### -param cbKeyObject [in]
 
 The size, in bytes, of the <i>pbKeyObject</i> buffer.
+
+If the value of this parameter is zero and the value of the <i>pbKeyObject</i> parameter is <b>NULL</b>, the memory for the duplicate key object is allocated by this function and freed by <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptdestroykey">BCryptDestroyKey</a>. <b>Windows 7:  </b>This memory management functionality is available beginning with Windows 7.
 
 ### -param dwFlags [in]
 

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptduplicatekey.md
@@ -65,7 +65,7 @@ A pointer to a <b>BCRYPT_KEY_HANDLE</b> variable that receives the handle of the
 
 ### -param pbKeyObject [out]
 
-A pointer to a buffer that receives the duplicate key object. The <i>cbKeyObject</i> parameter contains the size of this buffer. The required size of this buffer can be obtained by calling the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgetproperty">BCryptGetProperty</a> function to get the <b>BCRYPT_OBJECT_LENGTH</b> property. This will provide the size of the key object for the specified algorithm.
+An ***optional*** pointer to a buffer that receives the duplicate key object. The <i>cbKeyObject</i> parameter contains the size of this buffer. The required size of this buffer can be obtained by calling the <a href="/windows/desktop/api/bcrypt/nf-bcrypt-bcryptgetproperty">BCryptGetProperty</a> function to get the <b>BCRYPT_OBJECT_LENGTH</b> property. This will provide the size of the key object for the specified algorithm.
 
 This memory can only be freed after the <i>phNewKey</i> key handle is destroyed.
 


### PR DESCRIPTION
Updates documentation to mirror functionality shared with BCryptGenerateSymmetricKey