### PR TITLE
IsDebuggerPresent: Remove redundant line about WINNT macro definition

### DIFF
--- a/sdk-api-src/content/debugapi/nf-debugapi-isdebuggerpresent.md
+++ b/sdk-api-src/content/debugapi/nf-debugapi-isdebuggerpresent.md
@@ -73,9 +73,6 @@ This function allows an application to determine whether or not it is being debu
 
 To determine whether a remote process is being debugged, use the <a href="/windows/desktop/api/debugapi/nf-debugapi-checkremotedebuggerpresent">CheckRemoteDebuggerPresent</a> function.
 
-To compile an application that uses this function, define the _WIN32_WINNT macro as 0x0400 or later. For more information, see 
-<a href="/windows/desktop/WinProg/using-the-windows-headers">Using the Windows Headers</a>.
-
 ## -see-also
 
 <a href="/windows/desktop/api/debugapi/nf-debugapi-checkremotedebuggerpresent">CheckRemoteDebuggerPresent</a>

--- a/sdk-api-src/content/debugapi/nf-debugapi-isdebuggerpresent.md
+++ b/sdk-api-src/content/debugapi/nf-debugapi-isdebuggerpresent.md
@@ -11,8 +11,8 @@ ms.keywords: IsDebuggerPresent, IsDebuggerPresent function, _win32_isdebuggerpre
 req.header: debugapi.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows XP [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2003 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows NT Workstation 4.0 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows NT Server 4.0 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
Problem: Currently the doc about IsDebuggerPresent claims that you need to define the _WIN32_WINNT macro to use this function, even though this macro is defined automatically on a clean build with ```cl```:

```
#include <windows.h>
#include <stdio.h>

void main()
{
	printf("WIN32_WINNT: %x\n", _WIN32_WINNT);
	printf("DbgPresent: %d\n", IsDebuggerPresent());
}
```

```
cl main.c
main.exe
```

will output on my Win10 machine as expected:
```
WIN32_WINNT: a00
DbgPresent: 0
```

Solution: Remove the sentence about this macro, this it is not something that the users of this function need to take care of, the bottom of the page mention the minimum OS requirement anyway.