### PR TITLE
[Win32/Xaudio2] Fix warning message formatting in XAudio2Create doc

### DIFF
--- a/sdk-api-src/content/xaudio2/nf-xaudio2-xaudio2create.md
+++ b/sdk-api-src/content/xaudio2/nf-xaudio2-xaudio2create.md
@@ -71,7 +71,7 @@ An <a href="/windows/desktop/xaudio2/uint32-xaudio2-processor">XAUDIO2_PROCESSOR
 
 <a href="/windows/desktop/xaudio2/uint32-xaudio2-processor">XAUDIO2_PROCESSOR</a> default value is XAUDIO2_DEFAULT_PROCESSOR.
 
-<div class="alert"><b>Warning</b> If you specify <a href="/windows/desktop/xaudio2/uint32-xaudio2-processor">XAUDIO2_ANY_PROCESSOR</a>, the system will use all of the device's processors and, as noted above, create a worker thread for each processor.
+<div class="alert"><b>Warning</b> If you specify <a href="/windows/desktop/xaudio2/uint32-xaudio2-processor">XAUDIO2_ANY_PROCESSOR</a>, the system will use all of the device's processors and, as noted above, create a worker thread for each processor.</div>
 <div> </div>
 
 


### PR DESCRIPTION
Due to the unclosed div tag, the page styling is incorrect.

<img width="1258" height="1332" alt="image" src="https://github.com/user-attachments/assets/6ce830e9-87d0-409c-8991-c0a202a96d19" />
