### PR TITLE
Update nf-wlanapi-wlanscan.md

### DIFF
--- a/sdk-api-src/content/wlanapi/nf-wlanapi-wlanscan.md
+++ b/sdk-api-src/content/wlanapi/nf-wlanapi-wlanscan.md
@@ -71,7 +71,7 @@ The GUID of the interface to be queried.
 
 ### -param pDot11Ssid [in, optional]
 
-A pointer to a <a href="/windows/desktop/NativeWiFi/dot11-ssid">DOT11_SSID</a> structure that specifies the SSID of the network to be scanned. This parameter is optional. When set to <b>NULL</b>, the returned list contains all available networks. 
+A pointer to a <a href="/windows/desktop/NativeWiFi/dot11-ssid">DOT11_SSID</a> structure that specifies the SSID of the network to be scanned. This parameter may be <b>NULL</b>. 
 <b>Windows XP with SP3 and Wireless LAN API for Windows XP with SP2:  </b>This parameter must be <b>NULL</b>.
 
 ### -param pIeData [in, optional]


### PR DESCRIPTION
The current documentation for the `[in, optional] pDot11Ssid` parameter states that `the returned list contains all available networks` but the function doesn't return any list.