### PR TITLE
DeriveCapabilitySidsFromName is in KernelBase.dll not in Kernel32.dll

### DIFF
--- a/sdk-api-src/content/securitybaseapi/nf-securitybaseapi-derivecapabilitysidsfromname.md
+++ b/sdk-api-src/content/securitybaseapi/nf-securitybaseapi-derivecapabilitysidsfromname.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: OneCoreUAP.lib
-req.dll: Kernel32.dll
+req.dll: KernelBase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -41,7 +41,7 @@ api_type:
  - DllExport
 api_location:
  - api-ms-win-security-base-l1-2-2.dll
- - Kernel32.dll
+ - KernelBase.dll
 api_name:
  - DeriveCapabilitySidsFromName
 ---


### PR DESCRIPTION
Checking with dumpbin on my Windows 11 Pro machine, DeriveCapabilitySidsFromName is in KernelBase.dll not in Kernel32.dll