### PR TITLE
Update `CreateColorProfileFromLogColorSpace` to steer people away from a memory leak

### DIFF
--- a/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacea.md
+++ b/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacea.md
@@ -65,7 +65,7 @@ If the **lcsFilename** \[0\] member if the [**LOGCOLORSPACEA**](/windows/desktop
 
 ## -remarks
 
-This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. The [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function should be used to free this buffer.
+This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. Use the [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle) function to retrieve the handle for the buffer, and then use the [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function to free the handle.
 
 This function does not support Windows Color System (WCS) profiles CAMP, DMP, and GMMP.
 
@@ -74,3 +74,4 @@ This function does not support Windows Color System (WCS) profiles CAMP, DMP, an
 * [Basic color management concepts](/windows/win32/wcs/basic-color-management-concepts)
 * [Functions](/windows/win32/wcs/functions)
 * [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree)
+* [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle)

--- a/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacew.md
+++ b/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacew.md
@@ -65,7 +65,7 @@ If the **lcsFilename** \[0\] member if the [**LOGCOLORSPACEA**](/windows/desktop
 
 ## -remarks
 
-This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. Use the [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle) function to retrieve handle for the buffer, and then use the [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function to free the handle.
+This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. Use the [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle) function to retrieve the handle for the buffer, and then use the [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function to free the handle.
 
 This function does not support Windows Color System (WCS) profiles CAMP, DMP, and GMMP.
 

--- a/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacew.md
+++ b/sdk-api-src/content/icm/nf-icm-createprofilefromlogcolorspacew.md
@@ -65,7 +65,7 @@ If the **lcsFilename** \[0\] member if the [**LOGCOLORSPACEA**](/windows/desktop
 
 ## -remarks
 
-This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. The [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function should be used to free this buffer.
+This function can be used with ASCII or Unicode strings. The buffer created by this function must be freed by the caller when it is no longer needed or there will be a memory leak. Use the [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle) function to retrieve handle for the buffer, and then use the [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree) function to free the handle.
 
 This function does not support Windows Color System (WCS) profiles CAMP, DMP, and GMMP.
 
@@ -74,3 +74,4 @@ This function does not support Windows Color System (WCS) profiles CAMP, DMP, an
 * [Basic color management concepts](/windows/win32/wcs/basic-color-management-concepts)
 * [Functions](/windows/win32/wcs/functions)
 * [GlobalFree](/windows/win32/api/winbase/nf-winbase-globalfree)
+* [GlobalHandle](/windows/win32/api/winbase/nf-winbase-globalhandle)


### PR DESCRIPTION
The documentation indicates that you should use `GlobalFree` on the value stored at the address given by `pProfile`.

In other words, 

```c
BYTE* pProfile = NULL;
CreateProfileFromLogColorSpaceW(..., &pProfile);
GlobalFree((HGLOBAL)pProfile);
```

This is wrong, it is a memory leak. If you do this 65,536 times in a row then this method will start returning `ERROR_NOT_ENOUGH_MEMORY`. Apparently that's the maximum number of `HGLOBAL`s you can have.

The correct pattern is this:

```c
BYTE* pProfile = NULL;
CreateProfileFromLogColorSpaceW(..., &pProfile);
HGLOBAL hProfile = GlobalHandle(pProfile);
GlobalFree(hProfile);
```

I ran into this issue while working on my desktop app. I had a bug in a caching layer that was causing my color profile caching to not work, so it was recreating the profile on every call into the cache. After using the app for a few minutes it would crash because I convert Win32 errors into .NET exceptions.

cc @Sergio0694