### PR TITLE
Update nf-shobjidl_core-ishellfolder-parsedisplayname.md

### DIFF
--- a/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellfolder-parsedisplayname.md
+++ b/sdk-api-src/content/shobjidl_core/nf-shobjidl_core-ishellfolder-parsedisplayname.md
@@ -81,7 +81,7 @@ A null-terminated Unicode string with the display name. Because each Shell folde
 
 
 ```cpp
-::{CLSID for Control Panel}\::{CLSID for printers folder}
+::{5399E694-6CE5-4D6C-8FCE-1D8870FDCBA0}
 
 ```
 


### PR DESCRIPTION
The original text

> `::{CLSID for Control Panel}\::{CLSID for printers folder}`

doesn't match the previous sentence.

> retrieve a fully qualified identifier list for the control panel from the desktop folder

Furthermore, double-GUID Control Panel monikers are a legacy pattern. Thus, I replaced the original text with the Control Panel GUID: `::{5399E694-6CE5-4D6C-8FCE-1D8870FDCBA0}`
