### PR TITLE
Update nf-dxgi-idxgiswapchain-getbuffer.md

### DIFF
--- a/sdk-api-src/content/dxgi/nf-dxgi-idxgiswapchain-getbuffer.md
+++ b/sdk-api-src/content/dxgi/nf-dxgi-idxgiswapchain-getbuffer.md
@@ -63,7 +63,9 @@ A zero-based buffer index.
 
 If the swap chain's swap effect is <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_DISCARD</a>, this method can only access the first buffer; for this situation, set the index to zero.
 
-If the swap chain's swap effect is either <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_SEQUENTIAL</a> or <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a>, only the swap chain's zero-index buffer can be read from and written to. The swap chain's buffers with indexes greater than zero can only be read from; so if you call the <a href="/windows/desktop/api/dxgi/nf-dxgi-idxgiresource-getusage">IDXGIResource::GetUsage</a> method for such buffers, they have the <a href="/windows/desktop/direct3ddxgi/dxgi-usage">DXGI_USAGE_READ_ONLY</a> flag set.
+If the swap chain's swap effect is either <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_SEQUENTIAL</a>, only the swap chain's zero-index buffer can be read from and written to. The swap chain's buffers with indexes greater than zero can only be read from; so if you call the <a href="/windows/desktop/api/dxgi/nf-dxgi-idxgiresource-getusage">IDXGIResource::GetUsage</a> method for such buffers, they have the <a href="/windows/desktop/direct3ddxgi/dxgi-usage">DXGI_USAGE_READ_ONLY</a> flag set.
+
+If the swap chain's swap effect is <a href="/windows/desktop/api/dxgi/ne-dxgi-dxgi_swap_effect">DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL</a>, the relationship between indices and buffers is consistent. The result is identical if you get the swap chain's zero-index buffer after each time <a href="windows/win32/api/dxgi/nf-dxgi-idxgiswapchain-present">IDXGISwapChain::Present</a> is called. A correct frame index should be used to retrieve the current backbuffer.
 
 ### -param riid [in]
 


### PR DESCRIPTION
The documentation indicates DXGI_SWAP_EFFECT_SEQUENTIAL and DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL have the same index mechanism, but it's incorrect.

The flip sequential model has a constant and consecutive index range according to the descriptions in learn.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect and my verification. Therefore, the paragraph related to this should be revised.


