### PR TITLE
Update ns-wingdi-devmodew.md

### DIFF
--- a/sdk-api-src/content/wingdi/ns-wingdi-devmodew.md
+++ b/sdk-api-src/content/wingdi/ns-wingdi-devmodew.md
@@ -181,7 +181,7 @@ DMDO_90
 
 </td>
 <td>
-The display device orientation is 90 degrees (measured clockwise) from that of DMDO_DEFAULT.
+The display device orientation is 90 degrees (measured counter-clockwise) from that of DMDO_DEFAULT.
 
 </td>
 </tr>
@@ -191,7 +191,7 @@ DMDO_180
 
 </td>
 <td>
-The display device orientation is 180 degrees (measured clockwise) from that of DMDO_DEFAULT.
+The display device orientation is 180 degrees (measured counter-clockwise) from that of DMDO_DEFAULT.
 
 </td>
 </tr>
@@ -201,7 +201,7 @@ DMDO_270
 
 </td>
 <td>
-The display device orientation is 270 degrees (measured clockwise) from that of DMDO_DEFAULT.
+The display device orientation is 270 degrees (measured counter-clockwise) from that of DMDO_DEFAULT.
 
 </td>
 </tr>


### PR DESCRIPTION
Corrected `dmDisplayOrientation` table. The test code below seems to indicate that the angles are counter-clockwise (not clockwise) from `DMDO_DEFAULT`.

```
#include <iostream>
#include <windows.h>

int main()
{
    DEVMODE dm;
    // initialize the DEVMODE structure
    ZeroMemory(&dm, sizeof(dm));
    dm.dmSize = sizeof(dm);

    if (0 != EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dm))
    {
        // rotate the display 90 degrees from DMDO_DEFAULT

        DWORD dwCurrentWidth = dm.dmPelsWidth;
        DWORD dwCurrentHeight = dm.dmPelsHeight;
        dm.dmPelsWidth = dwCurrentHeight;
        dm.dmPelsHeight = dwCurrentWidth;
        dm.dmDisplayOrientation = DMDO_90;
        ChangeDisplaySettings(&dm, 0);

        std::cout << "Press Enter to continue..." << std::endl;
        std::cin.get();

        // restore the default orientation

        dm.dmPelsWidth = dwCurrentWidth;
        dm.dmPelsHeight = dwCurrentHeight;
        dm.dmDisplayOrientation = DMDO_DEFAULT;
        ChangeDisplaySettings(&dm, 0);
    }
}
