### PR TITLE
IDropTarget::Drop article update

### DIFF
--- a/sdk-api-src/content/oleidl/nf-oleidl-idroptarget-drop.md
+++ b/sdk-api-src/content/oleidl/nf-oleidl-idroptarget-drop.md
@@ -82,6 +82,17 @@ This method returns S_OK on success. Other possible values include the following
 <tr>
 <td width="40%">
 <dl>
+<dt><b>DRAGDROP_S_CANCEL</b></dt>
+</dl>
+</td>
+<td width="60%">
+The OLE drag-and-drop operation was canceled.
+
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
 <dt><b>E_UNEXPECTED</b></dt>
 </dl>
 </td>


### PR DESCRIPTION
DoDragDrop returns DRAGDROP_S_CANCEL in case of cancellation. Since IDropTarget::Drop result is returned by DoDragDrop, DRAGDROP_S_CANCEL should be in the list of possible return values for IDropTarget::Drop.