### PR TITLE
RmStartSession: Add information about strSessionKey size

### DIFF
--- a/sdk-api-src/content/restartmanager/nf-restartmanager-rmstartsession.md
+++ b/sdk-api-src/content/restartmanager/nf-restartmanager-rmstartsession.md
@@ -64,7 +64,7 @@ Reserved. This parameter should be 0.
 
 ### -param strSessionKey [out]
 
-A <b>null</b>-terminated string that contains the session key to the new session. The string must be allocated before calling  the <b>RmStartSession</b> function.
+A <b>null</b>-terminated string that contains the session key to the new session. The string of size `CCH_RM_SESSION_KEY + 1` must be allocated before calling the <b>RmStartSession</b> function.
 
 ## -returns
 


### PR DESCRIPTION
Source for the previously missing information is https://devblogs.microsoft.com/oldnewthing/20120217-00/?p=8283.