### PR TITLE
Resolve swapped DLL and Library fields (+ API locations) in 4 native function APIs

### DIFF
--- a/sdk-api-src/content/threadpoollegacyapiset/nf-threadpoollegacyapiset-deletetimerqueue.md
+++ b/sdk-api-src/content/threadpoollegacyapiset/nf-threadpoollegacyapiset-deletetimerqueue.md
@@ -9,7 +9,7 @@ prerelease: false
 req.assembly: 
 req.construct-type: function
 req.ddi-compliance: 
-req.dll: Kernel32.lib
+req.dll: Kernel32.dll
 req.header: threadpoollegacyapiset.h
 req.idl: 
 req.include-header: 

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2a.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2a.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.dll
-req.dll: Kernel32.lib
+req.lib: Kernel32.lib
+req.dll: Kernel32.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -42,7 +42,7 @@ api_type:
 api_location:
  - api-ms-win-core-wow64-l1-1-3.dll
  - api-ms-win-core-wow64-l1-1-2.dll
- - kernel32.lib
+ - kernel32.dll
  - API-MS-Win-Core-Wow64-L1-1-1.dll
  - KernelBase.dll
 api_name:

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.dll
-req.dll: Kernel32.lib
+req.lib: Kernel32.lib
+req.dll: Kernel32.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -42,7 +42,7 @@ api_type:
 api_location:
  - api-ms-win-core-wow64-l1-1-3.dll
  - api-ms-win-core-wow64-l1-1-2.dll
- - kernel32.lib
+ - kernel32.dll
  - API-MS-Win-Core-Wow64-L1-1-1.dll
  - KernelBase.dll
 api_name:

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64guestmachinesupported.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-iswow64guestmachinesupported.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.dll
-req.dll: Kernel32.lib
+req.lib: Kernel32.lib
+req.dll: Kernel32.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -42,7 +42,7 @@ api_type:
 api_location:
  - api-ms-win-core-wow64-l1-1-3.dll
  - api-ms-win-core-wow64-l1-1-2.dll
- - kernel32.lib
+ - kernel32.dll
  - API-MS-Win-Core-Wow64-L1-1-1.dll
  - KernelBase.dll
 api_name:


### PR DESCRIPTION
Hi! I'm currently working on my projects, and the combination of my sdk-api `nf-*` parser + my WinSDK API viewer helped me identify 4 bugs in the documentation for `DeleteTimerQueue`, `GetSystemWow64Directory2A`, `GetSystemWow64Directory2W`, `IsWow64GuestMachineSupported`.

The diff is self-explainatory and perfectly presents the bug in question. But I'll attach an example image from IsWow64GuestMachineSupported's MSDN page anyway to show this in action:
<img width="713" height="130" alt="image" src="https://github.com/user-attachments/assets/6a69d385-330b-49d2-a39d-ce6ba28e56b7" />

I wish whoever's dealing with this a great day/night.