### PR TITLE
Fix Edit_GetEndOfLine return value

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-edit_getendofline.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-edit_getendofline.md
@@ -45,12 +45,7 @@ api_name:
  - Edit_GetEndOfLine
 ---
 
-# Edit_GetEndOfLine macro
-
-
 ## -description
-
-
 
 Gets the end of line character used for the content of the edit control. You can use this macro or send the <a href="/windows/desktop/controls/em-getendofline">EM_GETENDOFLINE</a> message explicitly.
 
@@ -62,10 +57,10 @@ A handle to the edit control.
 
 ## Return value
 
-Returns the end-of-line character used by the edit control, which can be one of the following **EC\_ENDOFLINE** values:
+Returns the end-of-line character used by the edit control, which can be one of the following **EC_ENDOFLINE** values.
 
-| Value                                                                                                                                                   | Meaning                                                                                        |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
-| <span id="EC_ENDOFLINE_CRLF"></span><span id="ec_endofline_crlf"></span><dl> <dt>**EC\_ENDOFLINE\_CRLF**</dt> </dl> | The end-of-line character used for new linebreaks is carriage return followed by linefeed (CRLF).<br/> |
-| <span id="EC_ENDOFLINE_CR"></span><span id="ec_endofline_cr"></span><dl> <dt>**EC\_ENDOFLINE\_CR**</dt> </dl>       | The end-of-line character used for new linebreaks is carriage return (CR).<br/>                        |
-| <span id="EC_ENDOFLINE_LF"></span><span id="ec_endofline_lf"></span><dl> <dt>**EC\_ENDOFLINE\_LF**</dt> </dl>       | The end-of-line character used for new linebreaks is linefeed (LF).<br/>                               |
+| Value | Meaning |
+|-|-|
+| **EC_ENDOFLINE_CRLF** | The end-of-line character used for new linebreaks is carriage return followed by linefeed (CRLF). |
+| **EC_ENDOFLINE_CR** | The end-of-line character used for new linebreaks is carriage return (CR). |
+| **EC_ENDOFLINE_LF** | The end-of-line character used for new linebreaks is linefeed (LF). |

--- a/sdk-api-src/content/commctrl/nf-commctrl-edit_getendofline.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-edit_getendofline.md
@@ -59,3 +59,13 @@ Gets the end of line character used for the content of the edit control. You can
 ### -param hwndCtl
 
 A handle to the edit control.
+
+## Return value
+
+Returns the end-of-line character used by the edit control, which can be one of the following **EC\_ENDOFLINE** values:
+
+| Value                                                                                                                                                   | Meaning                                                                                        |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| <span id="EC_ENDOFLINE_CRLF"></span><span id="ec_endofline_crlf"></span><dl> <dt>**EC\_ENDOFLINE\_CRLF**</dt> </dl> | The end-of-line character used for new linebreaks is carriage return followed by linefeed (CRLF).<br/> |
+| <span id="EC_ENDOFLINE_CR"></span><span id="ec_endofline_cr"></span><dl> <dt>**EC\_ENDOFLINE\_CR**</dt> </dl>       | The end-of-line character used for new linebreaks is carriage return (CR).<br/>                        |
+| <span id="EC_ENDOFLINE_LF"></span><span id="ec_endofline_lf"></span><dl> <dt>**EC\_ENDOFLINE\_LF**</dt> </dl>       | The end-of-line character used for new linebreaks is linefeed (LF).<br/>                               |


### PR DESCRIPTION
The [`Edit_GetEndOfLine` macro](https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nf-commctrl-edit_getendofline) actually returns a `EC_ENDOFLINE`, not `void`.

> \Windows Kits\10\Include\10.0.26100.0\um\CommCtrl.h
```c++
#define EM_GETENDOFLINE         (ECM_FIRST + 13)
#define Edit_GetEndOfLine(hwndCtl) \
        (EC_ENDOFLINE)SNDMSG((hwndCtl), EM_GETENDOFLINE, 0, 0)
```

See the `EM_GETENDOFLINE` message for enum details https://learn.microsoft.com/en-us/windows/win32/controls/em-getendofline.