### PR TITLE
TabCtrl_AdjustRect return value type corrected

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-tabctrl_adjustrect.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-tabctrl_adjustrect.md
@@ -50,7 +50,7 @@ api_name:
 ## -syntax
 
 ```cpp
-VOID TabCtrl_AdjustRect(
+int TabCtrl_AdjustRect(
    HWND hwnd,
    BOOL bLarger,
    RECT *prc
@@ -59,7 +59,7 @@ VOID TabCtrl_AdjustRect(
 
 ## -returns
 
-Type: **[VOID](/windows/desktop/winprog/windows-data-types)**
+Type: **int**
 
 No return value.
 


### PR DESCRIPTION
Return value type is int:
```
#define TabCtrl_AdjustRect(hwnd, bLarger, prc) \
    (int)SNDMSG(hwnd, TCM_ADJUSTRECT, (WPARAM)(BOOL)(bLarger), (LPARAM)(RECT *)(prc))
```