### PR TITLE
Update nf-slpublic-slgetwindowsinformationdword.md to document SL_E_VALUE_NOT_FOUND

### DIFF
--- a/sdk-api-src/content/slpublic/nf-slpublic-slgetwindowsinformationdword.md
+++ b/sdk-api-src/content/slpublic/nf-slpublic-slgetwindowsinformationdword.md
@@ -99,4 +99,16 @@ The value portion of the name-value pair is not a <b>DWORD</b>.
 
 </td>
 </tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>SL_E_VALUE_NOT_FOUND</b></dt>
+<dt>0xC004F012</dt>
+</dl>
+</td>
+<td width="60%">
+The requested policy is not defined for the current device.
+
+</td>
+</tr>
 </table>


### PR DESCRIPTION
This is a useful return code to call out specifically as useful to callers of this API.