### PR TITLE
PathFileExists articles update

### DIFF
--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsa.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsa.md
@@ -64,13 +64,18 @@ Determines whether a path to a file system object such as a file or folder is va
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the full path of the object to verify.
+A pointer to a null-terminated string that contains the full path of the object to verify.
+
+By default, the name is limited to MAX_PATH characters. To extend this limit to 32,767 wide characters, prepend "\\\\?\\" to the path. For more information, see [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file).
+
+> [!TIP]
+> Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation without prepending "\\\\?\\". See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
 
 ## -returns
 
 Type: <b>BOOL</b>
 
-<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
+<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. If the file does not exist, <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>. If the path does not exist, <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="/windows/win32/debug/system-error-codes--0-499-">ERROR_PATH_NOT_FOUND</a>.
 
 ## -remarks
 

--- a/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
+++ b/sdk-api-src/content/shlwapi/nf-shlwapi-pathfileexistsw.md
@@ -64,13 +64,18 @@ Determines whether a path to a file system object such as a file or folder is va
 
 Type: <b>LPCTSTR</b>
 
-A pointer to a null-terminated string of maximum length MAX_PATH that contains the full path of the object to verify.
+A pointer to a null-terminated string that contains the full path of the object to verify.
+
+By default, the name is limited to MAX_PATH characters. To extend this limit to 32,767 wide characters, prepend "\\\\?\\" to the path. For more information, see [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file).
+
+> [!TIP]
+> Starting with Windows 10, Version 1607, you can opt-in to remove the MAX_PATH limitation without prepending "\\\\?\\". See the "Maximum Path Length Limitation" section of [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file) for details.
 
 ## -returns
 
 Type: <b>BOOL</b>
 
-<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. If the file does not exist, <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>.
+<b>TRUE</b> if the file exists; otherwise, <b>FALSE</b>. Call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information. If the file does not exist, <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="/windows/win32/debug/system-error-codes--0-499-">ERROR_FILE_NOT_FOUND</a>. If the path does not exist, <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> will return <a href="/windows/win32/debug/system-error-codes--0-499-">ERROR_PATH_NOT_FOUND</a>.
 
 ## -remarks
 


### PR DESCRIPTION
1. Since PathFileExists calls GetFileAttributes it supports extended-length paths:
```
Child-SP          RetAddr           Call Site
00000000`001bf718 000007fe`fefec9b1 kernel32!GetFileAttributesW
00000000`001bf720 00000001`3f9b1037 SHLWAPI!PathFileExistsW+0x2d
```
Extended-length paths usage info added to pszPath parameter description.
2. ERROR_FILE_NOT_FOUND case added to PathFileExistsA.
3. ERROR_PATH_NOT_FOUND case added.