### PR TITLE
nf-objidlbase-ipipedouble-pull.md: Delete 'double integer's

### DIFF
--- a/sdk-api-src/content/objidlbase/nf-objidlbase-ipipedouble-pull.md
+++ b/sdk-api-src/content/objidlbase/nf-objidlbase-ipipedouble-pull.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:objidlbase.IPipeDouble.Pull
 title: IPipeDouble::Pull (objidlbase.h)
-description: The IPipeDouble::Pull (objidlbase.h) method retrieves data of the double integer type from the pipe source.
+description: The IPipeDouble::Pull (objidlbase.h) method retrieves data of the double type from the pipe source.
 helpviewer_keywords: ["IPipeDouble interface [COM]","Pull method","IPipeDouble.Pull","IPipeDouble::Pull","Pull","Pull method [COM]","Pull method [COM]","IPipeDouble interface","_com_ipipedouble_pull","com.ipipedouble_pull","objidlbase/IPipeDouble::Pull"]
 old-location: com\ipipedouble_pull.htm
 tech.root: com
@@ -50,21 +50,21 @@ api_name:
 
 ## -description
 
-Retrieves data of the double integer type from the pipe source.
+Retrieves data of the double type from the pipe source.
 
 ## -parameters
 
 ### -param buf [out]
 
-A pointer to the memory buffer that receives the data. The buffer must be able to hold at least the number of double integers specified in <i>cRequest</i>.
+A pointer to the memory buffer that receives the data. The buffer must be able to hold at least the number of doubles specified in <i>cRequest</i>.
 
 ### -param cRequest [in]
 
-The number of double integers requested.
+The number of doubles requested.
 
 ### -param pcReturned [out]
 
-The actual number of double integers returned.
+The actual number of doubles returned.
 
 ## -returns
 
@@ -72,7 +72,7 @@ This method returns S_OK to indicate that the data was retrieved successfully.
 
 ## -remarks
 
-When the <b>Pull</b> method is called, data is requested from the provider of the pipe. The caller must provide a buffer that will hold at least the number of double integers specified in the <i>cRequest</i> parameter. The proxy will unmarshal the data into the provided buffer and set the number of double integers actually provided in <i>pcReturned</i>. The <i>pcReturned</i> parameter can be less than or equal to <i>cRequest</i>, but it will never be greater. When <i>pcReturned</i> is 0, it indicates that there is no more data.
+When the <b>Pull</b> method is called, data is requested from the provider of the pipe. The caller must provide a buffer that will hold at least the number of doubles specified in the <i>cRequest</i> parameter. The proxy will unmarshal the data into the provided buffer and set the number of doubles actually provided in <i>pcReturned</i>. The <i>pcReturned</i> parameter can be less than or equal to <i>cRequest</i>, but it will never be greater. When <i>pcReturned</i> is 0, it indicates that there is no more data.
 
 ## -see-also
 


### PR DESCRIPTION
see also #2020