### PR TITLE
EnumResourceNames/Ex: Add remark about resource name lifetime for the callback

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesa.md
@@ -87,7 +87,7 @@ The return value is **TRUE** if the function succeeds or **FALSE** if the functi
 
 If [IS_INTRESOURCE](/windows/desktop/api/winuser/nf-winuser-is_intresource)(*lpszType*) is **TRUE**, then *lpszType* specifies the integer identifier of the given resource type. Otherwise, it is a pointer to a null-terminated string. If the first character of the string is a pound sign (#), then the remaining characters represent a decimal number that specifies the integer identifier of the resource type. For example, the string "#258" represents the identifier 258.
 
-For each resource found, **EnumResourceNames** calls an application-defined callback function *lpEnumFunc*, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to **EnumResourceNames**.
+For each resource found, **EnumResourceNames** calls an application-defined callback function *lpEnumFunc*, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to **EnumResourceNames**. The passed name is only valid inside the callback - if the passed name is a string pointer, it points to an internal buffer that is reused for all callback invocations.
 
 Alternately, applications can call [EnumResourceNamesEx](/windows/desktop/api/libloaderapi/nf-libloaderapi-enumresourcenamesexw), which provides more precise control of what resources are enumerated.
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesexa.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesexa.md
@@ -153,7 +153,7 @@ integer identifier of the resource type. For example, the string "#258" represen
 
 The enumeration search can include both an LN file and its associated .mui files. It can be limited to a single binary module of any type. It can also be limited to the .mui files associated with a single LN file. By specifying an LN file for the <i>hModule</i> parameter and a nonzero <i>LangId</i> parameter, the search can be limited to the unique .mui file associated with that LN file and language.
 
-For each resource found, <b>EnumResourceNamesEx</b> calls an application-defined callback function <i>lpEnumFunc</i>, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to <b>EnumResourceNamesEx</b>.
+For each resource found, <b>EnumResourceNamesEx</b> calls an application-defined callback function <i>lpEnumFunc</i>, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to <b>EnumResourceNamesEx</b>. The passed name is only valid inside the callback - if the passed name is a string pointer, it points to an internal buffer that is reused for all callback invocations.
 
 If a resource has an ID, the ID is returned to the callback function; otherwise the resource name is returned to the callback function. For more information, see <a href="/windows/win32/api/libloaderapi/nc-libloaderapi-enumresnameproca">EnumResNameProc</a>.
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesexw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesexw.md
@@ -153,7 +153,7 @@ integer identifier of the resource type. For example, the string "#258" represen
 
 The enumeration search can include both an LN file and its associated .mui files. It can be limited to a single binary module of any type. It can also be limited to the .mui files associated with a single LN file. By specifying an LN file for the <i>hModule</i> parameter and a nonzero <i>LangId</i> parameter, the search can be limited to the unique .mui file associated with that LN file and language.
 
-For each resource found, <b>EnumResourceNamesEx</b> calls an application-defined callback function <i>lpEnumFunc</i>, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to <b>EnumResourceNamesEx</b>.
+For each resource found, <b>EnumResourceNamesEx</b> calls an application-defined callback function <i>lpEnumFunc</i>, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to <b>EnumResourceNamesEx</b>. The passed name is only valid inside the callback - if the passed name is a string pointer, it points to an internal buffer that is reused for all callback invocations.
 
 If a resource has an ID, the ID is returned to the callback function; otherwise the resource name is returned to the callback function. For more information, see <a href="/windows/win32/api/libloaderapi/nc-libloaderapi-enumresnameproca">EnumResNameProc</a>.
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesw.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-enumresourcenamesw.md
@@ -88,7 +88,7 @@ The return value is **TRUE** if the function succeeds or **FALSE** if the functi
 
 If [IS_INTRESOURCE](/windows/desktop/api/winuser/nf-winuser-is_intresource)(*lpszType*) is **TRUE**, then *lpszType* specifies the integer identifier of the given resource type. Otherwise, it is a pointer to a null-terminated string. If the first character of the string is a pound sign (#), then the remaining characters represent a decimal number that specifies the integer identifier of the resource type. For example, the string "#258" represents the identifier 258.
 
-For each resource found, **EnumResourceNames** calls an application-defined callback function *lpEnumFunc*, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to **EnumResourceNames**.
+For each resource found, **EnumResourceNames** calls an application-defined callback function *lpEnumFunc*, passing the name or the ID of each resource it finds, as well as the various other parameters that were passed to **EnumResourceNames**. The passed name is only valid inside the callback - if the passed name is a string pointer, it points to an internal buffer that is reused for all callback invocations.
 
 Alternately, applications can call [EnumResourceNamesEx](/windows/desktop/api/libloaderapi/nf-libloaderapi-enumresourcenamesexw), which provides more precise control of what resources are enumerated.
 


### PR DESCRIPTION
The current docs do not specify if it's safe to use the returned resource name outside of the callback (e.g. storing it in a variable for later comparison). Since the whole PE module is loaded in memory, a feasible implementation could return a pointer to the string inside the mapped image, so it's not "obvious" that a single buffer is reused for all callback invocations.

From my testing, the functions reuse a single internal buffer where the resource name is copied (the pointer passed for string resource names is the same in all invocations). I'm adding a remark that describes this, and also clarifies that the callee does not need to free the pointed-to memory at the end of the callback.