### PR TITLE
Update nf-winuser-getmenuiteminfow.md

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-getmenuiteminfow.md
+++ b/sdk-api-src/content/winuser/nf-winuser-getmenuiteminfow.md
@@ -77,7 +77,7 @@ The identifier or position of the menu item to get information about. The meanin
 
 Type: <b>BOOL</b>
 
-The meaning of <i>uItem</i>. If this parameter is <b>FALSE</b>, <i>uItem</i> is a menu item identifier. Otherwise, it is a menu item position. See <a href="/windows/desktop/menurc/about-menus">Accessing Menu Items Programmatically</a> for more information.
+The meaning of <i>Item</i>. If this parameter is <b>FALSE</b>, <i>Item</i> is a menu item identifier. Otherwise, it is a menu item position. See <a href="/windows/desktop/menurc/about-menus">Accessing Menu Items Programmatically</a> for more information.
 
 ### -param lpmii [in, out]
 


### PR DESCRIPTION
Changes _uItem_ to _Item_ for consistency with the function's syntax and the function's description in the header file.