### PR TITLE
Document HWNDPARENT (-8) for SetWindowLong... to Clarify Window Ownership

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
@@ -243,6 +243,8 @@ Do not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change 
 
 <b>GWL_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
+A window can have either a parent or an owner, or neither, but never both simultaneously.
+
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_OWNDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 
 Calling <b>SetWindowLong</b> to set the style on a progressbar will reset its position.

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlonga.md
@@ -106,6 +106,17 @@ Sets a new application instance handle.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="GWL_HWNDPARENT"></a><a id="gwl_hwndparent"></a><dl>
+<dt><b>GWL_HWNDPARENT</b></dt>
+<dt>-8</dt>
+</dl>
+</td>
+<td width="60%">
+Sets a new owner for a top-level window.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="GWL_ID"></a><a id="gwl_id"></a><dl>
 <dt><b>GWL_ID</b></dt>
 <dt>-12</dt>
@@ -228,7 +239,9 @@ Calling <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index creates a subclas
 Reserve extra window memory by specifying a nonzero value in the 
 				<b>cbWndExtra</b> member of the <a href="/windows/desktop/api/winuser/ns-winuser-wndclassexa">WNDCLASSEX</a> structure used with the <a href="/windows/desktop/api/winuser/nf-winuser-registerclassexa">RegisterClassEx</a> function. 
 
-You must not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+Do not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+
+<b>GWL_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_OWNDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
@@ -243,6 +243,8 @@ Do not call <b>SetWindowLongPtr</b> with the <b>GWLP_HWNDPARENT</b> index to cha
 
 <b>GWLP_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
+A window can have either a parent or an owner, or neither, but never both simultaneously.
+
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 
  Calling <b>SetWindowLongPtr</b> to set the style on a progressbar will reset its position.

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptra.md
@@ -108,6 +108,17 @@ Sets a new application instance handle.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="GWLP_HWNDPARENT"></a><a id="gwlp_hwndparent"></a><dl>
+<dt><b>GWLP_HWNDPARENT</b></dt>
+<dt>-8</dt>
+</dl>
+</td>
+<td width="60%">
+Sets a new owner for a top-level window.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="GWLP_ID"></a><a id="gwlp_id"></a><dl>
 <dt><b>GWLP_ID</b></dt>
 <dt>-12</dt>
@@ -229,6 +240,8 @@ Reserve extra window memory by specifying a nonzero value in the
 				<b>cbWndExtra</b> member of the <a href="/windows/desktop/api/winuser/ns-winuser-wndclassexa">WNDCLASSEX</a> structure used with the <a href="/windows/desktop/api/winuser/nf-winuser-registerclassexa">RegisterClassEx</a> function. 
 
 Do not call <b>SetWindowLongPtr</b> with the <b>GWLP_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+
+<b>GWLP_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
@@ -243,6 +243,8 @@ Do not call <b>SetWindowLongPtr</b> with the <b>GWLP_HWNDPARENT</b> index to cha
 
 <b>GWLP_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
+A window can have either a parent or an owner, or neither, but never both simultaneously.
+
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 
  Calling <b>SetWindowLongPtr</b> to set the style on a progressbar will reset its position.

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongptrw.md
@@ -108,6 +108,17 @@ Sets a new application instance handle.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="GWLP_HWNDPARENT"></a><a id="gwlp_hwndparent"></a><dl>
+<dt><b>GWLP_HWNDPARENT</b></dt>
+<dt>-8</dt>
+</dl>
+</td>
+<td width="60%">
+Sets a new owner for a top-level window.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="GWLP_ID"></a><a id="gwlp_id"></a><dl>
 <dt><b>GWLP_ID</b></dt>
 <dt>-12</dt>
@@ -229,6 +240,8 @@ Reserve extra window memory by specifying a nonzero value in the
 				<b>cbWndExtra</b> member of the <a href="/windows/desktop/api/winuser/ns-winuser-wndclassexa">WNDCLASSEX</a> structure used with the <a href="/windows/desktop/api/winuser/nf-winuser-registerclassexa">RegisterClassEx</a> function. 
 
 Do not call <b>SetWindowLongPtr</b> with the <b>GWLP_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+
+<b>GWLP_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_PARENTDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
@@ -243,6 +243,8 @@ Do not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change 
 
 <b>GWL_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
+A window can have either a parent or an owner, or neither, but never both simultaneously.
+
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_OWNDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 
 Calling <b>SetWindowLong</b> to set the style on a progressbar will reset its position.

--- a/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
+++ b/sdk-api-src/content/winuser/nf-winuser-setwindowlongw.md
@@ -106,6 +106,17 @@ Sets a new application instance handle.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="GWL_HWNDPARENT"></a><a id="gwl_hwndparent"></a><dl>
+<dt><b>GWL_HWNDPARENT</b></dt>
+<dt>-8</dt>
+</dl>
+</td>
+<td width="60%">
+Sets a new owner for a top-level window.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="GWL_ID"></a><a id="gwl_id"></a><dl>
 <dt><b>GWL_ID</b></dt>
 <dt>-12</dt>
@@ -228,7 +239,9 @@ Calling <b>SetWindowLong</b> with the <b>GWL_WNDPROC</b> index creates a subclas
 Reserve extra window memory by specifying a nonzero value in the 
 				<b>cbWndExtra</b> member of the <a href="/windows/desktop/api/winuser/ns-winuser-wndclassexa">WNDCLASSEX</a> structure used with the <a href="/windows/desktop/api/winuser/nf-winuser-registerclassexa">RegisterClassEx</a> function. 
 
-You must not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+Do not call <b>SetWindowLong</b> with the <b>GWL_HWNDPARENT</b> index to change the parent of a child window. Instead, use the <a href="/windows/desktop/api/winuser/nf-winuser-setparent">SetParent</a> function. 
+
+<b>GWL_HWNDPARENT</b> is used to change the owner of a top-level window, not the parent of a child window.
 
 If the window has a class style of <b>CS_CLASSDC</b> or <b>CS_OWNDC</b>, do not set the extended window styles <b>WS_EX_COMPOSITED</b> or <b>WS_EX_LAYERED</b>.
 


### PR DESCRIPTION
#### **Summary**  
This PR adds `HWNDPARENT (-8)` to the documentation for `SetWindowLong...` functions. This value exists in the Windows API but was not previously documented. The update clarifies its role and ensures developers can use it correctly.  

#### **Reason for Change**  
- `HWNDPARENT` is a valid window attribute that allows setting the **owner** of a top-level window.  
- The documentation did not mention this, making it unclear how to properly set window ownership.  
- This change helps developers understand the correct use of `SetWindowLong...` when managing window relationships.  

#### **Changes Made**  
- Added `HWNDPARENT (-8)` to the table of valid `SetWindowLong...` values.  
- Provided a short description of its function.  
- Clarified the difference between parent and owner relationships.  

#### **Impact**  
- Improves documentation clarity.  
- Helps developers avoid confusion between `SetWindowLongPtr(GWLP_HWNDPARENT)` and `SetParent()`.  
- Prevents misuse.  

#### **Sources**
- PDC 2005 - Five Things Every Win32 Developer Should Know - *Raymond Chen* - 2005/09 [Slide 32](https://image.slidesharecdn.com/fun412chen-120811232150-phpapp01/95/five-things-every-win32-developer-should-know-32-728.jpg?cb=1344727818)
[YouTube Video - minute: 52:00](https://youtu.be/rusDBeXe_u8)
- Devblogs - A window can have a parent or an owner but not both - *Raymond Chen* - March 15th, 2010 [link](https://devblogs.microsoft.com/oldnewthing/20100315-00/?p=14613)

#### **Additional Context**
In the first mentioned source above, I’m not sure if the "Set Owner Window" approach was presented solely as a hack, but it is an effective solution that proves useful in many scenarios. It is widely used by developers, including in WPF, as seen in the [WPF source code](https://github.com/dotnet/wpf/blob/main/src%2FMicrosoft.DotNet.Wpf%2Fsrc%2FPresentationFramework%2FSystem%2FWindows%2FWindow.cs#L4183). Personally, I use this approach in WinUI 3 by leveraging C#/Win32 P/Invoke, as demonstrated in this [use case example](https://github.com/Zakariathr22/ModalWindowExample/blob/8773ccde0e1a5e75ebc81925516554e74b12bc0b/ModalWindowExample/ModalWindow.xaml.cs#L55).

Please let me know if any further improvements are needed!