### PR TITLE
Update nf-icmpapi-icmp6sendecho2.md

### DIFF
--- a/sdk-api-src/content/icmpapi/nf-icmpapi-icmp6sendecho2.md
+++ b/sdk-api-src/content/icmpapi/nf-icmpapi-icmp6sendecho2.md
@@ -221,7 +221,7 @@ Use
 
 ## -remarks
 
-The <b>Icmp6SendEcho2</b> function is called synchronously if the <i>ApcRoutine</i> or <i>Event</i> parameters are <b>NULL</b>. When called synchronously, the return value contains the number of replies received and stored in <i>ReplyBuffer</i> after waiting for the time specified in the <i>Timeout</i> parameter. If the return value is zero, call 
+The <b>Icmp6SendEcho2</b> function is called synchronously if the <i>ApcRoutine</i> and <i>Event</i> parameters are <b>NULL</b>. When called synchronously, the return value contains the number of replies received and stored in <i>ReplyBuffer</i> after waiting for the time specified in the <i>Timeout</i> parameter. If the return value is zero, call 
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> for extended error information.
 
 The <b>Icmp6SendEcho2</b> function is called asynchronously when either the <i>ApcRoutine</i> or <i>Event</i> parameters are specified. When called asynchronously,  the <i>ReplyBuffer</i> and <i>ReplySize</i> parameters are  required to accept the response. ICMP response data is copied to the <i>ReplyBuffer</i> provided and the application is signaled (when the <i>Event</i> parameter is specified) or the callback function is called (when the <i>ApcRoutine</i> parameter is specified). The application must parse the data pointed to by <i>ReplyBuffer</i> parameter using the <a href="/windows/desktop/api/icmpapi/nf-icmpapi-icmp6parsereplies">Icmp6ParseReplies</a> function. 


### PR DESCRIPTION
Corrected language to reflect the conditions below:

> If the Event parameter is specified, the Icmp6SendEcho2 function is called asynchronously.

> If the ApcRoutine parameter is specified, the Icmp6SendEcho2 function is called asynchronously.
