### PR TITLE
Update remarks section in integrity information documentation

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_integrity_information.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_set_integrity_information.md
@@ -90,8 +90,6 @@ For more information, see [NTSTATUS Values](/windows-hardware/drivers/kernel/nts
 
 ## -remarks
 
-The integrity status can only be changed for empty files.
-
 If the [ReplaceFile](../winbase/nf-winbase-replacefilea.md) is used to replace a file with integrity set, and the *lpBackupFileName* parameter points to a location that does not have integrity set, the integrity status of the original file will not be persisted.
 
 Writes to integrity streams are always cluster-sized. Reads from integrity streams are always done in  16 KB blocks. This can lead to reads failing even when the corrupt area is outside the region being read. For example, if 4 KB is read at offset 0 in a file and there is corruption starting 12 KB into the file, a read would fail with **ERROR_DATA_CHECKSUM_ERROR** (0x143).


### PR DESCRIPTION
Removed the note that integrity status can only be changed for empty files.