### PR TITLE
Update nf-winnls-getnumberformatex.md

### DIFF
--- a/sdk-api-src/content/winnls/nf-winnls-getnumberformatex.md
+++ b/sdk-api-src/content/winnls/nf-winnls-getnumberformatex.md
@@ -94,7 +94,7 @@ Pointer to a null-terminated string containing the number string to format. This
 
 ### -param lpFormat [in, optional]
 
-Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-numberfmta">NUMBERFMT</a> structure that contains number formatting information, with all members set to appropriate values. If the application does not set this parameter to <b>NULL</b>, the function uses the locale only for formatting information not specified in the structure, for example, the locale string value for the negative sign.
+Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-numberfmta">NUMBERFMT</a> structure that contains number formatting information, with all members set to appropriate values. If the application does not set this parameter to <b>NULL</b>, the function uses the locale formatting information.
 
 ### -param lpNumberStr [out, optional]
 


### PR DESCRIPTION
Reasons for the edits:

1. The sentence "the function uses the locale only for formatting information not specified in the structure" is indeterminate.
2. The [NUMBERFMTW](https://learn.microsoft.com/en-us/windows/win32/api/winnls/ns-winnls-numberfmtw) structure does not provide a method to specify the string value for the negative sign.
3. The string value for the negative sign should not be affected by a locale. Mathematicians might otherwise object.

