### PR TITLE
Fix memory type in reference to shader-visible UAV descriptor documentation (ClearUAVUint)

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint.md
@@ -67,7 +67,7 @@ Type: [in] **[D3D12_CPU_DESCRIPTOR_HANDLE](./ns-d3d12-d3d12_cpu_descriptor_handl
 A [D3D12_CPU_DESCRIPTOR_HANDLE](./ns-d3d12-d3d12_cpu_descriptor_handle.md) in a non-shader visible descriptor heap that references an initialized descriptor for the unordered-access view (UAV) that is to be cleared.
 
 > [!IMPORTANT]
-> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers that implement the clear as a fixed-function hardware operation (rather than as a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in **WRITE_BACK** memory (similar to **D3D12_HEAP_TYPE_UPLOAD** heap types), and CPU reads from this type of memory are prohibitively slow.
+> This descriptor must not be in a shader-visible descriptor heap. This is to allow drivers that implement the clear as a fixed-function hardware operation (rather than as a dispatch) to efficiently read from the descriptor, as shader-visible heaps may be created in **WRITE_COMBINE** memory (similar to **D3D12_HEAP_TYPE_UPLOAD** heap types), and CPU reads from this type of memory are prohibitively slow.
 
 ### -param pResource
 


### PR DESCRIPTION
Shader visible descriptor heaps are usually WRITE_COMBINE on the CPU.