### PR TITLE
Minimum supported comctl32.dll version changed

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-defsubclassproc.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-defsubclassproc.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Comctl32.lib
-req.dll: Comctl32.dll (version 5.8 or later)
+req.dll: Comctl32.dll (version 5.82 or later)
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/commctrl/nf-commctrl-getwindowsubclass.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-getwindowsubclass.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Comctl32.lib
-req.dll: Comctl32.dll (version 6.0 or later)
+req.dll: Comctl32.dll (version 5.82 or later)
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -111,10 +111,6 @@ The subclass callback was not installed.
 </td>
 </tr>
 </table>
-
-## -remarks
-
-To use <b>GetWindowSubclass</b>, specify Comctl32.dll version 6 in the manifest. For more information on manifests, see <a href="/windows/desktop/Controls/cookbook-overview">Enabling Visual Styles</a>.
 
 ## -see-also
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-removewindowsubclass.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-removewindowsubclass.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Comctl32.lib
-req.dll: Comctl32.dll (version 5.8 or later)
+req.dll: Comctl32.dll (version 5.82 or later)
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/commctrl/nf-commctrl-setwindowsubclass.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-setwindowsubclass.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Comctl32.lib
-req.dll: Comctl32.dll (version 5.8 or later)
+req.dll: Comctl32.dll (version 5.82 or later)
 req.irql: 
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
SDK states that subclassing API can be used on Windows XP and above:
~~~
#if (NTDDI_VERSION >= NTDDI_WINXP)
...
typedef LRESULT (CALLBACK *SUBCLASSPROC)(HWND hWnd, UINT uMsg, WPARAM wParam,
    LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
...
_Success_(return) BOOL WINAPI SetWindowSubclass(_In_ HWND hWnd, _In_ SUBCLASSPROC pfnSubclass, _In_ UINT_PTR uIdSubclass,
    _In_ DWORD_PTR dwRefData);
_Success_(return) BOOL WINAPI GetWindowSubclass(_In_ HWND hWnd, _In_ SUBCLASSPROC pfnSubclass, _In_ UINT_PTR uIdSubclass,
    _Out_opt_ DWORD_PTR *pdwRefData);
_Success_(return) BOOL WINAPI RemoveWindowSubclass(_In_ HWND hWnd, _In_ SUBCLASSPROC pfnSubclass,
    _In_ UINT_PTR uIdSubclass);

LRESULT WINAPI DefSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
#endif
~~~
Windows XP includes comctl32.dll 5.82.
I checked subclassing API on Windows 7 SP1 x64 without manifest i.e. with comctl32.dll 5.82. Functions work as expected.