### PR TITLE
Update documentation for GetModuleFileName functions

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamea.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamea.md
@@ -79,7 +79,7 @@ The <b>GetModuleFileName</b> function does not retrieve the path for modules  th
 
 A pointer to a buffer that receives the fully qualified path of the module. If the length of the path is less than the size that the <i>nSize</i> parameter specifies, the function succeeds and the path is returned as a null-terminated string. 
 
-If the length of the path exceeds the size that  the <i>nSize</i> parameter specifies, the function succeeds and the string is truncated to <i>nSize</i>  characters including the terminating null character.
+If the length of the path equals or exceeds the value specified by <i>nSize</i>, the function succeeds and the string is truncated to <i>nSize</i> characters (including the terminating null character).
 
 <b>Windows XP:  </b>The string is truncated to <i>nSize</i> characters and is not null-terminated.
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
@@ -79,7 +79,7 @@ The <b>GetModuleFileName</b> function does not retrieve the path for modules  th
 
 A pointer to a buffer that receives the fully qualified path of the module. If the length of the path is less than the size that the <i>nSize</i> parameter specifies, the function succeeds and the path is returned as a null-terminated string. 
 
-If the length of the path exceeds or equals the size that  the <i>nSize</i> parameter specifies, the function succeeds and the string is truncated to <i>nSize</i>  characters including the terminating null character.
+If the length of the path equals or exceeds the value specified by <i>nSize</i>, the function succeeds and the string is truncated to <i>nSize</i>  characters (including the terminating null character).
 
 <b>Windows XP:  </b>The string is truncated to <i>nSize</i> characters and is not null-terminated.
 
@@ -137,4 +137,5 @@ For an example, see
 
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a>
+
 

--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getmodulefilenamew.md
@@ -79,7 +79,7 @@ The <b>GetModuleFileName</b> function does not retrieve the path for modules  th
 
 A pointer to a buffer that receives the fully qualified path of the module. If the length of the path is less than the size that the <i>nSize</i> parameter specifies, the function succeeds and the path is returned as a null-terminated string. 
 
-If the length of the path exceeds the size that  the <i>nSize</i> parameter specifies, the function succeeds and the string is truncated to <i>nSize</i>  characters including the terminating null character.
+If the length of the path exceeds or equals the size that  the <i>nSize</i> parameter specifies, the function succeeds and the string is truncated to <i>nSize</i>  characters including the terminating null character.
 
 <b>Windows XP:  </b>The string is truncated to <i>nSize</i> characters and is not null-terminated.
 
@@ -137,3 +137,4 @@ For an example, see
 
 
 <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibraryexa">LoadLibraryEx</a>
+


### PR DESCRIPTION
## Summary
Fix documentation ambiguity in GetModuleFileNameW regarding buffer size behavior when buffer size equals module path length.

## Problem
The original documentation stated truncation occurs when path length "exceeds" buffer size, but didn't clearly specify the behavior when they are equal. Testing revealed that even when buffer size exactly equals the path length, truncation still occurs.

## Solution
Updated the documentation to specify that truncation occurs when path length "exceeds or equals" the buffer size.

## Test Evidence
<img width="1538" height="875" alt="image" src="https://github.com/user-attachments/assets/2d92a3b9-2425-455f-924b-01905ff1ae57" />

Test showed:
- Full module path: 50 characters
- Buffer size 50: Resulted in truncation to 48 characters + null terminator
- This confirms that buffer_size == path_length is treated as insufficient
