### PR TITLE
Update ne-wingdi-displayconfig_pixelformat.md

### DIFF
--- a/sdk-api-src/content/wingdi/ne-wingdi-displayconfig_pixelformat.md
+++ b/sdk-api-src/content/wingdi/ne-wingdi-displayconfig_pixelformat.md
@@ -74,7 +74,7 @@ Indicates 32 BPP format.
 
 Indicates that the current display is not an 8, 16, 24, or 32 BPP GDI desktop mode. For example, a call to the <a href="/windows/desktop/api/winuser/nf-winuser-querydisplayconfig">QueryDisplayConfig</a> function returns DISPLAYCONFIG_PIXELFORMAT_NONGDI if a DirectX application previously set the desktop to A2R10G10B10 format. A call to the <a href="/windows/desktop/api/winuser/nf-winuser-setdisplayconfig">SetDisplayConfig</a> function fails if any pixel formats for active paths are set to DISPLAYCONFIG_PIXELFORMAT_NONGDI.
 
-### -field DISPLAYCONFIG_PIXELFORMAT_FORCE_UINT32:0xffffffff
+### -field DISPLAYCONFIG_PIXELFORMAT_FORCE_UINT32:0xFFFFFFFF
 
 Forces this enumeration to compile to 32 bits in size. Without this value, some compilers would allow this enumeration to compile to a size other than 32 bits. You should not use this value.
 


### PR DESCRIPTION
Changed `0xffffffff` to `0xFFFFFFFF` for consistency with other enumerations, e.g. [DISPLAYCONFIG_MODE_INFO_TYPE](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ne-wingdi-displayconfig_mode_info_type).