### PR TITLE
Info about last error information reset

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getnextwindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getnextwindow.md
@@ -102,6 +102,7 @@ Returns a handle to the window above the given window.
 Type: <b>HWND</b>
 
 If the function succeeds, the return value is a window handle. If no window exists with the specified relationship to the specified window, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+The function does not clear the last error information. To determine success or failure in case of <b>NULL</b> return value, clear the last error information by calling <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError</a> function with 0 value, then call <b>GetNextWindow</b>. Function failure will be indicated by a return value of <b>NULL</b> and a <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> function result that is nonzero.
 
 ## -remarks
 

--- a/sdk-api-src/content/winuser/nf-winuser-gettopwindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-gettopwindow.md
@@ -74,6 +74,7 @@ A handle to the parent window whose child windows are to be examined. If this pa
 Type: <b>HWND</b>
 
 If the function succeeds, the return value is a handle to the child window at the top of the Z order. If the specified window has no child windows, the return value is <b>NULL</b>. To get extended error information, use the <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> function.
+The function does not clear the last error information. To determine success or failure in case of <b>NULL</b> return value, clear the last error information by calling <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError</a> function with 0 value, then call <b>GetTopWindow</b>. Function failure will be indicated by a return value of <b>NULL</b> and a <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> function result that is nonzero.
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-getwindow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getwindow.md
@@ -177,6 +177,7 @@ The retrieved handle identifies the specified window's owner window, if any. For
 Type: <b>HWND</b>
 
 If the function succeeds, the return value is a window handle. If no window exists with the specified relationship to the specified window, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+The function does not clear the last error information. To determine success or failure in case of <b>NULL</b> return value, clear the last error information by calling <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError</a> function with 0 value, then call <b>GetWindow</b>. Function failure will be indicated by a return value of <b>NULL</b> and a <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> function result that is nonzero.
 
 ## -remarks
 


### PR DESCRIPTION
It turns out that GetTopWindow and GetWindow (+GetNextWindow) routines don't reset last error information.
Verified on Windows 7 SP1 x64.