### PR TITLE
Change DirectX 12 Agility SDK requirement to 1.6

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options12.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_feature_data_d3d12_options12.md
@@ -56,7 +56,7 @@ Indicates whether or not Enhanced Barriers are supported. `true` if supported, o
 
 Enhanced Barriers is not currently a hardware or driver requirement. So before using command list Barrier APIs, or resource creation APIs using the *InitialLayout* parameter, you must check for optional driver support via *EnhancedBarriersSupported*.
 
-Requires the DirectX 12 Agility SDK 1.7 or later; otherwise, the value is always `FALSE`.
+Requires the DirectX 12 Agility SDK 1.6 or later; otherwise, the value is always `FALSE`.
 
 ### -field RelaxedFormatCastingSupported
 
@@ -64,7 +64,7 @@ Type: \_Out\_ **[BOOL](/windows/win32/winprog/windows-data-types)**
 
 Technically used to indicate support for the functionality that enables integer aliasing.
 
-Requires the DirectX 12 Agility SDK 1.7 or later; otherwise, the value is always `FALSE`.
+Requires the DirectX 12 Agility SDK 1.6 or later; otherwise, the value is always `FALSE`.
 
 ## -remarks
 


### PR DESCRIPTION
Updated the required version of the DirectX 12 Agility SDK for Enhanced Barriers and Relaxed Format Casting support to version 1.6. It was previously listed that 1.7 was required, but no such Agility SDK version exists and is incorrect.