### PR TITLE
Return type corrected

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-listview_setitemcount.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-listview_setitemcount.md
@@ -50,7 +50,7 @@ api_name:
 ## -syntax
 
 ```cpp
-void ListView_SetItemCount(
+LRESULT ListView_SetItemCount(
    HWND hwndLV,
    int  cItems
 );
@@ -74,6 +74,12 @@ A handle to a list-view control.
 Type: <b>int</b>
 
 The number of items for which the list-view control should allocate memory.
+
+## -returns
+
+Type: <b>LRESULT</b>
+
+Returns nonzero if successful, or zero otherwise.
 
 ## -remarks
 

--- a/sdk-api-src/content/commctrl/nf-commctrl-listview_setitemcountex.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-listview_setitemcountex.md
@@ -50,7 +50,7 @@ api_name:
 ## -syntax
 
 ```cpp
-void ListView_SetItemCountEx(
+LRESULT ListView_SetItemCountEx(
    HWND  hwndLV,
    int   cItems,
    DWORD dwFlags
@@ -108,6 +108,12 @@ The list-view control will not change the scroll position when the item count ch
 </td>
 </tr>
 </table>
+
+## -returns
+
+Type: <b>LRESULT</b>
+
+Returns nonzero if successful, or zero otherwise.
 
 ## -remarks
 


### PR DESCRIPTION
ListView_SetItemCount\ListView_SetItemCountEx return type is LRESULT:
```
#define ListView_SetItemCount(hwndLV, cItems) \
  SNDMSG((hwndLV), LVM_SETITEMCOUNT, (WPARAM)(cItems), 0)

#define ListView_SetItemCountEx(hwndLV, cItems, dwFlags) \
  SNDMSG((hwndLV), LVM_SETITEMCOUNT, (WPARAM)(cItems), (LPARAM)(dwFlags))
```
The description is taken from LVM_SETITEMCOUNT article:
```
Returns nonzero if successful, or zero otherwise.
```