### PR TITLE
Fix formula for output buffer size for FSCTL_GET_NTFS_FILE_RECORD

### DIFF
--- a/sdk-api-src/content/winioctl/ni-winioctl-fsctl_get_ntfs_file_record.md
+++ b/sdk-api-src/content/winioctl/ni-winioctl-fsctl_get_ntfs_file_record.md
@@ -96,7 +96,7 @@ If the file records that correspond to file identifiers 10 through 14 are reques
 
 To determine the correct size of the output buffer pointed to by *lpOutBuffer*, first call the [FSCTL_GET_NTFS_VOLUME_DATA](ni-winioctl-fsctl_get_ntfs_volume_data.md) control code to get the size of one file record. This is the value of the **BytesPerFileRecordSegment** member of the returned [NTFS_VOLUME_DATA_BUFFER](ns-winioctl-ntfs_volume_data_buffer.md) structure. Then set the size of the output buffer to the following expression:
 
-```sizeof (NTFS_FILE_RECORD_OUTPUT_BUFFER) + sizeof (one file record) - 1```
+```offsetof(NTFS_FILE_RECORD_OUTPUT_BUFFER, FileRecordBuffer) + BytesPerFileRecordSegment```
 
 If a file consists of multiple file records, they must be retrieved individually.
 


### PR DESCRIPTION
Due to alignment, sizeof(NTFS_FILE_RECORD_OUTPUT_BUFFER)=16, but output buffer's correct size should be 12+BytesPerFileRecordSegment, not 15+BytesPerFileRecordSegment.