### PR TITLE
Correct documentation of lpBuffer parameter for MprConfigFilterGetInfo

### DIFF
--- a/sdk-api-src/content/mprapi/nf-mprapi-mprconfigfiltergetinfo.md
+++ b/sdk-api-src/content/mprapi/nf-mprapi-mprconfigfiltergetinfo.md
@@ -94,10 +94,9 @@ A <b>DWORD</b> value that describes the transport protocol type of the static fi
 </tr>
 </table>
 
-### -param lpBuffer [out]
+### -param lpBuffer [in_out]
 
-On successful completion, a pointer to a <a href="/windows/desktop/api/mprapi/ns-mprapi-mpr_filter_0">MPR_FILTER_0</a> structure that contains the filter driver configuration information. Free this memory buffer by calling 
-<a href="/windows/desktop/api/mprapi/nf-mprapi-mprconfigbufferfree">MprConfigBufferFree</a>.
+On successful completion, writes a <a href="/windows/desktop/api/mprapi/ns-mprapi-mpr_filter_0">MPR_FILTER_0</a> structure with the filter driver configuration information to the provided buffer. <i>lpBuffer</i> must be at least <i>sizeof(<a href="/windows/desktop/api/mprapi/ns-mprapi-mpr_filter_0">MPR_FILTER_0</a>)</i> bytes long.
 
 ## -returns
 


### PR DESCRIPTION
Updated parameter description for `lpBuffer` to indicate it is `in_out` and clarified its usage.

The original documentation incorrectly described this function as returning newly allocated memory when the parameter has the wrong level of indirection. Since this function does not allocate new memory, there is no reason to say that `lpBuffer` must be freed (it is valid to pass a buffer that is allocated on the stack). 