### PR TITLE
Update `nf-processenv-freeenvironmentstringsw.md`: Fix broken links to `GetEnvironmentStrings()`

### DIFF
--- a/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["FreeEnvironmentStrings", "FreeEnvironmentStrings function
 old-location: base\freeenvironmentstrings.htm
 tech.root: backup
 ms.assetid: 8ac73f6e-4b42-4730-bf88-4b671f57b63b
-ms.date: 12/05/2018
+ms.date: 12/02/2024
 ms.keywords: FreeEnvironmentStrings, FreeEnvironmentStrings function, FreeEnvironmentStringsA, FreeEnvironmentStringsW, _win32_freeenvironmentstrings, base.freeenvironmentstrings, processenv/FreeEnvironmentStrings, processenv/FreeEnvironmentStringsA, processenv/FreeEnvironmentStringsW, winbase/FreeEnvironmentStrings, winbase/FreeEnvironmentStringsA, winbase/FreeEnvironmentStringsW
 req.header: processenv.h
 req.include-header: Windows.h on Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008  Windows Server 2008 R2
@@ -54,7 +54,6 @@ api_name:
 
 # FreeEnvironmentStringsW function
 
-
 ## -description
 
 Frees a block of environment strings.
@@ -63,38 +62,28 @@ Frees a block of environment strings.
 
 ### -param penv
 
-A pointer to a block of environment strings. The pointer to the block must be obtained by calling the 
-<a href="/windows/desktop/api/rrascfg/nf-rrascfg-ieapproviderconfig-initialize">GetEnvironmentStrings</a> function.
+A pointer to a block of environment strings. The pointer to the block must be obtained by calling the [GetEnvironmentStringsW](nf-processenv-getenvironmentstringsw.md) function.
 
 ## -returns
 
 If the function succeeds, the return value is nonzero.
 
-If the function fails, the return value is zero To get extended error information, call 
-<a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is zero To get extended error information, call [GetLastError](../errhandlingapi/nf-errhandlingapi-getlasterror.md).
 
 ## -remarks
 
-If you used the ANSI version of <a href="/windows/desktop/api/rrascfg/nf-rrascfg-ieapproviderconfig-initialize">GetEnvironmentStrings</a>, be sure to use the ANSI version of <b>FreeEnvironmentStrings</b>. Similarly, if you used the Unicode version of <b>GetEnvironmentStrings</b>, be sure to use the Unicode version of <b>FreeEnvironmentStrings</b>.
+If you used the ANSI version of [GetEnvironmentStrings](nf-processenv-getenvironmentstrings.md), be sure to use the ANSI version of **FreeEnvironmentStrings**. Similarly, if you used the Unicode version of **GetEnvironmentStrings**, be sure to use the Unicode version of **FreeEnvironmentStrings**.
 
 
-#### Examples
+### Examples
 
-For an example, see 
-<a href="/windows/desktop/ProcThread/changing-environment-variables">Changing Environment Variables</a>.
-
-<div class="code"></div>
-
-
-
+For an example, see [Changing Environment Variables](/windows/win32/procthread/changing-environment-variables).
 
 > [!NOTE]
 > The processenv.h header defines FreeEnvironmentStrings as an alias that automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. Mixing usage of the encoding-neutral alias with code that is not encoding-neutral can lead to mismatches that result in compilation or runtime errors. For more information, see [Conventions for Function Prototypes](/windows/win32/intl/conventions-for-function-prototypes).
 
 ## -see-also
 
-<a href="/windows/desktop/ProcThread/environment-variables">Environment Variables</a>
+[Environment Variables](/windows/win32/procthread/environment-variables)
 
-
-
-<a href="/windows/desktop/api/rrascfg/nf-rrascfg-ieapproviderconfig-initialize">GetEnvironmentStrings</a>
+[GetEnvironmentStrings](nf-processenv-getenvironmentstrings.md)

--- a/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
+++ b/sdk-api-src/content/processenv/nf-processenv-freeenvironmentstringsw.md
@@ -68,7 +68,7 @@ A pointer to a block of environment strings. The pointer to the block must be ob
 
 If the function succeeds, the return value is nonzero.
 
-If the function fails, the return value is zero To get extended error information, call [GetLastError](../errhandlingapi/nf-errhandlingapi-getlasterror.md).
+If the function fails, the return value is zero. To get extended error information, call [GetLastError](../errhandlingapi/nf-errhandlingapi-getlasterror.md).
 
 ## -remarks
 


### PR DESCRIPTION
This also brings the formatting closer to `nf-processenv-freeenvironmentstrings.md`.