### PR TITLE
Fix ambiguous text of GetCopyableFootprints function

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-getcopyablefootprints.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-getcopyablefootprints.md
@@ -80,7 +80,7 @@ The number of subresources in the resource.  The range of valid values is 0 to (
 
 Type: <b>UINT64</b>
 
-The offset, in bytes, to the resource.
+The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts<i> array.
 
 ### -param pLayouts [out, optional]
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device8-getcopyablefootprints1.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device8-getcopyablefootprints1.md
@@ -68,7 +68,7 @@ The number of subresources in the resource. The range of valid values is 0 to (D
 
 Type: <b>UINT64</b>
 
-The offset, in bytes, to the resource.
+The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts<i> array.
 
 ### -param pLayouts
 


### PR DESCRIPTION
The current explanation for `BaseOffset` parameter is ambiguous. It is described as `The offset, in bytes, to the resource.`, which can be incorrectly interpreted as an offset of the resource represented by the `pResourceDesc` parameter.

In the function, `BaseOffset` is not an offset for the resource. Instead, it is a value that is simply added to the `Offset` of each subresource layout in the output `pLayouts` array.

For reference, see `d3dx12.h` version of `GetCopyableFootprints` : https://github.com/microsoft/DirectX-Headers/blob/18d5bfe96452667b201fd26aa25c6c305ae57e07/include/directx/d3dx12_resource_helpers.h#L520
