### PR TITLE
Wow64GetThreadContext invalid hyperlink replaced

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-getxstatefeaturesmask.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getxstatefeaturesmask.md
@@ -80,7 +80,7 @@ The <b>GetXStateFeaturesMask</b> function returns
      the mask of valid features in the specified context.  If a 
      <a href="/windows/desktop/api/winnt/ns-winnt-wow64_context">CONTEXT</a> is to be passed to 
      <a href="/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getthreadcontext">GetThreadContext</a> or 
-     <a href="https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/winbase/nf-winbase-wow64getthreadcontext.md">Wow64GetThreadContext</a>, the application must 
+     <a href="/windows/desktop/api/wow64apiset/nf-wow64apiset-wow64getthreadcontext">Wow64GetThreadContext</a>, the application must 
      call <a href="/windows/desktop/api/winbase/nf-winbase-setxstatefeaturesmask">SetXStateFeaturesMask</a> to set which 
      features are to be retrieved. 
      <b>GetXStateFeaturesMask</b> should then be called on 
@@ -134,6 +134,7 @@ The definition of XState features are processor vendor specific. Please refer to
 
 
 <a href="/windows/desktop/Debug/working-with-xstate-context">Working with XState Context</a>
+
 
 
 


### PR DESCRIPTION
The hyperlink previously led to an invalid path in the sdk-api repository