### PR TITLE
Add missing possible revision for WIN_CERTIFICATE

### DIFF
--- a/sdk-api-src/content/wintrust/ns-wintrust-win_certificate.md
+++ b/sdk-api-src/content/wintrust/ns-wintrust-win_certificate.md
@@ -66,7 +66,7 @@ Specifies the length, in bytes, of the signature.
 
 Specifies the certificate revision.
 
-The only defined certificate revision is <b>WIN_CERT_REVISION_1_0 (0x0100)</b>.
+The only defined certificate revisions are <b>WIN_CERT_REVISION_1_0 (0x0100)</b> and <b>WIN_CERT_REVISION_2_0 (0x0200)</b>.
 
 ### -field wCertificateType
 

--- a/sdk-api-src/content/wintrust/ns-wintrust-win_certificate.md
+++ b/sdk-api-src/content/wintrust/ns-wintrust-win_certificate.md
@@ -66,7 +66,7 @@ Specifies the length, in bytes, of the signature.
 
 Specifies the certificate revision.
 
-The only defined certificate revisions are <b>WIN_CERT_REVISION_1_0 (0x0100)</b> and <b>WIN_CERT_REVISION_2_0 (0x0200)</b>.
+The defined certificate revisions are <b>WIN_CERT_REVISION_1_0 (0x0100)</b> and <b>WIN_CERT_REVISION_2_0 (0x0200)</b>.
 
 ### -field wCertificateType
 


### PR DESCRIPTION
Since this was written, `WIN_CERT_REVISION_2_0` was introduced which has the value of `0x200`.