### PR TITLE
WLX_PROFILE_V1_0: Tell how pszProfile is allocated

### DIFF
--- a/sdk-api-src/content/winwlx/ns-winwlx-wlx_profile_v1_0.md
+++ b/sdk-api-src/content/winwlx/ns-winwlx-wlx_profile_v1_0.md
@@ -68,7 +68,7 @@ Must be set to WLX_PROFILE_TYPE_V1_0.
 
 Pointer to the profile path (for example, "%SystemRoot%\system32\config\AprilM001"). 
 
-The string pointed to by <b>pszProfile</b> must be separately allocated by your <a href="/windows/desktop/SecGloss/g-gly">GINA</a> DLL, using <a href="/windows/desktop/api/winbase/nf-winbase-localalloc">LocalAlloc</a>. It will be deallocated by <a href="/windows/desktop/SecGloss/w-gly">Winlogon</a>.
+The string pointed to by <b>pszProfile</b> must be separately allocated by your <a href="/windows/win32/SecGloss/g-gly">GINA</a> DLL, using <a href="/windows/win32/api/winbase/nf-winbase-localalloc">LocalAlloc</a>. It will be deallocated by <a href="/windows/win32/SecGloss/w-gly">Winlogon</a>.
 
 ## -remarks
 
@@ -78,4 +78,4 @@ GINA uses two structures to provide profile information: <a href="/windows/deskt
 
 ## -see-also
 
-<a href="/windows/desktop/api/winwlx/ns-winwlx-wlx_profile_v2_0">WLX_PROFILE_V2_0</a>
+<a href="/windows/win32/api/winwlx/ns-winwlx-wlx_profile_v2_0">WLX_PROFILE_V2_0</a>

--- a/sdk-api-src/content/winwlx/ns-winwlx-wlx_profile_v1_0.md
+++ b/sdk-api-src/content/winwlx/ns-winwlx-wlx_profile_v1_0.md
@@ -68,10 +68,7 @@ Must be set to WLX_PROFILE_TYPE_V1_0.
 
 Pointer to the profile path (for example, "%SystemRoot%\system32\config\AprilM001"). 
 
-
-
-
-The string pointed to by <b>pszProfile</b> must be separately allocated by your <a href="/windows/desktop/SecGloss/g-gly">GINA</a> DLL. It will be deallocated by <a href="/windows/desktop/SecGloss/w-gly">Winlogon</a>.
+The string pointed to by <b>pszProfile</b> must be separately allocated by your <a href="/windows/desktop/SecGloss/g-gly">GINA</a> DLL, using <a href="/windows/desktop/api/winbase/nf-winbase-localalloc">LocalAlloc</a>. It will be deallocated by <a href="/windows/desktop/SecGloss/w-gly">Winlogon</a>.
 
 ## -remarks
 


### PR DESCRIPTION
The `pszProfile` field needs to be allocated with LocalAlloc, since, according to investigations on Windows <= 2003, winlogon.exe will free this pointer with LocalFree.