### PR TITLE
Fix slash escaping in nf-shlobj_core-pathcleanupspec.md

### DIFF
--- a/sdk-api-src/content/shlobj_core/nf-shlobj_core-pathcleanupspec.md
+++ b/sdk-api-src/content/shlobj_core/nf-shlobj_core-pathcleanupspec.md
@@ -78,7 +78,7 @@ This value can be <b>NULL</b>.
 
 Type: <b>PWSTR</b>
 
-A pointer to a null-terminated buffer that contains the file or directory name to be cleaned. In the case of a file, include the file's extension. Note that because '\' is considered an invalid character and will be removed, this buffer cannot contain a path more than one directory deep.
+A pointer to a null-terminated buffer that contains the file or directory name to be cleaned. In the case of a file, include the file's extension. Note that because '\\' is considered an invalid character and will be removed, this buffer cannot contain a path more than one directory deep.
                     
                         
 


### PR DESCRIPTION
The page is currently rendering

> Note that because '' is considered an invalid character

Escape the `\` so that is renders

> Note that because '\\' is considered an invalid character 