### PR TITLE
Fix docs for `sourceString` param in `WindowsCreateString`

### DIFF
--- a/sdk-api-src/content/winstring/nf-winstring-windowscreatestring.md
+++ b/sdk-api-src/content/winstring/nf-winstring-windowscreatestring.md
@@ -58,7 +58,9 @@ Creates a new [**HSTRING**](/windows/win32/winrt/hstring) based on the specified
 
 Type: [in, optional] <b>LPCWSTR</b>
 
-A null-terminated string to use as the source for the new [**HSTRING**](/windows/win32/winrt/hstring). To create a new, empty, or <b>NULL</b> string, pass <b>NULL</b> for <i>sourceString</i> and 0 for <i>length</i>.
+The UTF-16LE-encoded text buffer to use as the source for the new [**HSTRING**](/windows/win32/winrt/hstring). To create a new, empty, or <b>NULL</b> string, pass <b>NULL</b> for <i>sourceString</i> and 0 for <i>length</i>.
+
+This buffer is not required to be null-terminated. <b>WindowsCreateString</b> will copy its contents and add a null-terminator in the new buffer backing the returned [**HSTRING**](/windows/win32/winrt/hstring).
 
 ### -param length
 


### PR DESCRIPTION
This doesn't actually require to be `null`-terminated, and it was quite confusing.

See https://devblogs.microsoft.com/oldnewthing/20160615-00/?p=93675:
> "WindowsCreateString creates an HSTRING from a UTF-16LE-encoded buffer and a specified length. The buffer does not require a terminating null."