### PR TITLE
Modify RtlInitUnicodeString DestinationString to be 'out'

### DIFF
--- a/sdk-api-src/content/winternl/nf-winternl-rtlinitunicodestring.md
+++ b/sdk-api-src/content/winternl/nf-winternl-rtlinitunicodestring.md
@@ -55,7 +55,7 @@ Initializes a counted Unicode string.
 
 ## -parameters
 
-### -param DestinationString [in, out]
+### -param DestinationString [out]
 
 The buffer for a counted Unicode string to be initialized. The length is initialized to zero if the <i>SourceString</i> is not specified.
 


### PR DESCRIPTION
Updated parameter documentation for DestinationString.

Reference:
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlinitunicodestring