### PR TITLE
Unify the Private Data docs between D3D9-D3D12

### DIFF
--- a/sdk-api-src/content/d3d10/nf-d3d10-id3d10device-getprivatedata.md
+++ b/sdk-api-src/content/d3d10/nf-d3d10-id3d10device-getprivatedata.md
@@ -81,9 +81,7 @@ This method returns one of the following <a href="/windows/desktop/direct3d10/d3
 
 ## -remarks
 
-The data stored in the device is set with <a href="/windows/desktop/api/d3d10/nf-d3d10-id3d10device-setprivatedata">ID3D10Device::SetPrivateData</a>. 
-
-The data retrieved and the guid will typically be application-defined.
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateDataInterface**, that interface will have its reference count incremented before the private data is returned.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d10/nf-d3d10-id3d10device-setprivatedatainterface.md
+++ b/sdk-api-src/content/d3d10/nf-d3d10-id3d10device-setprivatedatainterface.md
@@ -65,17 +65,13 @@ Guid associated with the interface.
 
 Type: <b>const IUnknown*</b>
 
-Pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>-derived interface to be associated with the device.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device object. Its reference count is incremented when set, and decremented when either the [ID3D10Device](/windows/win32/api/d3d10/nn-d3d10-id3d10device) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d10/nf-d3d10-id3d10device-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
 This method returns one of the following <a href="/windows/desktop/direct3d10/d3d10-graphics-reference-returnvalues">Direct3D 10 Return Codes</a>.
-
-## -remarks
-
-When this method is called ::addref() will be called on the IUnknown-derived interface, and when the device is destroyed ::release() will be called on the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>-derived interface.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d10/nf-d3d10-id3d10devicechild-getprivatedata.md
+++ b/sdk-api-src/content/d3d10/nf-d3d10-id3d10devicechild-getprivatedata.md
@@ -81,7 +81,7 @@ This method returns one of the following <a href="/windows/desktop/direct3d10/d3
 
 ## -remarks
 
-The data stored in the device child is set with <a href="/windows/desktop/api/d3d10/nf-d3d10-id3d10devicechild-setprivatedata">ID3D10DeviceChild::SetPrivateData</a>.
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateDataInterface**, that interface will have its reference count incremented before the private data is returned.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d10/nf-d3d10-id3d10devicechild-setprivatedatainterface.md
+++ b/sdk-api-src/content/d3d10/nf-d3d10-id3d10devicechild-setprivatedatainterface.md
@@ -65,17 +65,13 @@ Guid associated with the interface.
 
 Type: <b>const IUnknown*</b>
 
-Pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>-derived interface to be associated with the device child.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device child. Its reference count is incremented when set, and decremented when either the [ID3D10DeviceChild](/windows/win32/api/d3d10/nn-d3d10-id3d10devicechild) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d10/nf-d3d10-id3d10devicechild-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
 This method returns one of the following <a href="/windows/desktop/direct3d10/d3d10-graphics-reference-returnvalues">Direct3D 10 Return Codes</a>.
-
-## -remarks
-
-When this method is called ::addref() will be called on the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>-derived interface, and when the device child is destroyed ::release() will be called on the IUnknown-derived interface.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11device-getprivatedata.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11device-getprivatedata.md
@@ -81,7 +81,7 @@ This method returns one of the codes described in the topic <a href="/windows/de
 
 ## -remarks
 
-If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by SetPrivateDataInterface, that interface will have its reference count incremented before the private data is returned.
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateDataInterface**, that interface will have its reference count incremented before the private data is returned.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11device-setprivatedatainterface.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11device-setprivatedatainterface.md
@@ -65,7 +65,7 @@ Guid associated with the interface.
 
 Type: <b>const IUnknown*</b>
 
-Pointer to an IUnknown-derived interface to be associated with the device child.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device object. Its reference count is incremented when set, and decremented when either the [ID3D11Device](/windows/win32/api/d3d11/nn-d3d11-id3d11device) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d11/nf-d3d11-id3d11device-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicechild-getprivatedata.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicechild-getprivatedata.md
@@ -86,7 +86,7 @@ This method returns one of the
 
 The data stored in the device child is set by calling <a href="/windows/desktop/api/d3d11/nf-d3d11-id3d11devicechild-setprivatedata">ID3D11DeviceChild::SetPrivateData</a>.
         
-If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by SetPrivateDataInterface, that interface will have its reference count incremented before the private data is returned.
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateDataInterface**, that interface will have its reference count incremented before the private data is returned.
 
 <b>Windows Phone 8:
         </b> This API is supported.

--- a/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicechild-setprivatedatainterface.md
+++ b/sdk-api-src/content/d3d11/nf-d3d11-id3d11devicechild-setprivatedatainterface.md
@@ -65,17 +65,13 @@ Guid associated with the interface.
 
 Type: <b>const IUnknown*</b>
 
-Pointer to an IUnknown-derived interface to be associated with the device child.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device child. Its reference count is incremented when set, and decremented when either the [ID3D11DeviceChild](/windows/win32/api/d3d11/nn-d3d11-id3d11devicechild) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d11/nf-d3d11-id3d11devicechild-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
 This method returns one of the following <a href="/windows/desktop/direct3d11/d3d11-graphics-reference-returnvalues">Direct3D 11 Return Codes</a>.
-
-## -remarks
-
-When this method is called ::addref() will be called on the IUnknown-derived interface, and when the device child is destroyed ::release() will be called on the IUnknown-derived interface.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12object-getprivatedata.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12object-getprivatedata.md
@@ -80,7 +80,7 @@ This method returns one of the <a href="/windows/desktop/direct3d12/d3d12-graphi
 
 ## -remarks
 
-If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by SetPrivateDataInterface, that interface will have its reference count incremented before the private data is returned.
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateDataInterface**, that interface will have its reference count incremented before the private data is returned.
 
 ## -see-also
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12object-setprivatedatainterface.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12object-setprivatedatainterface.md
@@ -61,7 +61,7 @@ The **GUID** to associate with the interface.
 
 Type: **const [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)\***
 
-A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device object. Its reference count is incremented when set, and its reference count is decremented when either the [ID3D12Object](/windows/win32/api/d3d12/nn-d3d12-id3d12object) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d12/nf-d3d12-id3d12object-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device object. Its reference count is incremented when set, and decremented when either the [ID3D12Object](/windows/win32/api/d3d12/nn-d3d12-id3d12object) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/d3d12/nf-d3d12-id3d12object-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 

--- a/sdk-api-src/content/d3d9/nf-d3d9-idirect3dvolume9-getprivatedata.md
+++ b/sdk-api-src/content/d3d9/nf-d3d9-idirect3dvolume9-getprivatedata.md
@@ -80,6 +80,10 @@ Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></
 
 If the method succeeds, the return value is D3D_OK. If the method fails, the return value can be one of the following: D3DERR_INVALIDCALL, D3DERR_MOREDATA, D3DERR_NOTFOUND.
 
+## -remarks
+
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateData** with a `D3DSPD_IUNKNOWN` flag, that interface will have its reference count incremented before the private data is returned.
+
 ## -see-also
 
 <a href="/windows/desktop/api/d3d9helper/nn-d3d9helper-idirect3dvolume9">IDirect3DVolume9</a>

--- a/sdk-api-src/content/d3d9helper/nf-d3d9helper-idirect3dresource9-getprivatedata.md
+++ b/sdk-api-src/content/d3d9helper/nf-d3d9helper-idirect3dresource9-getprivatedata.md
@@ -97,6 +97,8 @@ This method is inherited by the following interfaces:
     
 <a href="/windows/desktop/api/d3d9helper/nn-d3d9helper-idirect3dvertexbuffer9">IDirect3DVertexBuffer9</a>.
 
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateData** with a `D3DSPD_IUNKNOWN` flag, that interface will have its reference count incremented before the private data is returned.
+
 ## -see-also
 
 <a href="/windows/desktop/api/d3d9helper/nn-d3d9helper-idirect3dresource9">IDirect3DResource9</a>

--- a/sdk-api-src/content/d3d9helper/nf-d3d9helper-idirect3dvolume9-getprivatedata.md
+++ b/sdk-api-src/content/d3d9helper/nf-d3d9helper-idirect3dvolume9-getprivatedata.md
@@ -80,6 +80,10 @@ Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></
 
 If the method succeeds, the return value is D3D_OK. If the method fails, the return value can be one of the following: D3DERR_INVALIDCALL, D3DERR_MOREDATA, D3DERR_NOTFOUND.
 
+## -remarks
+
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateData** with a `D3DSPD_IUNKNOWN` flag, that interface will have its reference count incremented before the private data is returned.
+
 ## -see-also
 
 <a href="/windows/desktop/api/d3d9helper/nn-d3d9helper-idirect3dvolume9">IDirect3DVolume9</a>

--- a/sdk-api-src/content/ddraw/nf-ddraw-idirectdrawsurface7-getprivatedata.md
+++ b/sdk-api-src/content/ddraw/nf-ddraw-idirectdrawsurface7-getprivatedata.md
@@ -85,6 +85,8 @@ If it fails, the method can return one of the following error values:
 
 ## -remarks
 
+If the data returned is a pointer to an <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>, or one of its derivative classes, which was previously set by **SetPrivateData** with a `DDSPD_IUNKNOWNPOINTER` flag, that interface will have its reference count incremented before the private data is returned.
+
 
 
 ## -see-also

--- a/sdk-api-src/content/dxgi/nf-dxgi-idxgiobject-setprivatedatainterface.md
+++ b/sdk-api-src/content/dxgi/nf-dxgi-idxgiobject-setprivatedatainterface.md
@@ -65,19 +65,13 @@ A GUID identifying the interface.
 
 Type: <b>const <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a>*</b>
 
-The interface to set.
+A pointer to the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown)-derived interface to be associated with the device object. Its reference count is incremented when set, and decremented when either the [IDXGIObject](/windows/win32/api/dxgi/nn-dxgi-idxgiobject) is destroyed, or when the data is overwritten by calling [SetPrivateData](/windows/win32/api/dxgi/nf-dxgi-idxgiobject-setprivatedata) or **SetPrivateDataInterface** with the same **GUID**.
 
 ## -returns
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
 Returns one of the following <a href="/windows/desktop/direct3ddxgi/dxgi-error">DXGI_ERROR</a>.
-
-## -remarks
-
-This API associates an interface pointer with the object.
-
-When the interface is set its reference count is incremented. When the data are overwritten (by calling SPD or SPDI with the same GUID) or the object is destroyed, ::Release() is called and the interface's reference count is decremented.
 
 ## -see-also
 


### PR DESCRIPTION
Uses D3D12 wording as a template as it was the most exhaustive. With these changes, private data should consistently document the `IUnknown`-type data that was previously lacking.

This repository contains D3D7 docs, but D3D8 docs seem to be archived and un-editable? They would need the changes from D3D9 mirrored.