### PR TITLE
CreateEventEx: Clarify that zero flags is also OK

### DIFF
--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be 0 or more of the following values.
+This parameter can be 0 or one of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be zero or more of the following values.
+This parameter can be 0 or more of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexa.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be one or more of the following values.
+This parameter can be zero or more of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be 0 or more of the following values.
+This parameter can be 0 or one of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be zero or more of the following values.
+This parameter can be 0 or more of the following values.
 
 <table>
 <tr>

--- a/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
+++ b/sdk-api-src/content/synchapi/nf-synchapi-createeventexw.md
@@ -93,7 +93,7 @@ The object can be created in a private namespace. For more information, see <a h
 
 ### -param dwFlags [in]
 
-This parameter can be one or more of the following values.
+This parameter can be zero or more of the following values.
 
 <table>
 <tr>


### PR DESCRIPTION
Clarify that it is also possible to pass zero flags to the ```dwFlags``` param and it is not required to pass at least one of the flags. Similar to how it is written in ```CreateMutexExW```

Confirmed that passing zero flags works as expected with WinObj:

![image](https://github.com/user-attachments/assets/b6cd6107-8f8c-44fd-9de6-9c80df40fd62)
