### PR TITLE
Update ns-wlanapi-wlan_radio_state.md

### DIFF
--- a/sdk-api-src/content/wlanapi/ns-wlanapi-wlan_radio_state.md
+++ b/sdk-api-src/content/wlanapi/ns-wlanapi-wlan_radio_state.md
@@ -64,7 +64,7 @@ The number of valid PHY indices in the <b>PhyRadioState</b> member.
 
 ### -field PhyRadioState
 
-An array of <a href="/windows/desktop/api/wlanapi/ns-wlanapi-wlan_phy_radio_state">WLAN_PHY_RADIO_STATE</a> structures that specify the radio states of a number of PHY indices. Only the first <b>dwNumberOfPhys</b> entries in this array are valid.
+An array of <a href="/windows/desktop/api/wlanapi/ns-wlanapi-wlan_phy_radio_state">WLAN_PHY_RADIO_STATE</a> structures that specify the radio states of a number of PHY indices. Only the first <b>dwNumberOfPhys</b> entries in this array are valid. WLAN_MAX_PHY_INDEX is set to 64.
 
 ## -remarks
 


### PR DESCRIPTION
Added description of `WLAN_MAX_PHY_INDEX` as in the `WLAN_INTERFACE_CAPABILITY` structure [documentation page](https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ns-wlanapi-wlan_interface_capability). 