### PR TITLE
Fix typos about ` and escape it

### DIFF
--- a/sdk-api-src/content/d3d12/ne-d3d12-d3d12_shading_rate_combiner.md
+++ b/sdk-api-src/content/d3d12/ne-d3d12-d3d12_shading_rate_combiner.md
@@ -57,7 +57,7 @@ Specifies the combiner `C.xy = min(A.xy, B.xy)`, for combiner (C) and inputs (A 
 
 ### -field D3D12_SHADING_RATE_COMBINER_SUM:4
 
-Specifies the combiner C.xy = min(maxRate, A.xy + B.xy)`, for combiner (C) and inputs (A and B).
+Specifies the combiner `C.xy = min(maxRate, A.xy + B.xy)`, for combiner (C) and inputs (A and B).
 
 ## -remarks
 

--- a/sdk-api-src/content/dbghelp/nc-dbghelp-pget_target_attribute_value64.md
+++ b/sdk-api-src/content/dbghelp/nc-dbghelp-pget_target_attribute_value64.md
@@ -70,7 +70,7 @@ If this attribute is being requested, the *AttributeData* parameter will indicat
 
 If PAC is disabled (or the stack walk is not for an ARM64 platform), the implementation should return FALSE indicating that this attribute cannot be provided.
 
-The special value **TARGET_ATTIBUTE_PACMASK_LIVETARGET** (0xffffffff`ffffffff) may be returned as an indication that the PAC mask is the same as the process calling StackWalk2.
+The special value **TARGET_ATTIBUTE_PACMASK_LIVETARGET** (0xffffffffffffffff) may be returned as an indication that the PAC mask is the same as the process calling StackWalk2.
 
 ### -param AttributeData [in]
 

--- a/sdk-api-src/content/dcomp/nf-dcomp-idcompositiondevice4-checkcompositiontexturesupport.md
+++ b/sdk-api-src/content/dcomp/nf-dcomp-idcompositiondevice4-checkcompositiontexturesupport.md
@@ -60,7 +60,7 @@ The backing Direct3D device.
 
 Type: \_Out\_ **[BOOL](/windows/win32/winprog/windows-data-types)\***
 
-Points to a value of `true` if *renderingDevice* supports composition textures; otherwise 'false`.
+Points to a value of `true` if *renderingDevice* supports composition textures; otherwise `false`.
 
 ## -returns
 

--- a/sdk-api-src/content/directml/ns-directml-dml_element_wise_is_infinity_operator_desc.md
+++ b/sdk-api-src/content/directml/ns-directml-dml_element_wise_is_infinity_operator_desc.md
@@ -69,7 +69,7 @@ A [DML_IS_INFINITY_MODE](/windows/win32/api/directml/ne-directml-dml_is_infinity
 
 * If **DML_IS_INFINITY_MODE_EITHER**, then 1 will be returned if the element is -inf or inf, otherwise 0.
 * If **DML_IS_INFINITY_MODE_POSITIVE**, then 1 will be returned if the element is inf, otherwise 0.
-* If **DML_IS_INFINITY_MODE_NEGATIVE**`, then 1 will be returned if the element is -inf, otherwise 0.
+* If **DML_IS_INFINITY_MODE_NEGATIVE**, then 1 will be returned if the element is -inf, otherwise 0.
 
 ## -remarks
 

--- a/sdk-api-src/content/inputscope/ne-inputscope-inputscope.md
+++ b/sdk-api-src/content/inputscope/ne-inputscope-inputscope.md
@@ -358,7 +358,7 @@ Indicates numbers, including commas, negative sign, and decimal. For United Stat
 
 Indicates a single ANSI character, codepage 1252. For United States locations, this includes the following characters.
 
-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdEfghijklmnopqrstuvwxyz0123456789!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdEfghijklmnopqrstuvwxyz0123456789!\"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_\`{|}~
 
 ### -field IS_PASSWORD:31
 

--- a/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roparsetypename.md
+++ b/sdk-api-src/content/rometadataresolution/nf-rometadataresolution-roparsetypename.md
@@ -172,7 +172,7 @@ Example 3 (instantiated parameterized interface type)
 <li>
 <b>Input typename</b>
 
-Windows.Foundation.Collections.IIterator`1&lt;Windows.Foundation.Collections.IMapView`2&lt;Windows.Foundation.Collections.IVector`1&lt;String&gt;, String&gt;&gt;
+Windows.Foundation.Collections.IIterator\`1&lt;Windows.Foundation.Collections.IMapView\`2&lt;Windows.Foundation.Collections.IVector\`1&lt;String&gt;, String&gt;&gt;
 
 </li>
 <li>

--- a/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfow.md
+++ b/sdk-api-src/content/shellapi/ns-shellapi-shellexecuteinfow.md
@@ -172,7 +172,7 @@ For further discussion on when this flag is necessary, see the Remarks section.<
 <td>Indicates a user initiated launch that enables tracking of frequently used programs and other behaviors.</td>
 </tr>
 <tr valign="top">
-<td>SEE_MASK_FLAG_HINST_IS_SITE` (0x08000000)</td>
+<td>SEE_MASK_FLAG_HINST_IS_SITE (0x08000000)</td>
 <td>The <b>hInstApp</b> member is used to specify the <a href="/windows/desktop/api/unknwn/nn-unknwn-iunknown">IUnknown</a> of an object that implements <a href="/previous-versions/windows/internet-explorer/ie-developer/platform-apis/cc678965(v=vs.85)">IServiceProvider</a>. This object will be used as a site pointer. The site pointer is used to provide services to the <a href="/windows/desktop/api/shellapi/nf-shellapi-shellexecuteexa">ShellExecuteEx</a> function, the handler binding process, and invoked verb handlers.
  
 <a href="/windows/win32/api/shobjidl_core/nn-shobjidl_core-icreatingprocess">ICreatingProcess</a> can be provided to allow the caller to alter some parameters of the process being created.

--- a/sdk-api-src/content/windows.ui.composition.interop/nf-windows-ui-composition-interop-icompositorinterop2-checkcompositiontexturesupport.md
+++ b/sdk-api-src/content/windows.ui.composition.interop/nf-windows-ui-composition-interop-icompositorinterop2-checkcompositiontexturesupport.md
@@ -60,7 +60,7 @@ The backing Direct3D device.
 
 Type: \_Out\_ **[BOOL](/windows/win32/winprog/windows-data-types)\***
 
-Points to a value of `true` if *renderingDevice* supports composition textures; otherwise 'false`.
+Points to a value of `true` if *renderingDevice* supports composition textures; otherwise `false`.
 
 ## -returns
 

--- a/sdk-api-src/content/wtsapi32/nf-wtsapi32-wtscloudauthduplicateserializedusercredential.md
+++ b/sdk-api-src/content/wtsapi32/nf-wtsapi32-wtscloudauthduplicateserializedusercredential.md
@@ -68,7 +68,7 @@ Receives a pointer to the duplicated instance of *WTS_SERIALIZED_USER_CREDENTIAL
 ## -returns
 
 If the function succeeds, the return value is a nonzero value.
-If the function fails, the return value is zero. To get extended error information, call the [`GetLastError'](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror) function.
+If the function fails, the return value is zero. To get extended error information, call the [GetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror) function.
 
 ## -remarks
 


### PR DESCRIPTION
Fix typos about ` and escape it if necessary in pages like:

https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-shellexecuteinfow

https://learn.microsoft.com/en-us/windows/win32/api/windows.ui.composition.interop/nf-windows-ui-composition-interop-icompositorinterop2-checkcompositiontexturesupport

https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtscloudauthduplicateserializedusercredential

And in this very broken page https://learn.microsoft.com/en-us/windows/win32/api/inputscope/ne-inputscope-inputscope