### PR TITLE
Update nf-winuser-getmenuitemcount.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getmenuitemcount.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getmenuitemcount.md
@@ -59,7 +59,7 @@ Determines the number of items in the specified menu.
 
 ## -parameters
 
-### -param hMenu [in, optional]
+### -param hMenu [in]
 
 Type: <b>HMENU</b>
 


### PR DESCRIPTION
It's not clear why the `hMenu` parameter is optional.