### PR TITLE
Fix some typos and bad info in fileapi.h docs

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getlogicaldrivestringsw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlogicaldrivestringsw.md
@@ -70,9 +70,8 @@ Fills a buffer with strings that specify valid drives in the system.
 
 ### -param nBufferLength [in]
 
-The maximum size of the buffer pointed to by <i>lpBuffer</i>, in 
-      <b>TCHARs</b>. This size does not include the terminating null character. If this 
-      parameter is zero, <i>lpBuffer</i> is not used.
+The maximum size of the buffer pointed to by <i>lpBuffer</i>, in
+      <b>TCHARs</b>. If this parameter is zero, <i>lpBuffer</i> is not used.
 
 ### -param lpBuffer [out]
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getlogicaldrivestringsw.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlogicaldrivestringsw.md
@@ -70,8 +70,8 @@ Fills a buffer with strings that specify valid drives in the system.
 
 ### -param nBufferLength [in]
 
-The maximum size of the buffer pointed to by <i>lpBuffer</i>, in
-      <b>TCHARs</b>. If this parameter is zero, <i>lpBuffer</i> is not used.
+The maximum size of the buffer pointed to by <i>lpBuffer</i>, in <b>TCHARs</b>. This value includes
+      space for the terminating null character. If this parameter is zero, <i>lpBuffer</i> is not used.
 
 ### -param lpBuffer [out]
 
@@ -186,3 +186,4 @@ For an example, see
 
 
 <a href="/windows/desktop/FileIO/volume-management-functions">Volume Management Functions</a>
+

--- a/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamea.md
@@ -93,7 +93,7 @@ The size of the buffer <i>lpszLongPath</i> points to, in
 If the function succeeds, the return value is the length, in <b>TCHARs</b>, of the 
        string copied to <i>lpszLongPath</i>, not including the terminating null character.
 
-If the <i>lpBuffer</i> buffer is too small to contain the path, the return value is the 
+If the <i>lpszLongPath</i> buffer is too small to contain the path, the return value is the 
        size, in <b>TCHARs</b>, of the buffer that is required to hold the path and the 
        terminating null character.
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamew.md
@@ -103,7 +103,7 @@ The size of the buffer <i>lpszLongPath</i> points to, in
 If the function succeeds, the return value is the length, in <b>TCHARs</b>, of the 
        string copied to <i>lpszLongPath</i>, not including the terminating null character.
 
-If the <i>lpBuffer</i> buffer is too small to contain the path, the return value is the 
+If the <i>lpszLongPath</i> buffer is too small to contain the path, the return value is the 
        size, in <b>TCHARs</b>, of the buffer that is required to hold the path and the 
        terminating null character.
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2a.md
@@ -52,7 +52,7 @@ Retrieves the path of the directory designated for temporary files, based on the
 
 ### -param BufferLength [in]
 
-The size of the string buffer identified by *lpBuffer*, in **TCHARs**.
+The size of the string buffer identified by *Buffer*, in **TCHARs**.
 
 ### -param Buffer [out]
 
@@ -60,7 +60,7 @@ A pointer to a string buffer that receives the null-terminated string specifying
 
 ## -returns
 
-If the function succeeds, the return value is the length, in **TCHARs**, of the string copied to *lpBuffer*, not including the terminating null character. If the return value is greater than *nBufferLength*, the return value is the length, in **TCHARs**, of the buffer required to hold the path.
+If the function succeeds, the return value is the length, in **TCHARs**, of the string copied to *Buffer*, not including the terminating null character. If the return value is greater than *BufferLength*, the return value is the length, in **TCHARs**, of the buffer required to hold the path.
 
 If the function fails, the return value is zero. To get extended error information, call [GetLastError](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 

--- a/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2w.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-gettemppath2w.md
@@ -53,7 +53,7 @@ Retrieves the path of the directory designated for temporary files, based on the
 
 ### -param BufferLength [in]
 
-The size of the string buffer identified by *lpBuffer*, in **TCHARs**.
+The size of the string buffer identified by *Buffer*, in **TCHARs**.
 
 ### -param Buffer [out]
 
@@ -61,7 +61,7 @@ A pointer to a string buffer that receives the null-terminated string specifying
 
 ## -returns
 
-If the function succeeds, the return value is the length, in **TCHARs**, of the string copied to *lpBuffer*, not including the terminating null character. If the return value is greater than *nBufferLength*, the return value is the length, in **TCHARs**, of the buffer required to hold the path.
+If the function succeeds, the return value is the length, in **TCHARs**, of the string copied to *Buffer*, not including the terminating null character. If the return value is greater than *BufferLength*, the return value is the length, in **TCHARs**, of the buffer required to hold the path.
 
 If the function fails, the return value is zero. To get extended error information, call [GetLastError](/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 


### PR DESCRIPTION
These functions' docs referred to parameter names that didn't exist.

Also, the docs for the [`GetLogicalDriveStringsW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrivestringsw) function's `nBufferLength` parameter said "This size does not include the terminating null character" but this isn't true as far as I can tell.