### PR TITLE
Escape Markdown characters

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocesstoken.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentprocesstoken.md
@@ -11,8 +11,8 @@ ms.keywords: GetCurrentProcessToken, GetCurrentProcessToken function [Security],
 req.header: processthreadsapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8 [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2012 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadeffectivetoken.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadeffectivetoken.md
@@ -11,8 +11,8 @@ ms.keywords: GetCurrentThreadEffectiveToken, GetCurrentThreadEffectiveToken func
 req.header: processthreadsapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8 [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2012 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadtoken.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getcurrentthreadtoken.md
@@ -11,8 +11,8 @@ ms.keywords: GetCurrentThreadToken, GetCurrentThreadToken function [Security], p
 req.header: processthreadsapi.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8 [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2012 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows 8 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 

--- a/sdk-api-src/content/windows.foundation/nf-windows-foundation-istringable-tostring.md
+++ b/sdk-api-src/content/windows.foundation/nf-windows-foundation-istringable-tostring.md
@@ -11,8 +11,8 @@ ms.keywords: IStringable interface [Windows Runtime],ToString method, IStringabl
 req.header: windows.foundation.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 8.1 [desktop apps | UWP apps]
-req.target-min-winversvr: Windows Server 2012 R2 [desktop apps | UWP apps]
+req.target-min-winverclnt: Windows 8.1 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2012 R2 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
Escape Markdown characters like it's done in https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation in pages like https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocesstoken