### PR TITLE
Clarify that pwszObjectName needs to be null terminated in WinHttpOpenRequest

### DIFF
--- a/sdk-api-src/content/winhttp/nf-winhttp-winhttpopenrequest.md
+++ b/sdk-api-src/content/winhttp/nf-winhttp-winhttpopenrequest.md
@@ -65,7 +65,7 @@ Pointer to a string that contains the <a href="/windows/desktop/WinHttp/glossary
 
 ### -param pwszObjectName [in]
 
-Pointer to a string that contains the name of the target resource of the specified HTTP verb. This is generally a file name, an executable module, or a search specifier.
+Pointer to a <b>null</b>-terminated string that contains the name of the target resource of the specified HTTP verb. This is generally a file name, an executable module, or a search specifier.
 
 ### -param pwszVersion [in]
 


### PR DESCRIPTION
This better matches the Documentation of [WinHttpConnect](https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpconnect#parameters) which does specify that the host name string must be null terminated