### PR TITLE
Remove outdated note on the Vista SDK

### DIFF
--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringa.md
@@ -86,10 +86,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv4AddressToString</b> is
 
 The <b>IN_ADDR</b> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4AddressToString</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4AddressToString</b> function  is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexa.md
@@ -14,7 +14,7 @@ req.idl:
 req.include-header: Mstcpip.h 
 req.irql: 
 req.kmdf-ver: 
-req.lib: 
+req.lib: ntdll.lib 
 req.max-support: 
 req.namespace: 
 req.redist: 
@@ -115,8 +115,6 @@ When either UNICODE or _UNICODE is defined, <b>RtlIpv4AddressToStringEx</b> is d
 When both UNICODE and _UNICODE are not defined, <b>RtlIpv4AddressToStringEx</b> is defined to <b>RtlIpv4AddressToStringExA</b>, the ANSI version of this function. The <i>AddressString</i> parameter is defined to the PSTR data type.
 
 The <b>IN_ADDR</b> structure is defined in the <i>Inaddr.h</i> header file.
-
-An import library containing the <b>RtlIpv4AddressToStringEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4AddressToStringEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
 
 ## -see-also
 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringexw.md
@@ -129,8 +129,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv4AddressToStringEx</b> 
 
 The <b>IN_ADDR</b> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4AddressToStringEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4AddressToStringEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 ## -see-also
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4addresstostringw.md
@@ -86,10 +86,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv4AddressToString</b> is
 
 The <b>IN_ADDR</b> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4AddressToString</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4AddressToString</b> function  is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressa.md
@@ -150,10 +150,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv4StringToAddress</b> is
 
 The <a href="/windows/desktop/api/winsock2/ns-winsock2-in_addr">IN_ADDR</a> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4StringToAddress</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4StringToAddress</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexa.md
@@ -14,7 +14,7 @@ req.idl:
 req.include-header: Mstcpip.h 
 req.irql: 
 req.kmdf-ver: 
-req.lib: 
+req.lib: ntdll.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
@@ -112,8 +112,6 @@ When either UNICODE or _UNICODE is defined, <b>RtlIpv4StringToAddressEx</b> is d
 When both UNICODE and  _UNICODE are not defined, <b>RtlIpv4StringToAddressEx</b> is defined to <b>RtlIpv4StringToAddressExA</b>, the ANSI version of this function. The <i>AddressString</i> parameter is defined to the PCSTR data type.
 
 The <a href="/windows/desktop/api/winsock2/ns-winsock2-in_addr">IN_ADDR</a> structure is defined in the <i>Inaddr.h</i> header file.
-
-An import library containing the <b>RtlIpv4StringToAddressEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4StringToAddressEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
 
 ## -see-also
 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressexw.md
@@ -148,8 +148,6 @@ When both UNICODE and  _UNICODE are not defined, <b>RtlIpv4StringToAddressEx</b>
 
 The <a href="/windows/desktop/api/winsock2/ns-winsock2-in_addr">IN_ADDR</a> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4StringToAddressEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4StringToAddressEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 ## -see-also
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv4stringtoaddressw.md
@@ -150,10 +150,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv4StringToAddress</b> is
 
 The <a href="/windows/desktop/api/winsock2/ns-winsock2-in_addr">IN_ADDR</a> structure is defined in the <i>Inaddr.h</i> header file.
 
-An import library containing the <b>RtlIpv4StringToAddress</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv4StringToAddress</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringa.md
@@ -92,10 +92,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6AddressToString</b> is
 
 The <b>IN6_ADDR</b> structure is defined in the <i>In6addr.h</i> header file.
 
-An import library containing the <b>RtlIpv6AddressToString</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6AddressToString</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexa.md
@@ -123,8 +123,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6AddressToStringEx</b> 
 
 The <b>IN6_ADDR</b> structure is defined in the <i>In6addr.h</i> header file.
 
-An import library containing the <b>RtlIpv6AddressToStringEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6AddressToStringEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 ## -see-also
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>  

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringexw.md
@@ -141,8 +141,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6AddressToStringEx</b> 
 
 The <b>IN6_ADDR</b> structure is defined in the <i>In6addr.h</i> header file.
 
-An import library containing the <b>RtlIpv6AddressToStringEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6AddressToStringEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 ## -see-also
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6addresstostringw.md
@@ -92,10 +92,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6AddressToString</b> is
 
 The <b>IN6_ADDR</b> structure is defined in the <i>In6addr.h</i> header file.
 
-An import library containing the <b>RtlIpv6AddressToString</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6AddressToString</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressa.md
@@ -137,8 +137,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6StringToAddress</b> is
 
 The <a href="/previous-versions/windows/desktop/legacy/ms738560(v=vs.85)">IN6_ADDR</a> structure is defined in the In6addr.h header file.
 
-An import library containing the <b>RtlIpv6StringToAddress</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6StringToAddress</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 
 
 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexa.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexa.md
@@ -14,7 +14,7 @@ req.idl:
 req.include-header: Mstcpip.h 
 req.irql: 
 req.kmdf-ver: 
-req.lib: 
+req.lib: ntdll.lib
 req.max-support: 
 req.namespace: 
 req.redist: 
@@ -114,8 +114,6 @@ When either UNICODE or _UNICODE is defined, <b>RtlIpv6StringToAddressEx</b> is d
 When both UNICODE and _UNICODE are not defined, <b>RtlIpv6StringToAddressEx</b> is defined to <b>RtlIpv6StringToAddressExA</b>, the ANSI version of this function. The <i>AddressString</i> parameter is defined to the PCSTR data type.
 
 The <a href="/previous-versions/windows/desktop/legacy/ms738560(v=vs.85)">IN6_ADDR</a> structure is defined in the In6addr.h header file.
-
-An import library containing the <b>RtlIpv6StringToAddressEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6StringToAddressEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
 
 ## -see-also
 

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressexw.md
@@ -134,8 +134,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6StringToAddressEx</b> 
 
 The <a href="/previous-versions/windows/desktop/legacy/ms738560(v=vs.85)">IN6_ADDR</a> structure is defined in the In6addr.h header file.
 
-An import library containing the <b>RtlIpv6StringToAddressEx</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6StringToAddressEx</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
 ## -see-also
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a>

--- a/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressw.md
+++ b/sdk-api-src/content/ip2string/nf-ip2string-rtlipv6stringtoaddressw.md
@@ -137,10 +137,6 @@ When both UNICODE and _UNICODE are not defined, <b>RtlIpv6StringToAddress</b> is
 
 The <a href="/previous-versions/windows/desktop/legacy/ms738560(v=vs.85)">IN6_ADDR</a> structure is defined in the In6addr.h header file.
 
-An import library containing the <b>RtlIpv6StringToAddress</b> function is not included in the Microsoft Windows Software Development Kit (SDK) released for Windows Vista. The <b>RtlIpv6StringToAddress</b> function is included in the <i>Ntdll.lib</i> import library included in the Windows Driver Kit (WDK). An application could also use the <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulehandlea">GetModuleHandle</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-getprocaddress">GetProcAddress</a> functions to retrieve the function pointer from the <i>Ntdll.dll</i> and call this function.
-
-
-
 
 
 > [!NOTE]


### PR DESCRIPTION
Vista is out of support and newer SDKs do include ntdll.lib.