### PR TITLE
Link SetupDiEnumDeviceInfo to example

### DIFF
--- a/sdk-api-src/content/setupapi/nf-setupapi-setupdienumdeviceinfo.md
+++ b/sdk-api-src/content/setupapi/nf-setupapi-setupdienumdeviceinfo.md
@@ -83,6 +83,8 @@ To enumerate device information elements, an installer should initially call <b>
 
 Call <a href="/windows/desktop/api/setupapi/nf-setupapi-setupdienumdeviceinterfaces">SetupDiEnumDeviceInterfaces</a> to get a context structure for a device <i>interface</i> element (versus a device <i>information</i> element).
 
+An example of <b>SetupDiEnumDeviceInfo</b> usage is available on the page documenting <a href="/windows/desktop/api/setupapi/nf-setupapi-setupdigetclassdevsw">SetupDiGetClassDevsW</a>.
+
 ## -see-also
 
 <a href="/windows/desktop/api/setupapi/ns-setupapi-sp_devinfo_data">SP_DEVINFO_DATA</a>
@@ -102,3 +104,4 @@ Call <a href="/windows/desktop/api/setupapi/nf-setupapi-setupdienumdeviceinterfa
 
 
 <a href="/windows/desktop/api/setupapi/nf-setupapi-setupdiopendeviceinfoa">SetupDiOpenDeviceInfo</a>
+


### PR DESCRIPTION
The page for SetupDiGetClassDevsW contains an in-context example of using SetupDiEnumDeviceInfo. Add a link from SetupDiEnumDeviceInfo to SetupDiGetClassDevsW.