### PR TITLE
Info about the failure with code pages 1147 and 20949

### DIFF
--- a/sdk-api-src/content/winnls/nf-winnls-getcpinfoexa.md
+++ b/sdk-api-src/content/winnls/nf-winnls-getcpinfoexa.md
@@ -133,6 +133,8 @@ Returns a nonzero value if successful, or 0 otherwise. To get extended error inf
 <li>ERROR_INVALID_PARAMETER. Any of the parameter values was invalid.</li>
 </ul>
 
+Returns a zero value for code pages 1147 and 20949. <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns ERROR_SUCCESS for code page 1147 and ERROR_MUI_FILE_NOT_FOUND for 20949. All <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a> fields are filled with valid data, except for CodePageName, which is empty.
+
 ## -remarks
 
 The information retrieved in the <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a> structure is not always useful for all code pages. To determine buffer sizes, for example, the application should call <a href="/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar">MultiByteToWideChar</a> or <a href="/windows/desktop/api/stringapiset/nf-stringapiset-widechartomultibyte">WideCharToMultiByte</a> to request an accurate buffer size. If <b>CPINFOEX</b> settings indicate that a lead byte exists, the conversion function does not necessarily handle lead bytes differently, for example, in the case of a missing or illegal trail byte.

--- a/sdk-api-src/content/winnls/nf-winnls-getcpinfoexa.md
+++ b/sdk-api-src/content/winnls/nf-winnls-getcpinfoexa.md
@@ -128,12 +128,9 @@ Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX<
 
 Returns a nonzero value if successful, or 0 otherwise. To get extended error information, the application can call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>, which can return one of the following error codes:
 
-
-<ul>
-<li>ERROR_INVALID_PARAMETER. Any of the parameter values was invalid.</li>
-</ul>
-
-Returns a zero value for code pages 1147 and 20949. <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns ERROR_SUCCESS for code page 1147 and ERROR_MUI_FILE_NOT_FOUND for 20949. All <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a> fields are filled with valid data, except for CodePageName, which is empty.
+- ERROR_INVALID_PARAMETER if any of the parameter values are invalid.
+- ERROR_SUCCESS for code page 1147
+- ERROR_MUI_FILE_NOT_FOUND for code page 20949.
 
 ## -remarks
 

--- a/sdk-api-src/content/winnls/nf-winnls-getcpinfoexw.md
+++ b/sdk-api-src/content/winnls/nf-winnls-getcpinfoexw.md
@@ -124,7 +124,7 @@ Reserved; must be 0.
 
 ### -param lpCPInfoEx [out]
 
-Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a> structure that receives information about the code page.
+Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX</a> structure that receives information about the code page.
 
 ## -returns
 
@@ -135,9 +135,11 @@ Returns a nonzero value if successful, or 0 otherwise. To get extended error inf
 <li>ERROR_INVALID_PARAMETER. Any of the parameter values was invalid.</li>
 </ul>
 
+Returns a zero value for code pages 1147 and 20949. <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns ERROR_SUCCESS for code page 1147 and ERROR_MUI_FILE_NOT_FOUND for 20949. All <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX</a> fields are filled with valid data, except for CodePageName, which is empty.
+
 ## -remarks
 
-The information retrieved in the <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a> structure is not always useful for all code pages. To determine buffer sizes, for example, the application should call <a href="/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar">MultiByteToWideChar</a> or <a href="/windows/desktop/api/stringapiset/nf-stringapiset-widechartomultibyte">WideCharToMultiByte</a> to request an accurate buffer size. If <b>CPINFOEX</b> settings indicate that a lead byte exists, the conversion function does not necessarily handle lead bytes differently, for example, in the case of a missing or illegal trail byte.
+The information retrieved in the <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX</a> structure is not always useful for all code pages. To determine buffer sizes, for example, the application should call <a href="/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar">MultiByteToWideChar</a> or <a href="/windows/desktop/api/stringapiset/nf-stringapiset-widechartomultibyte">WideCharToMultiByte</a> to request an accurate buffer size. If <b>CPINFOEX</b> settings indicate that a lead byte exists, the conversion function does not necessarily handle lead bytes differently, for example, in the case of a missing or illegal trail byte.
 
 
 
@@ -148,7 +150,7 @@ The information retrieved in the <a href="/windows/desktop/api/winnls/ns-winnls-
 
 ## -see-also
 
-<a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexa">CPINFOEX</a>
+<a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX</a>
 
 
 

--- a/sdk-api-src/content/winnls/nf-winnls-getcpinfoexw.md
+++ b/sdk-api-src/content/winnls/nf-winnls-getcpinfoexw.md
@@ -130,12 +130,9 @@ Pointer to a <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX<
 
 Returns a nonzero value if successful, or 0 otherwise. To get extended error information, the application can call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>, which can return one of the following error codes:
 
-
-<ul>
-<li>ERROR_INVALID_PARAMETER. Any of the parameter values was invalid.</li>
-</ul>
-
-Returns a zero value for code pages 1147 and 20949. <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a> returns ERROR_SUCCESS for code page 1147 and ERROR_MUI_FILE_NOT_FOUND for 20949. All <a href="/windows/desktop/api/winnls/ns-winnls-cpinfoexw">CPINFOEX</a> fields are filled with valid data, except for CodePageName, which is empty.
+- ERROR_INVALID_PARAMETER if any of the parameter values are invalid.
+- ERROR_SUCCESS for code page 1147
+- ERROR_MUI_FILE_NOT_FOUND for code page 20949.
 
 ## -remarks
 
@@ -171,3 +168,4 @@ The information retrieved in the <a href="/windows/desktop/api/winnls/ns-winnls-
 
 
 <a href="/windows/desktop/Intl/national-language-support-functions">National Language Support Functions</a>
+


### PR DESCRIPTION
1. GetCPInfoEx fails with code pages 1147 and 20949. GetLastError returns ERROR_SUCCESS for 1147 and ERROR_MUI_FILE_NOT_FOUND for 20949. All CPINFOEX info is valid, except for CodePageName, which is empty. Tested on Windows 7 SP1 x64.
2. CPINFOEX link corrected.