### PR TITLE
Update nf-fileapi-getfinalpathnamebyhandlea.md

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
@@ -233,10 +233,8 @@ Invalid flags were specified for <i>dwFlags</i>.
 
 The Server Message Block (SMB) Protocol does not support queries for normalized paths. Consequently, when you call this function passing the handle of a file opened using SMB, and with the FILE_NAME_NORMALIZED flag, the function splits the path into its components and tries to query for the normalized name of each of those components in turn. If the user lacks access permission to any one of those components, then the function call fails with ERROR_ACCESS_DENIED.
 
-Windows Versions  post Windows 10 v1709 and Windows Server v1709 do support FileNormalizedNameInformation  information class  via  SMB per  the MS-SMB2 specification Appendix A , Section 3.3.5.20.1
-<a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_414"> MS-SMB2 specification</a>
-
-
+> [!NOTE]
+> Windows 10 version 1709 and later and Windows Server version 1709 and later support the **FileNormalizedNameInformation** information class via SMB. See the [MS-SMB2 specification] (/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_414) Appendix A, Section 3.3.5.20.1 for more information.
 
  A final path is the path that is returned when a path is fully resolved. For example, for a symbolic link 
      named "C:\tmp\mydir" that points to "D:\yourdir", the final path would be 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
@@ -233,6 +233,11 @@ Invalid flags were specified for <i>dwFlags</i>.
 
 The Server Message Block (SMB) Protocol does not support queries for normalized paths. Consequently, when you call this function passing the handle of a file opened using SMB, and with the FILE_NAME_NORMALIZED flag, the function splits the path into its components and tries to query for the normalized name of each of those components in turn. If the user lacks access permission to any one of those components, then the function call fails with ERROR_ACCESS_DENIED.
 
+Windows Versions  post Windows 10 v1709 and Windows Server v1709 do support FileNormalizedNameInformation  information class  via  SMB per  the MS-SMB2 specification Appendix A , Section 3.3.5.20.1
+<a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_414"> MS-SMB2 specification</a>
+
+
+
  A final path is the path that is returned when a path is fully resolved. For example, for a symbolic link 
      named "C:\tmp\mydir" that points to "D:\yourdir", the final path would be 
      "D:\yourdir".


### PR DESCRIPTION
adding note  and reference  to SMB2 specs  in regard  of  support for FileNormalizedNameInformation