### PR TITLE
Update buffer size notes for (Sym)FindExecutableImage(Ex)(W)

### DIFF
--- a/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofile.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofile.md
@@ -69,7 +69,7 @@ The path where symbol files are located. This can be multiple paths separated by
 
 ### -param DebugFilePath [out]
 
-A pointer to a buffer that receives the full path of the .dbg file.
+A pointer to a buffer that receives the full path of the .dbg file. This buffer must be at least MAX_PATH+1 characters.
 
 ## -returns
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofileex.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofileex.md
@@ -68,7 +68,7 @@ The path where symbol files are located. This can be multiple paths separated by
 
 ### -param DebugFilePath [out]
 
-A pointer to a buffer that receives the full path of the .dbg file.
+A pointer to a buffer that receives the full path of the .dbg file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofileexw.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-finddebuginfofileexw.md
@@ -68,7 +68,7 @@ The path where symbol files are located. This can be multiple paths separated by
 
 ### -param DebugFilePath [out]
 
-A pointer to a buffer that receives the full path of the .dbg file.
+A pointer to a buffer that receives the full path of the .dbg file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimage.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimage.md
@@ -68,7 +68,7 @@ The path where symbol files are located. This can be multiple paths separated by
 
 ### -param ImageFilePath [out]
 
-A pointer to a buffer that receives the full path of the executable file.
+A pointer to a buffer that receives the full path of the executable file. This buffer must be at least MAX_PATH+1 characters.
 
 ## -returns
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimageex.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimageex.md
@@ -67,7 +67,7 @@ The path where symbol files are located. This string can contain multiple paths 
 
 ### -param ImageFilePath [out]
 
-A pointer to a buffer that receives the full path of the executable file.
+A pointer to a buffer that receives the full path of the executable file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimageexw.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-findexecutableimageexw.md
@@ -67,7 +67,7 @@ The path where symbol files are located. This string can contain multiple paths 
 
 ### -param ImageFilePath [out]
 
-A pointer to a buffer that receives the full path of the executable file.
+A pointer to a buffer that receives the full path of the executable file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfinddebuginfofile.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfinddebuginfofile.md
@@ -67,7 +67,7 @@ The name of the .dbg file. You can use a partial path.
 
 ### -param DebugFilePath [out]
 
-The fully qualified path of the .dbg file. This buffer must be at least MAX_PATH characters.
+The fully qualified path of the .dbg file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfinddebuginfofilew.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfinddebuginfofilew.md
@@ -67,7 +67,7 @@ The name of the .dbg file. You can use a partial path.
 
 ### -param DebugFilePath [out]
 
-The fully qualified path of the .dbg file. This buffer must be at least MAX_PATH characters.
+The fully qualified path of the .dbg file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfindexecutableimage.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfindexecutableimage.md
@@ -67,7 +67,7 @@ The name of the executable file. You can use a partial path.
 
 ### -param ImageFilePath [out]
 
-The fully qualified path of the executable file. This buffer must be at least MAX_PATH characters.
+The fully qualified path of the executable file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfindexecutableimagew.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfindexecutableimagew.md
@@ -67,7 +67,7 @@ The name of the executable file. You can use a partial path.
 
 ### -param ImageFilePath [out]
 
-The fully qualified path of the executable file. This buffer must be at least MAX_PATH characters.
+The fully qualified path of the executable file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param Callback [in]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfindfileinpath.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfindfileinpath.md
@@ -129,7 +129,7 @@ The <i>id</i> parameter is a pointer to a <b>GUID</b>.
 
 ### -param FoundFile [out]
 
-A pointer to a buffer that receives the fully qualified path to the symbol file. This buffer must be at least MAX_PATH characters.
+A pointer to a buffer that receives the fully qualified path to the symbol file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param callback [in, optional]
 

--- a/sdk-api-src/content/dbghelp/nf-dbghelp-symfindfileinpathw.md
+++ b/sdk-api-src/content/dbghelp/nf-dbghelp-symfindfileinpathw.md
@@ -129,7 +129,7 @@ The <i>id</i> parameter is a pointer to a <b>GUID</b>.
 
 ### -param FoundFile [out]
 
-A pointer to a buffer that receives the fully qualified path to the symbol file. This buffer must be at least MAX_PATH characters.
+A pointer to a buffer that receives the fully qualified path to the symbol file. This buffer must be at least MAX_PATH+1 characters.
 
 ### -param callback [in, optional]
 


### PR DESCRIPTION
All these functions assume a valid output buffer size of 261 characters (MAX_PATH+1).
The DbgHelp.h header has this information as SAL annotations (or whatever they're called this week) but it seems this information hasn't been migrated to the docs.