### PR TITLE
Get(/Thread)ErrorMode: Add missing possible return value

### DIFF
--- a/sdk-api-src/content/errhandlingapi/nf-errhandlingapi-geterrormode.md
+++ b/sdk-api-src/content/errhandlingapi/nf-errhandlingapi-geterrormode.md
@@ -73,6 +73,16 @@ The process error mode. This function returns one of the following values.
 <tr>
 <td width="40%">
 <dl>
+<dt>0</dt>
+</dl>
+</td>
+<td width="60%">
+Uses the system default, which displays all error dialog boxes.
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
 <dt><b>SEM_FAILCRITICALERRORS</b></dt>
 <dt>0x0001</dt>
 </dl>

--- a/sdk-api-src/content/errhandlingapi/nf-errhandlingapi-getthreaderrormode.md
+++ b/sdk-api-src/content/errhandlingapi/nf-errhandlingapi-getthreaderrormode.md
@@ -68,6 +68,16 @@ The process error mode. This function returns one of the following values.
 <tr>
 <td width="40%">
 <dl>
+<dt>0</dt>
+</dl>
+</td>
+<td width="60%">
+Uses the system default, which is to display all error dialog boxes.
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
 <dt><b>SEM_FAILCRITICALERRORS</b></dt>
 <dt>0x0001</dt>
 </dl>


### PR DESCRIPTION
Copied the meaning of the zero return value from ```SetErrorMode```, the following code verifies this:

```
#include <windows.h>
#include <stdio.h>

int main()
{
	SetErrorMode(0); // or SetThread..
	printf("the error mode is %d\n", GetErrorMode()); // or GetThread..
}
```