### PR TITLE
Add return codes for occlusion and presentation mode change to IDirect3DDevice9Ex::PresentEx

### DIFF
--- a/sdk-api-src/content/d3d9/nf-d3d9-idirect3ddevice9ex-presentex.md
+++ b/sdk-api-src/content/d3d9/nf-d3d9-idirect3ddevice9ex-presentex.md
@@ -104,7 +104,7 @@ Allows the application to request that the method return immediately when the dr
 
 Type: <b><a href="/windows/win32/com/structure-of-com-error-codes">HRESULT</a></b>
 
-Possible return values include: S_OK, D3DERR_DEVICELOST, D3DERR_DEVICEHUNG, D3DERR_DEVICEREMOVED, or D3DERR_OUTOFVIDEOMEMORY (see <a href="/windows/desktop/direct3d9/d3derr">D3DERR</a>). See <a href="/windows/desktop/direct3d9/dx9lh">Lost Device Behavior Changes</a> for more information about lost, hung, and removed devices.
+Possible return values include: S_OK, D3DERR_DEVICELOST, D3DERR_DEVICEHUNG, D3DERR_DEVICEREMOVED, or D3DERR_OUTOFVIDEOMEMORY (see <a href="/windows/desktop/direct3d9/d3derr">D3DERR</a>) or S_PRESENT_OCCLUDED, or S_PRESENT_MODE_CHANGED (see <a href="/windows/win32/direct3d9/device-state-return-codes">S_PRESENT</a>). See <a href="/windows/desktop/direct3d9/dx9lh">Lost Device Behavior Changes</a> for more information about lost, hung, and removed devices.
 
 <table>
 <tr>


### PR DESCRIPTION
Both https://learn.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9ex-checkdevicestate and https://learn.microsoft.com/en-us/windows/win32/api/d3d9/nf-d3d9-idirect3ddevice9ex-presentex return `S_PRESENT_OCCLUDED` and `S_PRESENT_MODE_CHANGED` codes to handle window occlusion and device mode change.