### PR TITLE
Update nf-processenv-setstdhandleex.md

### DIFF
--- a/sdk-api-src/content/processenv/nf-processenv-setstdhandleex.md
+++ b/sdk-api-src/content/processenv/nf-processenv-setstdhandleex.md
@@ -18,8 +18,8 @@ req.lib:
 req.max-support: 
 req.namespace: 
 req.redist: 
-req.target-min-winverclnt: Windows 10 Build 20348
-req.target-min-winversvr: Windows 10 Build 20348
+req.target-min-winverclnt: Windows Vista
+req.target-min-winversvr: Windows Server 2008
 req.target-type: 
 req.type-library: 
 req.umdf-ver: 
@@ -60,7 +60,9 @@ Optional. Receives the previous handle.
 
 ## -returns
 
-Returns S_OK on success.
+If the function succeeds, the return value is nonzero.
+
+If the function fails, the return value is zero. To get extended error information, call [**GetLastError**](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 


### PR DESCRIPTION
- `SetStdHandleEx` is a NT6 API, see also "processenv.h" in Windows SDK:
```C
#if (_WIN32_WINNT >= 0x0600)

WINBASEAPI
BOOL
WINAPI
SetStdHandleEx(
    _In_ DWORD nStdHandle,
    _In_ HANDLE hHandle,
    _Out_opt_ PHANDLE phPrevValue
    );

#endif // _WIN32_WINNT >= 0x0600
```
- It returns `BOOL`, zero means failed and nonzero means succeeded.  `S_OK` is 0, which should be a `HRESULT` value.