### PR TITLE
`IsWindowVisible()` may produce an error

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-iswindowvisible.md
+++ b/sdk-api-src/content/winuser/nf-winuser-iswindowvisible.md
@@ -77,7 +77,7 @@ A handle to the window to be tested.
 
 Type: <b>BOOL</b>
 
-If the specified window, its parent window, its parent's parent window, and so forth, have the <b>WS_VISIBLE</b> style, the return value is nonzero. Otherwise, the return value is zero. 
+If the specified window, its parent window, its parent's parent window, and so forth, have the <b>WS_VISIBLE</b> style, the return value is nonzero. Otherwise, or in the case of an error, the return value is zero.
 
 Because the return value specifies whether the window has the <b>WS_VISIBLE</b> style, it may be nonzero even if the window is totally obscured by other windows.
 


### PR DESCRIPTION
I was hesitant to commit the following text, which was based on tests, because it may sound like an unauthorized contract:

> To be able to tell an absent <b>WS_VISIBLE</b> style apart from an error condition and retrieve extended error information, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError(ERROR_SUCCESS)</a></b> in preparation to <b>IsWindowVisible</b>, and finally <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a></b>.

<details><summary>(As Markdown)</summary>

```md
To be able to tell an absent <b>WS_VISIBLE</b> style apart from an error condition and retrieve extended error information, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError(ERROR_SUCCESS)</a></b> in preparation to <b>IsWindowVisible</b>, and finally <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a></b>.
```
</details>

Or, a bit stronger:

> To get extended error information, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a></b>. To be able to tell an absent <b>WS_VISIBLE</b> style apart from an error condition, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError(ERROR_SUCCESS)</a></b> in preparation to <b>IsWindowVisible</b>.

<details><summary>(As Markdown)</summary>

```md
To get extended error information, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a></b>. To be able to tell an absent <b>WS_VISIBLE</b> style apart from an error condition, call <b><a href="/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror">SetLastError(ERROR_SUCCESS)</a></b> in preparation to <b>IsWindowVisible</b>.
```
</details>

Would it be okay to use one of those texts as the second paragraph under the "Return value" heading?

---

Tests I did on Windows 11 Home 24H2 (in another language, from memory):

```c
SetLastError(ERROR_SUCCESS);
isVisible = IsWindowVisible((HWND)123);  // Invalid handle.
if (!isVisible) {
    DWORD lastError = GetLastError();
    // `lastError` is `ERROR_INVALID_WINDOW_HANDLE`.
}

///////////////////////////////////////

SetLastError(123);
isVisible = IsWindowVisible(validHwnd);
if (!isVisible) {
    DWORD lastError = GetLastError();
    // `lastError` is 123. So, preparation `SetLastError(ERROR_SUCCESS)` is needed.
}
```
