### PR TITLE
Remove UTF-8 BOM

### DIFF
--- a/sdk-api-src/content/evntprov/ns-evntprov-event_filter_descriptor.md
+++ b/sdk-api-src/content/evntprov/ns-evntprov-event_filter_descriptor.md
@@ -1,4 +1,4 @@
-﻿---
+---
 UID: NS:evntprov._EVENT_FILTER_DESCRIPTOR
 title: EVENT_FILTER_DESCRIPTOR (evntprov.h)
 description:

--- a/sdk-api-src/content/evntrace/nf-evntrace-controltracea.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-controltracea.md
@@ -1,4 +1,4 @@
-﻿---
+---
 UID: NF:evntrace.ControlTraceA
 title: ControlTraceA function (evntrace.h)
 description: The ControlTraceA (ANSI) function (evntrace.h) flushes, queries, updates, or stops the specified event tracing session.

--- a/sdk-api-src/content/evntrace/nf-evntrace-controltracew.md
+++ b/sdk-api-src/content/evntrace/nf-evntrace-controltracew.md
@@ -1,4 +1,4 @@
-﻿---
+---
 UID: NF:evntrace.ControlTraceW
 title: ControlTraceW function (evntrace.h)
 description: The ControlTraceW (Unicode) function (evntrace.h) flushes, queries, updates, or stops the specified event tracing session.

--- a/sdk-api-src/content/evntrace/ns-evntrace-event_trace_properties.md
+++ b/sdk-api-src/content/evntrace/ns-evntrace-event_trace_properties.md
@@ -1,4 +1,4 @@
-﻿---
+---
 UID: NS:evntrace._EVENT_TRACE_PROPERTIES
 title: EVENT_TRACE_PROPERTIES (evntrace.h)
 description:

--- a/sdk-api-src/content/evntrace/ns-evntrace-event_trace_properties_v2.md
+++ b/sdk-api-src/content/evntrace/ns-evntrace-event_trace_properties_v2.md
@@ -1,4 +1,4 @@
-﻿---
+---
 UID: NS:evntrace._EVENT_TRACE_PROPERTIES_V2
 title: EVENT_TRACE_PROPERTIES_V2 (evntrace.h)
 description:


### PR DESCRIPTION
For consistency and also to have them rendered correctly on GitHub, for example you can see how broken it is now:
https://github.com/MicrosoftDocs/sdk-api/blob/5afb46306d9d99f2c56eea0f3ddfd45cb84cc486/sdk-api-src/content/evntprov/ns-evntprov-event_filter_descriptor.md