### PR TITLE
Update misleading informations in NtNotifyChangeMultipleKeys

### DIFF
--- a/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
@@ -62,11 +62,11 @@ A handle to an open key. The handle must be opened with the <b>KEY_NOTIFY</b> ac
 
 ### -param Count [in, optional]
 
-The number of subkeys under the key specified by the <i>MasterKeyHandle</i> parameter. This parameter must be 1.
+The number of keys objects provided in the <i>SubordinateObjects</i> parameter. This parameter must be 1.
 
 ### -param SubordinateObjects [in, optional]
 
-Pointer to an array of <a href="/windows-hardware/drivers/ddi/content/wudfwdm/ns-wudfwdm-_object_attributes">OBJECT_ATTRIBUTES</a> structures, one for each subkey.   This array can contain one <b>OBJECT_ATTRIBUTES</b> structure.
+Pointer to an array of <a href="/windows-hardware/drivers/ddi/content/wudfwdm/ns-wudfwdm-_object_attributes">OBJECT_ATTRIBUTES</a> structures, one for each key.   This array can contain one <b>OBJECT_ATTRIBUTES</b> structure and you can't provide a key in the same hive as the <i>MasterKeyHandle</i> key.
 
 ### -param Event [in, optional]
 
@@ -74,11 +74,11 @@ A handle to an event created by the caller. If <i>Event</i> is not <b>NULL</b>, 
 
 ### -param ApcRoutine [in, optional]
 
-A pointer to an asynchronous procedure call (APC) function supplied by the caller. If <i>ApcRoutine</i> is not <b>NULL</b>, the specified APC function executes after the operation completes.
+A pointer to an asynchronous procedure call (APC) function supplied by the caller. If <i>ApcRoutine</i> is not <b>NULL</b>, the specified APC function executes after the operation completes. A <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-_work_queue_item">WORK_QUEUE_ITEM</a> must be provided instead of ApcRoutine in the <i>ZwNotifyChangeMultipleKeys</i> variant.
 
 ### -param ApcContext [in, optional]
 
-A pointer to a context supplied by the caller for its APC function. This value is passed to the APC function when it is executed. The <i>Asynchronous</i> parameter must be <b>TRUE</b>. If <i>ApcContext</i> is specified, the <i>Event</i> parameter must be <b>NULL</b>.
+A pointer to a context supplied by the caller for its APC function. This value is passed to the APC function when it is executed. The <i>Asynchronous</i> parameter must be <b>TRUE</b>. If <i>ApcContext</i> is specified, the <i>Event</i> parameter must be <b>NULL</b>. A <a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-_work_queue_type">WORK_QUEUE_TYPE</a> must be provided instead of ApcContext in the <i>ZwNotifyChangeMultipleKeys</i> variant.
 
 ### -param IoStatusBlock [out]
 

--- a/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntnotifychangemultiplekeys.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["NtNotifyChangeMultipleKeys","NtNotifyChangeMultipleKeys f
 old-location: winprog\ntnotifychangemultiplekeys.htm
 tech.root: winprog
 ms.assetid: c1ee9793-490c-45de-a2a5-deab630917f6
-ms.date: 12/05/2018
+ms.date: 04/30/2025
 ms.keywords: NtNotifyChangeMultipleKeys, NtNotifyChangeMultipleKeys function [Windows API], REG_NOTIFY_CHANGE_ATTRIBUTES, REG_NOTIFY_CHANGE_LAST_SET, REG_NOTIFY_CHANGE_NAME, REG_NOTIFY_CHANGE_SECURITY, base.ntnotifychangemultiplekeys, winprog.ntnotifychangemultiplekeys, winternl/NtNotifyChangeMultipleKeys
 req.header: winternl.h
 req.include-header: 
@@ -66,7 +66,7 @@ The number of keys objects provided in the <i>SubordinateObjects</i> parameter. 
 
 ### -param SubordinateObjects [in, optional]
 
-Pointer to an array of <a href="/windows-hardware/drivers/ddi/content/wudfwdm/ns-wudfwdm-_object_attributes">OBJECT_ATTRIBUTES</a> structures, one for each key.   This array can contain one <b>OBJECT_ATTRIBUTES</b> structure and you can't provide a key in the same hive as the <i>MasterKeyHandle</i> key.
+Pointer to an array of <a href="/windows-hardware/drivers/ddi/content/wudfwdm/ns-wudfwdm-_object_attributes">OBJECT_ATTRIBUTES</a> structures, one for each key.   This array can contain one <b>OBJECT_ATTRIBUTES</b> structure and must not be a key in the same hive as the <i>MasterKeyHandle</i> key.
 
 ### -param Event [in, optional]
 


### PR DESCRIPTION
During my analysis, I put so much time wondering why my call to NtNotifyChangeMultipleKeys returns with `STATUS_INVALID_PARAMETER` and `STATUS_INVALID_OBJECT_NAME` while everything is correct, according to the documentations, just to find out there are misleading information in it. I'm making this PR so other people won't be confused like me.