### PR TITLE
Update ns-winsock2-wsaoverlapped.md

### DIFF
--- a/sdk-api-src/content/winsock2/ns-winsock2-wsaoverlapped.md
+++ b/sdk-api-src/content/winsock2/ns-winsock2-wsaoverlapped.md
@@ -63,13 +63,13 @@ The
 
 ### -field Internal
 
-Type: <b>ULONG_PTR</b>
+Type: <b>DWORD</b>
 
 Reserved for internal use. The Internal member is used internally by the entity that implements overlapped I/O. For service providers that create sockets as installable file system (IFS) handles, this parameter is used by the underlying operating system. Other service providers (non-IFS providers) are free to use this parameter as necessary.
 
 ### -field InternalHigh
 
-Type: <b>ULONG_PTR</b>
+Type: <b>DWORD</b>
 
 Reserved. Used internally by the entity that implements overlapped I/O. For service providers that create sockets as IFS handles, this parameter is used by the underlying operating system. NonIFS providers are free to use this parameter as necessary.
 
@@ -87,16 +87,9 @@ Reserved for use by service providers.
 
 ### -field hEvent
 
-Type: <b>HANDLE</b>
+Type: <b>WSAEVENT</b>
 
 If an overlapped I/O operation is issued without an I/O completion routine (the operation's <i>lpCompletionRoutine</i> parameter is set to null), then this parameter should either contain a valid handle to a WSAEVENT object or be null. If the <i>lpCompletionRoutine</i> parameter of the call is non-null then applications are free to use this parameter as necessary.
-
-
-#### - Pointer
-
-Type: <b>PVOID</b>
-
-Reserved for use by service providers.
 
 ## -see-also
 


### PR DESCRIPTION
Uses the correct datatypes as shown by the struct on the page, however:

The presented syntax on the site is incorrect, for modern Windows! It is using the Win16 format of the structure, while in Win32 the structure is typedef'd to OVERLAPPED, along with LPWSAOVERLAPPED to _OVERLAPPED*. Interpreting the structure as-is and passing it to functions in Win32 will cause them to error with WSA_INVALID_HANDLE. I do not know how to modify the displayed struct, any help there would be useful.

Additionally, hEvent is a little unclear when it comes to using it with I/O completion ports, but I'm unsure how to transform the current description.

Relevant excerpt from um/WinSock2.h, SDK version 10.0.26100.0:
```h
#ifdef WIN32

#define WSAAPI                  FAR PASCAL
#define WSAEVENT                HANDLE
#define LPWSAEVENT              LPHANDLE
#define WSAOVERLAPPED           OVERLAPPED
typedef struct _OVERLAPPED *    LPWSAOVERLAPPED;

#define WSA_IO_PENDING          (ERROR_IO_PENDING)
#define WSA_IO_INCOMPLETE       (ERROR_IO_INCOMPLETE)
#define WSA_INVALID_HANDLE      (ERROR_INVALID_HANDLE)
#define WSA_INVALID_PARAMETER   (ERROR_INVALID_PARAMETER)
#define WSA_NOT_ENOUGH_MEMORY   (ERROR_NOT_ENOUGH_MEMORY)
#define WSA_OPERATION_ABORTED   (ERROR_OPERATION_ABORTED)

#define WSA_INVALID_EVENT       ((WSAEVENT)NULL)
#define WSA_MAXIMUM_WAIT_EVENTS (MAXIMUM_WAIT_OBJECTS)
#define WSA_WAIT_FAILED         (WAIT_FAILED)
#define WSA_WAIT_EVENT_0        (WAIT_OBJECT_0)
#define WSA_WAIT_IO_COMPLETION  (WAIT_IO_COMPLETION)
#define WSA_WAIT_TIMEOUT        (WAIT_TIMEOUT)
#define WSA_INFINITE            (INFINITE)

#else /* WIN16 */

#define WSAAPI                  FAR PASCAL
typedef DWORD                   WSAEVENT, FAR * LPWSAEVENT;

typedef struct _WSAOVERLAPPED {
    DWORD    Internal;
    DWORD    InternalHigh;
    DWORD    Offset;
    DWORD    OffsetHigh;
    WSAEVENT hEvent;
} WSAOVERLAPPED, FAR * LPWSAOVERLAPPED;

#define WSA_IO_PENDING          (WSAEWOULDBLOCK)
#define WSA_IO_INCOMPLETE       (WSAEWOULDBLOCK)
#define WSA_INVALID_HANDLE      (WSAENOTSOCK)
#define WSA_INVALID_PARAMETER   (WSAEINVAL)
#define WSA_NOT_ENOUGH_MEMORY   (WSAENOBUFS)
#define WSA_OPERATION_ABORTED   (WSAEINTR)

#define WSA_INVALID_EVENT       ((WSAEVENT)NULL)
#define WSA_MAXIMUM_WAIT_EVENTS (MAXIMUM_WAIT_OBJECTS)
#define WSA_WAIT_FAILED         ((DWORD)-1L)
#define WSA_WAIT_EVENT_0        ((DWORD)0)
#define WSA_WAIT_TIMEOUT        ((DWORD)0x102L)
#define WSA_INFINITE            ((DWORD)-1L)

#endif  /* WIN32 */
```