### PR TITLE
Re-apply 3 verified PRs with merge conflicts (#2051, #838, #1814)

### DIFF
--- a/sdk-api-src/content/commctrl/nf-commctrl-listview_getitemcount.md
+++ b/sdk-api-src/content/commctrl/nf-commctrl-listview_getitemcount.md
@@ -73,3 +73,10 @@ Gets the number of items in a list-view control. You can use this macro or send 
 Type: <b><a href="/windows/desktop/WinProg/windows-data-types">HWND</a></b>
 
 A handle to the list-view control.
+
+## -returns
+
+Type: int
+
+Returns the count of items in the listview.
+

--- a/sdk-api-src/content/wingdi/nf-wingdi-gettextextentexpointi.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-gettextextentexpointi.md
@@ -67,7 +67,7 @@ A pointer to an array of glyph indices for which extents are to be retrieved.
 
 ### -param cwchString [in]
 
-The number of glyphs in the array pointed to by the <i>pgiIn</i> parameter.
+The number of glyphs in the array pointed to by the <i>lpwszString</i> parameter.
 
 ### -param nMaxExtent [in]
 
@@ -79,7 +79,7 @@ A pointer to an integer that receives a count of the maximum number of character
 
 ### -param lpnDx [out]
 
-A pointer to an array of integers that receives partial glyph extents. Each element in the array gives the distance, in logical units, between the beginning of the glyph indices array and one of the glyphs that fits in the space specified by the <i>nMaxExtent</i> parameter. Although this array should have at least as many elements as glyph indices specified by the <i>cgi</i> parameter, the function fills the array with extents only for as many glyph indices as are specified by the <i>lpnFit</i> parameter. If <i>lpnFit</i> is <b>NULL</b>, the function does not compute partial string widths.
+A pointer to an array of integers that receives partial glyph extents. Each element in the array gives the distance, in logical units, between the beginning of the glyph indices array and one of the glyphs that fits in the space specified by the <i>nMaxExtent</i> parameter. Although this array should have at least as many elements as glyph indices specified by the <i>cwchString</i> parameter, the function fills the array with extents only for as many glyph indices as are specified by the <i>lpnFit</i> parameter. If <i>lpnFit</i> is <b>NULL</b>, the function does not compute partial string widths.
 
 ### -param lpSize [out]
 
@@ -93,7 +93,7 @@ If the function fails, the return value is zero.
 
 ## -remarks
 
-If both the <i>lpnFit</i> and <i>alpDx</i> parameters are <b>NULL</b>, calling the <b>GetTextExtentExPointI</b> function is equivalent to calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentpointi">GetTextExtentPointI</a> function.
+If both the <i>lpnFit</i> and <i>lpnDx</i> parameters are <b>NULL</b>, calling the <b>GetTextExtentExPointI</b> function is equivalent to calling the <a href="/windows/desktop/api/wingdi/nf-wingdi-gettextextentpointi">GetTextExtentPointI</a> function.
 
 When this function returns the text extent, it assumes that the text is horizontal, that is, that the escapement is always 0. This is true for both the horizontal and vertical measurements of the text. Even if you use a font that specifies a nonzero escapement, this function doesn't use the angle while it computes the text extent. The app must convert it explicitly. However, when the graphics mode is set to <a href="/windows/desktop/api/wingdi/nf-wingdi-setgraphicsmode">GM_ADVANCED</a> and the character orientation is 90 degrees from the print orientation, the values that this function return do not follow this rule. When the character orientation and the print orientation match for a given string, this function returns the dimensions of the string in the <a href="/windows/win32/api/windef/ns-windef-size">SIZE</a> structure as { cx : 116, cy : 18 }.  When the character orientation and the print orientation are 90 degrees apart for the same string, this function returns the dimensions of the string in the <b>SIZE</b> structure as { cx : 18, cy : 116 }.
 

--- a/sdk-api-src/content/winuser/nf-winuser-copyimage.md
+++ b/sdk-api-src/content/winuser/nf-winuser-copyimage.md
@@ -195,7 +195,7 @@ Uses the default color format.
 </dl>
 </td>
 <td width="60%">
-Uses the width or height specified by the system metric values for cursors or icons, if the <i>cxDesired</i> or <i>cyDesired</i> values are set to zero. If this flag is not specified and <i>cxDesired</i> and <i>cyDesired</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
+Uses the width or height specified by the system metric values for cursors or icons, if the <i>cx</i> or <i>cy</i> values are set to zero. If this flag is not specified and <i>cx</i> and <i>cy</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
@@ -169,7 +169,7 @@ The default flag; it does nothing. All it means is "not <b>LR_MONOCHROME</b>".
 </dl>
 </td>
 <td width="60%">
-Uses the width or height specified by the system metric values for cursors or icons, if the <i>cxDesired</i> or <i>cyDesired</i> values are set to zero. If this flag is not specified and <i>cxDesired</i> and <i>cyDesired</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
+Uses the width or height specified by the system metric values for cursors or icons, if the <i>cx</i> or <i>cy</i> values are set to zero. If this flag is not specified and <i>cx</i> and <i>cy</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
 
 </td>
 </tr>

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
@@ -169,7 +169,7 @@ The default flag; it does nothing. All it means is "not <b>LR_MONOCHROME</b>".
 </dl>
 </td>
 <td width="60%">
-Uses the width or height specified by the system metric values for cursors or icons, if the <i>cxDesired</i> or <i>cyDesired</i> values are set to zero. If this flag is not specified and <i>cxDesired</i> and <i>cyDesired</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
+Uses the width or height specified by the system metric values for cursors or icons, if the <i>cx</i> or <i>cy</i> values are set to zero. If this flag is not specified and <i>cx</i> and <i>cy</i> are set to zero, the function uses the actual resource size. If the resource contains multiple images, the function uses the size of the first image.
 
 </td>
 </tr>


### PR DESCRIPTION
Re-applies changes from 3 community PRs that had merge conflicts but were verified against SDK headers:

- **PR #2051** (by @DJm00n): Fix LR_DEFAULTSIZE param names \cxDesired\/\cyDesired\ → \cx\/\cy\ in CopyImage/LoadImage docs
- **PR #838** (by @feerrenrut): Fix param name references (\pgiIn\→\lpwszString\, \cgi\→\cwchString\, \lpDx\→\lpnDx\) in GetTextExtentExPointI — verified against wingdi.h
- **PR #1814** (by @antmor): Add missing return type to ListView_GetItemCount macro

All changes verified against Windows SDK headers.