### PR TITLE
Remove outdated `InitializeObjectAttributes` comment

### DIFF
--- a/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntcreatefile.md
@@ -804,4 +804,4 @@ NTFS is the only Microsoft file system that implements <b>FILE_RESERVE_OPFILTER<
 
 For more information on oplocks, see [Opportunistic Locks](/windows/win32/fileio/opportunistic-locks).
 
-Note that the WDK header file NtDef.h is necessary for many constant definitions as well as the <b>InitializeObjectAttributes</b> macro. You can also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to dynamically link to NtDll.dll.
+Note that the WDK header file NtDef.h is necessary for many constant definitions. You can also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to dynamically link to NtDll.dll.

--- a/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
+++ b/sdk-api-src/content/winternl/nf-winternl-ntopenfile.md
@@ -113,8 +113,8 @@ Driver routines that run in a process context other than that of the system proc
 
 Callers of <b>ZwCreateFile</b> must be running at IRQL = PASSIVE_LEVEL.
 
-Note that the WDK header file Ntdef.h is necessary for many constant definitions 
-    as well as the <b>InitializeObjectAttributes</b> macro. You can also use the 
+Note that the WDK header file Ntdef.h is necessary for many constant definitions.
+You can also use the 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya">LoadLibrary</a> and 
     <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to dynamically link to 
     Ntdll.dll.


### PR DESCRIPTION
The `InitializeObjectAttributes` macro has been in winternl.h since at least the Windows 7 SP1 SDK, if not earlier.