### PR TITLE
nf-winreg-regnotifychangekeyvalue.md: Separate the mentioned HKEY* values with commas

### DIFF
--- a/sdk-api-src/content/winreg/nf-winreg-regnotifychangekeyvalue.md
+++ b/sdk-api-src/content/winreg/nf-winreg-regnotifychangekeyvalue.md
@@ -66,18 +66,15 @@ Notifies the caller about changes to the attributes or contents of a specified r
 
 A handle to an open registry key. This handle is returned by the 
 <a href="/windows/desktop/api/winreg/nf-winreg-regcreatekeyexa">RegCreateKeyEx</a> or <a href="/windows/desktop/api/winreg/nf-winreg-regopenkeyexa">RegOpenKeyEx</a> function. It can also be one of the following 
-<a href="/windows/desktop/SysInfo/predefined-keys">predefined keys</a>: 
+<a href="/windows/desktop/SysInfo/predefined-keys">predefined keys</a>:
 
+<b>HKEY_CLASSES_ROOT</b>,
+<b>HKEY_CURRENT_CONFIG</b>,
+<b>HKEY_CURRENT_USER</b>,
+<b>HKEY_LOCAL_MACHINE</b>,
+<b>HKEY_USERS</b>.
 
-
-
-<b>HKEY_CLASSES_ROOT</b>
-<b>HKEY_CURRENT_CONFIG</b>
-<b>HKEY_CURRENT_USER</b>
-<b>HKEY_LOCAL_MACHINE</b>
-<b>HKEY_USERS</b>
-This parameter must be a local handle. If 
-<b>RegNotifyChangeKeyValue</b> is called with a remote handle, it returns ERROR_INVALID_HANDLE.
+This parameter must be a local handle. If <b>RegNotifyChangeKeyValue</b> is called with a remote handle, it returns ERROR_INVALID_HANDLE.
 
 The key must have been opened with the KEY_NOTIFY access right. For more information, see 
 <a href="/windows/desktop/SysInfo/registry-key-security-and-access-rights">Registry Key Security and Access Rights</a>.


### PR DESCRIPTION
In order to improve readability in the english version of the docs, and how they are displayed in the automated translations.