### PR TITLE
Update nf-pathcch-pathcchstripprefix.md: Fix escape sequence

### DIFF
--- a/sdk-api-src/content/pathcch/nf-pathcch-pathcchstripprefix.md
+++ b/sdk-api-src/content/pathcch/nf-pathcch-pathcchstripprefix.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-Removes the "\\?\" prefix, if present, from a file path.
+Removes the "\\\\?\\" prefix, if present, from a file path.
 
 ## -parameters
 


### PR DESCRIPTION
The description currently mentions a `\?` prefix. It should actually be the extended path prefix `\\?\`.