### PR TITLE
GetDiskSpaceInformationW: Fix wrong return values

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskspaceinformationw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskspaceinformationw.md
@@ -64,7 +64,7 @@ A [**DISK_SPACE_INFORMATION**](ns-fileapi-disk_space_information.md) structure c
 
 ## -returns
 
-Returns `TRUE` if the function succeeds, or `FALSE` if it fails. To get extended error information, call the `GetLastError` function.
+Returns `S_OK` if the function succeeds, or a value from [here](https://learn.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values) if it fails. To get extended error information, call the `GetLastError` function.
 
 ## -remarks
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getdiskspaceinformationw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getdiskspaceinformationw.md
@@ -64,7 +64,7 @@ A [**DISK_SPACE_INFORMATION**](ns-fileapi-disk_space_information.md) structure c
 
 ## -returns
 
-Returns `S_OK` if the function succeeds, or a value from [here](https://learn.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values) if it fails. To get extended error information, call the `GetLastError` function.
+Returns `S_OK` if the function succeeds, or a value from [Common HRESULT Values](/windows/win32/seccrypto/common-hresult-values) if it fails. You can call [GetLastError](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) for extended error information.
 
 ## -remarks
 


### PR DESCRIPTION
The nasty thing is if you rely on the docs you want `TRUE` which is 1 but `S_OK` is 0 so the function "always fails" 