### PR TITLE
Fix incorrect ole32 documentation for COM DeviceCatalog APIs

### DIFF
--- a/sdk-api-src/content/combaseapi/nf-combaseapi-coregisterdevicecatalog.md
+++ b/sdk-api-src/content/combaseapi/nf-combaseapi-coregisterdevicecatalog.md
@@ -21,8 +21,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Ole32.lib
-req.dll: Ole32.dll
+req.lib: onecore.lib
+req.dll: combase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -38,7 +38,6 @@ topic_type:
 api_type:
  - DllExport
 api_location:
- - Ole32.dll
  - API-MS-Win-Core-Com-l1-1-3.dll
  - ComBase.dll
 api_name:

--- a/sdk-api-src/content/combaseapi/nf-combaseapi-corevokedevicecatalog.md
+++ b/sdk-api-src/content/combaseapi/nf-combaseapi-corevokedevicecatalog.md
@@ -21,8 +21,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Ole32.lib
-req.dll: Ole32.dll
+req.lib: onecore.lib
+req.dll: combase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -38,7 +38,6 @@ topic_type:
 api_type:
  - DllExport
 api_location:
- - Ole32.dll
  - API-MS-Win-Core-Com-l1-1-3.dll
  - ComBase.dll
 api_name:


### PR DESCRIPTION
These APIs have always been implemented by combase.dll, not ole32.dll. They've never been in the ole32 import lib.

However, the combaseapi apiset had incorrect reverse forwarder configuration that identified ole32 as the legacy host of _all_ contained APIs, even those that were added to combase.dll after it was split from ole32.dll. The bad reverse forwarders resulted in bad import table entries for these APIs; I fixed that last year under bug 48441982.

I'm guessing that the incorrect documentation info also originated from that incorrect reverse forwarder.