### PR TITLE
Update DWRITE_LINE_BREAKPOINT for clarity on breaking conditions

### DIFF
--- a/sdk-api-src/content/dwrite/ns-dwrite-dwrite_line_breakpoint.md
+++ b/sdk-api-src/content/dwrite/ns-dwrite-dwrite_line_breakpoint.md
@@ -56,31 +56,31 @@ Line breakpoint characteristics of a character.
 
 ### -field breakConditionBefore
 
-Type: <b>UINT8</b>
+Type: <b>UINT8 : 2</b>
 
-Indicates a breaking condition before the character.
+Indicates a breaking condition before the character, equivalent to **DWRITE_BREAK_CONDITION**
 
 ### -field breakConditionAfter
 
-Type: <b>UINT8</b>
+Type: <b>UINT8 : 2</b>
 
-Indicates a breaking condition after the character.
+Indicates a breaking condition after the character, equivalent to **DWRITE_BREAK_CONDITION**.
 
 ### -field isWhitespace
 
-Type: <b>UINT8</b>
+Type: <b>UINT8 : 1</b>
 
 Indicates that the character is some form of whitespace, which may be meaningful for justification.
 
 ### -field isSoftHyphen
 
-Type: <b>UINT8</b>
+Type: <b>UINT8 : 1</b>
 
 Indicates that the character is a soft hyphen, often used to indicate hyphenation points inside words.
 
 ### -field padding
 
-Type: <b>UINT8</b>
+Type: <b>UINT8 : 2</b>
 
 Reserved for future use.
 

--- a/sdk-api-src/content/dwrite/ns-dwrite-dwrite_line_breakpoint.md
+++ b/sdk-api-src/content/dwrite/ns-dwrite-dwrite_line_breakpoint.md
@@ -58,13 +58,13 @@ Line breakpoint characteristics of a character.
 
 Type: <b>UINT8 : 2</b>
 
-Indicates a breaking condition before the character, equivalent to **DWRITE_BREAK_CONDITION**
+Indicates a breaking condition before the character, equivalent to [DWRITE_BREAK_CONDITION](/windows/win32/api/dwrite/ne-dwrite-dwrite_break_condition).
 
 ### -field breakConditionAfter
 
 Type: <b>UINT8 : 2</b>
 
-Indicates a breaking condition after the character, equivalent to **DWRITE_BREAK_CONDITION**.
+Indicates a breaking condition after the character, equivalent to [DWRITE_BREAK_CONDITION](/windows/win32/api/dwrite/ne-dwrite-dwrite_break_condition).
 
 ### -field isWhitespace
 
@@ -84,3 +84,6 @@ Type: <b>UINT8 : 2</b>
 
 Reserved for future use.
 
+## -see-also
+
+[DWRITE_BREAK_CONDITION](/windows/win32/api/dwrite/ne-dwrite-dwrite_break_condition)


### PR DESCRIPTION
- Link the two breaking bitfields to the **DWRITE_BREAK_CONDITION** enum so readers understand the values are equivalent (ideally it would be an actual *see also* link, but I'm unsure the syntax for internal links like that).
- Fix the types to bitfields, as `isWhitespace` is a single bit, not an entire `UINT8`.

**Steve**: I'm not at all particular on the wording. I just wanted a correlation between these fields and the corresponding enum.