### PR TITLE
Undocumented error 12058

### DIFF
--- a/sdk-api-src/content/wininet/nf-wininet-ftpopenfilea.md
+++ b/sdk-api-src/content/wininet/nf-wininet-ftpopenfilea.md
@@ -211,6 +211,8 @@ After calling
 
 Only one file can be open in a single FTP session. Therefore, no file handle is returned and the application simply uses the FTP session handle when necessary.
 
+Undocumented error 12058 can occur when FtpOpenFile function fails due to a lack of available local ports.
+
 The 
 <i>lpszFileName</i> parameter can be either a partially or fully qualified file name relative to the current directory.
 

--- a/sdk-api-src/content/wininet/nf-wininet-ftpopenfilea.md
+++ b/sdk-api-src/content/wininet/nf-wininet-ftpopenfilea.md
@@ -47,9 +47,6 @@ api_name:
  - FtpOpenFileW
 ---
 
-# FtpOpenFileA function
-
-
 ## -description
 
 Initiates access to a remote file on an FTP server for reading or writing.
@@ -211,7 +208,7 @@ After calling
 
 Only one file can be open in a single FTP session. Therefore, no file handle is returned and the application simply uses the FTP session handle when necessary.
 
-Undocumented error 12058 can occur when FtpOpenFile function fails due to a lack of available local ports.
+Error 12058 can occur if **FtpOpenFileA** fails due to a lack of available local ports.
 
 The 
 <i>lpszFileName</i> parameter can be either a partially or fully qualified file name relative to the current directory.


### PR DESCRIPTION
Undocumented error 12058 can occur when FtpOpenFile function fails due to a lack of available local ports.
Test case: copying several thousand small files to FTP.
Process Monitor detects access to previously closed TCP connection that is in TIME-WAIT state:
```
8:29:39,8170258	JustManager.exe	1372	TCP Connect	PC:51100 -> PC:51101	SUCCESS	Length: 0, mss: 1460, sackopt: 1, tsopt: 0, wsopt: 1, rcvwin: 8192, rcvwinscale: 8, sndwinscale: 8, seqnum: 0, connid: 0
8:29:39,8177204	JustManager.exe	1372	TCP Send	PC:51100 -> PC:51101	SUCCESS	Length: 48, startime: 48918, endtime: 48918, seqnum: 0, connid: 0
8:29:39,8179216	JustManager.exe	1372	TCP Disconnect	PC:51100 -> PC:51101	SUCCESS	Length: 0, seqnum: 0, connid: 0
8:30:10,1349327	JustManager.exe	1372	TCP Disconnect	PC:51100 -> PC:51101	SUCCESS	Length: 0, seqnum: 0, connid: 0
```
Callstack:
```
0	ntoskrnl.exe	EtwpTraceNetwork + 0x53	0xfffff80003182833	C:\Windows\system32\ntoskrnl.exe
1	tcpip.sys	 ?? ::FNODOBFM::`string' + 0x280cc	0xfffff880016bb330	C:\Windows\System32\drivers\tcpip.sys
2	tcpip.sys	TcpCloseTcb + 0x84	0xfffff8800167bde4	C:\Windows\System32\drivers\tcpip.sys
3	tcpip.sys	TcpCreateAndConnectTcbRateLimitComplete + 0x4ab	0xfffff8800167807b	C:\Windows\System32\drivers\tcpip.sys
4	tcpip.sys	TcpCreateAndConnectTcbInspectConnectComplete + 0x47	0xfffff88001677327	C:\Windows\System32\drivers\tcpip.sys
5	tcpip.sys	TcpContinueCreateAndConnect + 0x7f4	0xfffff880016772b4	C:\Windows\System32\drivers\tcpip.sys
6	tcpip.sys	TcpCreateAndConnectTcbInspectConnectRequestComplete + 0x5c	0xfffff8800167aa5c	C:\Windows\System32\drivers\tcpip.sys
7	tcpip.sys	TcpCreateAndConnectTcbWorkQueueRoutine + 0x273	0xfffff88001679e33	C:\Windows\System32\drivers\tcpip.sys
8	tcpip.sys	TcpCreateAndConnectTcb + 0xade	0xfffff8800167a98e	C:\Windows\System32\drivers\tcpip.sys
9	tdx.sys	TdxConnectConnection + 0x4dd	0xfffff88003c8e45d	C:\Windows\system32\DRIVERS\tdx.sys
10	tdx.sys	TdxTdiDispatchInternalDeviceControl + 0x39d	0xfffff88003c8cc3d	C:\Windows\system32\DRIVERS\tdx.sys
11	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x2dc1	0xfffff88003cc3871	C:\Windows\system32\Drivers\AMonTDLH.sys
12	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x2caf	0xfffff88003cc375f	C:\Windows\system32\Drivers\AMonTDLH.sys
13	AMonTDLH.sys	AMonTDLH.sys + 0x351a	0xfffff88003cbb51a	C:\Windows\system32\Drivers\AMonTDLH.sys
14	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x684	0xfffff88003cc1134	C:\Windows\system32\Drivers\AMonTDLH.sys
15	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x807	0xfffff88003cc12b7	C:\Windows\system32\Drivers\AMonTDLH.sys
16	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0xa47	0xfffff88003cc14f7	C:\Windows\system32\Drivers\AMonTDLH.sys
17	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x5847	0xfffff88003cc62f7	C:\Windows\system32\Drivers\AMonTDLH.sys
18	AMonTDLH.sys	IAnfdTDSetRemoteIpPortV4V6 + 0x8eb	0xfffff88003cc139b	C:\Windows\system32\Drivers\AMonTDLH.sys
19	afd.sys	 ?? ::GFJBLGFE::`string' + 0x79be	0xfffff88003d372bb	C:\Windows\system32\drivers\afd.sys
20	ntoskrnl.exe	IopSynchronousServiceTail + 0xfa	0xfffff800033191fa	C:\Windows\system32\ntoskrnl.exe
21	ntoskrnl.exe	IopXxxControlFile + 0xc51	0xfffff800034d68b1	C:\Windows\system32\ntoskrnl.exe
22	ntoskrnl.exe	NtDeviceIoControlFile + 0x56	0xfffff800033673c6	C:\Windows\system32\ntoskrnl.exe
23	ntoskrnl.exe	KiSystemServiceCopyEnd + 0x13	0xfffff800030bff53	C:\Windows\system32\ntoskrnl.exe
24	ntdll.dll	ZwDeviceIoControlFile + 0xa	0x7777981a	C:\Windows\SYSTEM32\ntdll.dll
25	MSWSOCK.dll	_GSHandlerCheck_SEH + 0x2d10	0x7fefc9b0547	C:\Windows\system32\MSWSOCK.dll
26	MSWSOCK.dll	SockDoConnect + 0x366	0x7fefc9a5c09	C:\Windows\system32\MSWSOCK.dll
27	MSWSOCK.dll	WSPConnect + 0x2a	0x7fefc9a599a	C:\Windows\system32\MSWSOCK.dll
28	WS2_32.dll	connect + 0xac	0x7fefea0439c	C:\Windows\system32\WS2_32.dll
29	WININET.dll	CWxSocket::DirectConnect + 0x9e	0x7fefe498886	C:\Windows\system32\WININET.dll
30	WININET.dll	ICSocket::DirectConnect + 0x112	0x7fefe42c2f6	C:\Windows\system32\WININET.dll
31	WININET.dll	I_NegotiateDataConnection + 0x4d9	0x7fefe43a905	C:\Windows\system32\WININET.dll
32	WININET.dll	I_AttemptDataNegotiation + 0x65	0x7fefe43a3c5	C:\Windows\system32\WININET.dll
33	WININET.dll	NegotiateDataConnection + 0x4e	0x7fefe43b7a6	C:\Windows\system32\WININET.dll
34	WININET.dll	wFtpOpenFile + 0x102	0x7fefe436242	C:\Windows\system32\WININET.dll
35	WININET.dll	InternalFtpOpenFileA + 0x380	0x7fefe431e5c	C:\Windows\system32\WININET.dll
36	WININET.dll	FtpOpenFileA + 0x8e	0x7fefe43018e	C:\Windows\system32\WININET.dll
```
Quite often this error is accompanied by event 4227 (EVENT_TCPIP_TCP_TIME_WAIT_COLLISION).
Error detected on Windows 7 SP1 x64.

Need to be checked by someone with access to WinINet code. Obviously, this error should be added to Wininet.h and described in [wininet-errors article](https://learn.microsoft.com/en-us/windows/win32/wininet/wininet-errors).