### PR TITLE
user32: Remove incorrect remark from TileWindows and CascadeWindows

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-cascadewindows.md
+++ b/sdk-api-src/content/winuser/nf-winuser-cascadewindows.md
@@ -124,9 +124,7 @@ If the function fails, the return value is zero. To get extended error informati
 
 ## -remarks
 
-By default, <b>CascadeWindows</b> arranges the windows in the order provided by the <i>lpKids</i> array, but preserves the <a href="/windows/desktop/winmsg/window-features">Z-Order</a>. If you specify the <b>MDITILE_ZORDER</b> flag, <b>CascadeWindows</b> arranges the windows in Z order. 
-
-Calling <b>CascadeWindows</b> causes all maximized windows to be restored to their previous size.
+By default, <b>CascadeWindows</b> arranges the windows in the order provided by the <i>lpKids</i> array, but preserves the <a href="/windows/desktop/winmsg/window-features">Z-Order</a>. If you specify the <b>MDITILE_ZORDER</b> flag, <b>CascadeWindows</b> arranges the windows in Z order.
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-tilewindows.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tilewindows.md
@@ -121,10 +121,6 @@ If the function succeeds, the return value is the number of windows arranged.
 
 If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
 
-## -remarks
-
-Calling <b>TileWindows</b> causes all maximized windows to be restored to their previous size.
-
 ## -see-also
 
 <a href="/windows/desktop/api/winuser/nf-winuser-cascadewindows">CascadeWindows</a>


### PR DESCRIPTION
Problem: The documentation of TileWindows and CascadeWindows contains a remark claiming that after calling these functions, the maximized windows are restored to their original size. This is a partially correct claim; while the windows are indeed restored, they are not restored to the original size, but rather to a specific size appropriate for the tiling/cascade pattern.

Solution: Remove the incorrect remark from both doc pages.