### PR TITLE
ListView_SetView article update to match the SDK

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-listview_setview.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-listview_setview.md
@@ -50,7 +50,7 @@ api_name:
 ## -syntax
 
 ```cpp
-int ListView_SetView(
+DWORD ListView_SetView(
    HWND  hwnd,
    DWORD iView
 );
@@ -58,9 +58,9 @@ int ListView_SetView(
 
 ## -returns
 
-Type: **int**
+Type: **DWORD**
 
-Returns 1 if successful, or -1 otherwise. For example, returns -1 if the view is invalid. 
+Returns 1 if successful, or UINT_MAX otherwise. For example, returns UINT_MAX if the view is invalid.
 
 
 ## -description


### PR DESCRIPTION
LVM_SETVIEW message returns -1 in case of failure, but ListView_SetView macro performs type casting to DWORD (CommCtrl.h, Windows SDK 10.0.26100.0):
```
#define ListView_SetView(hwnd, iView) \
    (DWORD)SNDMSG((hwnd), LVM_SETVIEW, (WPARAM)(DWORD)(iView), 0)
```
Documentation states that ListView_SetView return type is int and in case of failure it returns -1.
This change brings the article to match CommCtrl.h, but it's better to fix this inconsistency on SDK side.