### PR TITLE
SO_UPDATE_ACCEPT_CONTEXT needs to accept pointer-sized integer.

### DIFF
--- a/sdk-api-src/content/winsock/nf-winsock-setsockopt.md
+++ b/sdk-api-src/content/winsock/nf-winsock-setsockopt.md
@@ -300,7 +300,7 @@ The following tables list some of the common options supported by the <b>setsock
 </tr>
 <tr>
 <td>SO_UPDATE_ACCEPT_CONTEXT</td>
-<td>int</td>
+<td>UINT_PTR</td>
 <td>Updates the accepting socket with the context of the listening socket.</td>
 </tr>
 <tr>


### PR DESCRIPTION
If it would accepted 32bit integer, as previously documented, it would fail on 64bit systems with WSAEFAULT error (number 10014 or 0x271e).