### PR TITLE
Remove tab characters in YAML

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-get_pointerid_wparam.md
+++ b/sdk-api-src/content/winuser/nf-winuser-get_pointerid_wparam.md
@@ -7,7 +7,7 @@ old-location: inputmsg\get_pointerid_wparam.htm
 tech.root: InputMsg
 ms.assetid: 31f7dde6-1486-4050-b9b6-ffc2ed991211
 ms.date: 07/01/2025
-ms.keywords: GET_POINTERID_WPARAM, GET_POINTERID_WPARAM	, GET_POINTERID_WPARAM macro [Input Messages and Notifications], inputmsg.get_pointerid_wparam, winuser/GET_POINTERID_WPARAM
+ms.keywords: GET_POINTERID_WPARAM, GET_POINTERID_WPARAM, GET_POINTERID_WPARAM macro [Input Messages and Notifications], inputmsg.get_pointerid_wparam, winuser/GET_POINTERID_WPARAM
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows

--- a/sdk-api-src/content/winuser/nf-winuser-is_pointer_flag_set_wparam.md
+++ b/sdk-api-src/content/winuser/nf-winuser-is_pointer_flag_set_wparam.md
@@ -7,7 +7,7 @@ old-location: inputmsg\is_pointer_flag_set_wparam.htm
 tech.root: InputMsg
 ms.assetid: 31f7dde6-1486-4050-b9b6-ffc2ed991200
 ms.date: 07/01/2025
-ms.keywords: IS_POINTER_FLAG_SET_WPARAM, IS_POINTER_FLAG_SET_WPARAM	, IS_POINTER_FLAG_SET_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_flag_set_wparam, winuser/IS_POINTER_FLAG_SET_WPARAM
+ms.keywords: IS_POINTER_FLAG_SET_WPARAM, IS_POINTER_FLAG_SET_WPARAM, IS_POINTER_FLAG_SET_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_flag_set_wparam, winuser/IS_POINTER_FLAG_SET_WPARAM
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows

--- a/sdk-api-src/content/winuser/nf-winuser-is_pointer_incontact_wparam.md
+++ b/sdk-api-src/content/winuser/nf-winuser-is_pointer_incontact_wparam.md
@@ -7,7 +7,7 @@ old-location: inputmsg\is_pointer_incontact_wparam.htm
 tech.root: InputMsg
 ms.assetid: 31f7dde6-1486-4050-b9b6-ffc2ed9912a8
 ms.date: 07/01/2025
-ms.keywords: IS_POINTER_INCONTACT_WPARAM, IS_POINTER_INCONTACT_WPARAM	, IS_POINTER_INCONTACT_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_incontact_wparam, winuser/IS_POINTER_INCONTACT_WPARAM
+ms.keywords: IS_POINTER_INCONTACT_WPARAM, IS_POINTER_INCONTACT_WPARAM, IS_POINTER_INCONTACT_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_incontact_wparam, winuser/IS_POINTER_INCONTACT_WPARAM
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows

--- a/sdk-api-src/content/winuser/nf-winuser-is_pointer_inrange_wparam.md
+++ b/sdk-api-src/content/winuser/nf-winuser-is_pointer_inrange_wparam.md
@@ -7,7 +7,7 @@ old-location: inputmsg\is_pointer_inrange_wparam.htm
 tech.root: InputMsg
 ms.assetid: 41f7dde6-1486-4050-b9b6-ffc2ed9912a8
 ms.date: 07/01/2025
-ms.keywords: IS_POINTER_INRANGE_WPARAM, IS_POINTER_INRANGE_WPARAM	, IS_POINTER_INRANGE_WPARAM macro, inputmsg.is_pointer_inrange_wparam, winuser/IS_POINTER_INRANGE_WPARAM
+ms.keywords: IS_POINTER_INRANGE_WPARAM, IS_POINTER_INRANGE_WPARAM, IS_POINTER_INRANGE_WPARAM macro, inputmsg.is_pointer_inrange_wparam, winuser/IS_POINTER_INRANGE_WPARAM
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows

--- a/sdk-api-src/content/winuser/nf-winuser-is_pointer_new_wparam.md
+++ b/sdk-api-src/content/winuser/nf-winuser-is_pointer_new_wparam.md
@@ -7,7 +7,7 @@ old-location: inputmsg\is_pointer_new_wparam.htm
 tech.root: InputMsg
 ms.assetid: 21f7dde6-1486-4050-b9b6-ffc2ed9912a8
 ms.date: 07/01/2025
-ms.keywords: IS_POINTER_NEW_WPARAM, IS_POINTER_NEW_WPARAM	, IS_POINTER_NEW_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_new_wparam, winuser/IS_POINTER_NEW_WPARAM
+ms.keywords: IS_POINTER_NEW_WPARAM, IS_POINTER_NEW_WPARAM, IS_POINTER_NEW_WPARAM macro [Input Messages and Notifications], inputmsg.is_pointer_new_wparam, winuser/IS_POINTER_NEW_WPARAM
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows


### PR DESCRIPTION
Fixes parsing the YAML with PyYAML, which otherwise fails with "found character '\t' that cannot start any token".