### PR TITLE
Add undocumented requirements for MEM_ADDRESS_REQUIREMENTS 

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -74,7 +74,7 @@ If this member is <b>NULL</b>, then there is no upper limit.
 ### -field Alignment
 
 Specifies power-of-2 alignment. Specifying 0 aligns the returned address on the system allocation granularity.
-If nonzero, this value must be larger or equal to the system allocation granularity.
+If nonzero, this value must be greater than or equal to the system allocation granularity.
 
 ## -remarks
 

--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -68,7 +68,7 @@ If this member is <b>NULL</b>, then there is no lower limit.
 ### -field HighestEndingAddress
 
 Specifies the highest acceptable address (inclusive).
-This address must not exceed <b>lpMaximumApplicationAddress</b> and must be **one less** than a multiple of the allocation granularity returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>.
+This address must not exceed <b>lpMaximumApplicationAddress</b> and must be <b>one less</b> than a multiple of the allocation granularity returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>.
 If this member is <b>NULL</b>, then there is no upper limit.
 
 ### -field Alignment

--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -68,12 +68,13 @@ If this member is <b>NULL</b>, then there is no lower limit.
 ### -field HighestEndingAddress
 
 Specifies the highest acceptable address (inclusive).
-This address must not exceed <b>lpMaximumApplicationAddress</b> returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>.
+This address must not exceed <b>lpMaximumApplicationAddress</b> and must be **one less** than a multiple of the allocation granularity returned by <a href="/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getsysteminfo">GetSystemInfo</a>.
 If this member is <b>NULL</b>, then there is no upper limit.
 
 ### -field Alignment
 
 Specifies power-of-2 alignment. Specifying 0 aligns the returned address on the system allocation granularity.
+If nonzero, this value must be larger or equal to the sytem allocation granularity.
 
 ## -remarks
 

--- a/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
+++ b/sdk-api-src/content/winnt/ns-winnt-mem_address_requirements.md
@@ -74,7 +74,7 @@ If this member is <b>NULL</b>, then there is no upper limit.
 ### -field Alignment
 
 Specifies power-of-2 alignment. Specifying 0 aligns the returned address on the system allocation granularity.
-If nonzero, this value must be larger or equal to the sytem allocation granularity.
+If nonzero, this value must be larger or equal to the system allocation granularity.
 
 ## -remarks
 


### PR DESCRIPTION
Based on my testing, `VirtualAlloc2` and other winapi functions taking [`MEM_ADDRESS_REQUIREMENTS`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-mem_address_requirements) will fail with `ERROR_INVALID_PARAMETER` if the following do not hold:
- If `HighestEndingAddress` is not NULL, then it must be 1 less than a multiple of the allocation granularity.
- If `Alignment` is nonzero, it must be larger or equal to the allocation granularity.

This is not currently documented, and are things I believe most readers would expect the function to take into account for them (e.g. by rounding `HighestEndingAddress` down to the highest suitable value). 