### PR TITLE
wuapi: IUpdate: setter and getter param and retval info, slight corrections

### DIFF
--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-accepteula.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-accepteula.md
@@ -104,4 +104,6 @@ The Microsoft Software License Terms for the update could not be located.
 
 ## -see-also
 
+[EulaAccepted property](nf-wuapi-iupdate-get_eulaaccepted.md)
+
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_autoselectonwebsites.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_autoselectonwebsites.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is flagged to be automatically selected by Windows Update, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_bundledupdates.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_bundledupdates.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IUpdateCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IUpdateCollection](nn-wuapi-iupdatecollection.md) containing the bundled updates for the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_canrequiresource.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_canrequiresource.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the source media of the update is required for installation or uninstallation, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_categories.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_categories.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>ICategoryCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [ICategoryCollection](nn-wuapi-icategorycollection.md) containing the categories.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that  this property returns is for the language that is specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that was used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deadline.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deadline.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant">VARIANT</a>. If the update has a deadline, it receives a value of type <b>VT_DATE</b> containing a <b>DATE</b> value specifying the deadline. If the update does not have a deadline, it receives a value of type <b>VT_EMPTY</b>.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 In COM, if the update has a deadline, the return value is of type VT_DATE and contains a DATE value that specifies the deadline. Otherwise, the return value is of type VT_EMPTY.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deltacompressedcontentavailable.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deltacompressedcontentavailable.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if delta-compressed content is available on a server for the update, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deltacompressedcontentpreferred.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deltacompressedcontentpreferred.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if delta-compressed content is preferred, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deploymentaction.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_deploymentaction.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>DeploymentAction*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/wuapi/ne-wuapi-deploymentaction">DeploymentAction</a> that receives the action for which the update is deployed.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_description.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_description.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the localized description of the update. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_downloadcontents.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_downloadcontents.md
@@ -58,9 +58,11 @@ This property is read-only.
 
 ## -parameters
 
-### -param retval
+### -param retval [out, retval]
 
-An [IUpdateDownloadContentCollection](nn-wuapi-iupdatedownloadcontentcollection.md) that allows you to enumerate the URLs for download contents associated with an update.
+Type: <b>IUpdateDownloadContentCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IUpdateDownloadContentCollection](nn-wuapi-iupdatedownloadcontentcollection.md) that allows you to enumerate the URLs for download contents associated with an update.
 
 ## -see-also
 

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_downloadpriority.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_downloadpriority.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>DownloadPriority*</b>
+
+A pointer to a variable of type [DownloadPriority](ne-wuapi-downloadpriority.md) that receives the suggested download priority of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulaaccepted.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulaaccepted.md
@@ -69,4 +69,6 @@ If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRE
 
 ## -see-also
 
+[AcceptEula method](nf-wuapi-update-accepteula.md)
+
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulaaccepted.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulaaccepted.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the terms are accepted, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulatext.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_eulatext.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the localized license text. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_handlerid.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_handlerid.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the identifier of the install handler. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The valid values for the <b>HandlerID</b> property include the following:

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_handlerid.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_handlerid.md
@@ -48,7 +48,6 @@ api_name:
 
 # IUpdate::get_HandlerID
 
-
 ## -description
 
 Gets the install handler of the update.
@@ -71,23 +70,11 @@ If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRE
 
 The valid values for the <b>HandlerID</b> property include the following:
 
-<ul>
-<li>The Command Line Installation Handlerhttp://schemas.microsoft.com/msus/2002/12/UpdateHandlers/CommandLineInstallation
-
-</li>
-<li>The Inf Based Installation Handlerhttp://schemas.microsoft.com/msus/2002/12/UpdateHandlers/InfBasedInstallation
-
-</li>
-<li>The <a href="/windows/desktop/Msi/windows-installer-portal">Windows Installer</a> Installation Handlerhttp://schemas.microsoft.com/msus/2002/12/UpdateHandlers/WindowsInstaller
-
-</li>
-<li>The Package Installer for Microsoft Windows Operating Systems and Windows Components (update.exe) Installation Handlerhttp://schemas.microsoft.com/msus/2002/12/UpdateHandlers/WindowsPatch
-
-</li>
-<li>The Component Based Servicing (CBS) Handlerhttp://schemas.microsoft.com/msus/2002/12/UpdateHandlers/Cbs
-
-</li>
-</ul>
+* The Command Line Installation Handler: <code>http://schemas.microsoft.com/msus/2002/12/UpdateHandlers/CommandLineInstallation</code>
+* The Inf Based Installation Handler: <code>http://schemas.microsoft.com/msus/2002/12/UpdateHandlers/InfBasedInstallation</code>
+* The <a href="/windows/desktop/Msi/windows-installer-portal">Windows Installer</a> Installation Handler: <code>http://schemas.microsoft.com/msus/2002/12/UpdateHandlers/WindowsInstaller</code>
+* The Package Installer for Microsoft Windows Operating Systems and Windows Components (update.exe) Installation Handler: <code>http://schemas.microsoft.com/msus/2002/12/UpdateHandlers/WindowsPatch</code>
+* The Component Based Servicing (CBS) Handler: <code>http://schemas.microsoft.com/msus/2002/12/UpdateHandlers/Cbs</code>
 
 ## -see-also
 

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_identity.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_identity.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IUpdateIdentity**</b>
+
+A pointer that, upon success, receives a pointer to an [IUpdateIdentity](nn-wuapi-iupdateidentity.md) containing the unique identifier of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_image.md
@@ -57,6 +57,12 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IImageInformation**</b>
+
+A pointer that, upon success, receives a pointer to an [IImageInformation](nn-wuapi-iimageinformation.md) containing the image information.
+
 ## -returns
 
 Returns S_OK if successful. Otherwise, returns a COM or Windows error code.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_installationbehavior.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_installationbehavior.md
@@ -57,6 +57,12 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IInstallationBehavior**</b>
+
+A pointer that, upon success, receives a pointer to an [IInstallationBehavior](nn-wuapi-iinstallationbehavior.md) containing the installation options of the update.
+
 ## -returns
 
 Returns S_OK if successful. Otherwise, returns a COM or Windows error code.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isbeta.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isbeta.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is a beta release, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isdownloaded.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isdownloaded.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is downloaded, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ishidden.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ishidden.md
@@ -74,4 +74,6 @@ An attempt to mark a mandatory update as hidden causes an error.
 
 ## -see-also
 
+[IsHidden setter](nf-wuapi-iupdate-put_ishidden.md)
+
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ishidden.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ishidden.md
@@ -58,6 +58,16 @@ This property is read/write.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is hidden, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 An attempt to mark a mandatory update as hidden causes an error.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isinstalled.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isinstalled.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is installed, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ismandatory.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_ismandatory.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update is mandatory, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If you try to mark a mandatory update as hidden, an error occurs.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isuninstallable.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_isuninstallable.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>VARIANT_BOOL*</b>
+
+A pointer to a variable of type <a href="/windows/win32/api/oaidl/ns-oaidl-variant#__variant_name_2__variant_name_3bool">VARIANT_BOOL</a> that receives <b>VARIANT_TRUE</b> if the update can be uninstalled, and <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_kbarticleids.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_kbarticleids.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing the Knowledge Base article IDs.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_languages.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_languages.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing the supported languages.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 This property refers to the language of the update itself.  The language that is used for the title and description of the update is not necessarily the language of the update itself.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_lastdeploymentchangetime.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_lastdeploymentchangetime.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>DATE*</b>
+
+A pointer that, upon success, receives the last published date of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 On computers that are running Windows XP, the <b>LastDeploymentChangeTime</b> property retrieves the same date and time that are retrieved by the  <a href="/previous-versions/windows/desktop/ms750903(v=vs.85)">CreationDate</a> property  of the <b>IUpdateApproval</b> interface. The <a href="/previous-versions/windows/desktop/ms750903(v=vs.85)">CreationDate</a> property is used on computers that are running Windows Server 2003.
@@ -64,3 +74,5 @@ On computers that are running Windows XP, the <b>LastDeploymentChangeTime</b> p
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>
+
+<a href="/windows/win32/api/oaidl/ns-oaidl-variant">VARIANT</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_maxdownloadsize.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_maxdownloadsize.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>DECIMAL*</b>
+
+A pointer that, upon success, receives the maximum download size of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdate-get_mindownloadsize">MinDownloadSize</a> property of an update is always downloaded.  However, the <b>MaxDownloadSize</b> property is not always downloaded. The <b>MaxDownloadSize</b> property is downloaded based on the configuration of the computer that receives the update.
@@ -64,3 +74,5 @@ The <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdate-get_mindownloadsize">Mi
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>
+
+<a href="/windows/win32/api/oaidl/ns-oaidl-variant">VARIANT</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_mindownloadsize.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_mindownloadsize.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>DECIMAL*</b>
+
+A pointer that, upon success, receives the minimum download size of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The <b>MinDownloadSize</b> property of an update is always downloaded.  However, the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdate-get_maxdownloadsize">MaxDownloadSize</a> property is not always downloaded. The <b>MaxDownloadSize</b> property is downloaded based on the configuration of the computer that receives the update.
@@ -64,3 +74,5 @@ The <b>MinDownloadSize</b> property of an update is always downloaded.  However,
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>
+
+<a href="/windows/win32/api/oaidl/ns-oaidl-variant">VARIANT</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_moreinfourls.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_moreinfourls.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing hyperlinks to more information about the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_msrcseverity.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_msrcseverity.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the severity rating. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The following ratings are the possible severity ratings of a security issue that is fixed by an update. These ratings were revised by the Microsoft Security Response Center in November 2002.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedcpuspeed.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedcpuspeed.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>LONG*</b>
+
+A pointer that, upon success, receives the recommended CPU speed.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The following properties of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a> interface return 0 (zero) when the information is not available:

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedharddiskspace.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedharddiskspace.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>LONG*</b>
+
+A pointer that, upon success, receives the recommended free disk space.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The following properties of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a> interface return 0 (zero) when the information is not available:

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedmemory.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_recommendedmemory.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>LONG*</b>
+
+A pointer that, upon success, receives the recommended physical memory size.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 The following properties of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a> interface return 0 (zero) when the information is not available:

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_releasenotes.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_releasenotes.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the localized release notes. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_securitybulletinids.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_securitybulletinids.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing the security bulletin IDs.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supersededupdateids.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supersededupdateids.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing the IDs of the superseded updates.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -see-also
 
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supersededupdateids.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supersededupdateids.md
@@ -51,7 +51,7 @@ api_name:
 
 ## -description
 
-Gets a collection of update identifiers. This collection of identifiers specifies the updates that are superseded by the update.
+Gets a collection of update identifiers. This collection of identifiers specifies the updates that are superseded by this update.
 
 This property is read-only.
 

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supporturl.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_supporturl.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the hyperlink to the support information. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_title.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_title.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the localized title of the update. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_type.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_type.md
@@ -57,9 +57,13 @@ This property is read-only.
 
 ## -parameters
 
-### -param retval
+### -param retval [out, retval]
 
-A member of the [UpdateType](ne-wuapi-updatetype.md) enumeration specifying the type of the update.
+A pointer to a variable of type [UpdateType](ne-wuapi-updatetype.md) that receives the type of the update.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
 
 ## -see-also
 

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationbehavior.md
@@ -57,6 +57,12 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IInstallationBehavior**</b>
+
+A pointer that, upon success, receives a pointer to an [IInstallationBehavior](nn-wuapi-iinstallationbehavior.md) containing the uninstallation options of the update.
+
 ## -returns
 
 Returns S_OK if successful. Otherwise, returns a COM or Windows error code.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationnotes.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationnotes.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>BSTR*</b>
+
+A pointer to a variable of type <a href="/previous-versions/windows/desktop/automat/bstr">BSTR</a> that receives the uninstallation notes. The caller must free this memory with the <a href="/windows/win32/api/oleauto/nf-oleauto-sysfreestring">SysFreeString</a> function when it is no longer required.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property  of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationsteps.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-get_uninstallationsteps.md
@@ -57,6 +57,16 @@ This property is read-only.
 
 ## -parameters
 
+### -param retval [out, retval]
+
+Type: <b>IStringCollection**</b>
+
+A pointer that, upon success, receives a pointer to an [IStringCollection](nn-wuapi-istringcollection.md) containing the uninstallation steps.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 If the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesearcher">IUpdateSearcher</a> interface  is  created by using the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession-createupdatesearcher">IUpdateSession::CreateUpdateSearcher</a> method, the information  that   this property returns is for the language that is  specified by the <a href="/windows/desktop/api/wuapi/nf-wuapi-iupdatesession2-get_userlocale">UserLocale</a> property. This is the <b>UserLocale</b> property of the <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdatesession2">IUpdateSession2</a> interface of the session that is used to create <b>IUpdateSearcher</b>.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
@@ -74,4 +74,6 @@ An attempt to mark a mandatory update as hidden causes an error.
 
 ## -see-also
 
+[IsHidden getter](nf-wuapi-iupdate-get_ishidden.md)
+
 <a href="/windows/desktop/api/wuapi/nn-wuapi-iupdate">IUpdate</a>

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
@@ -58,6 +58,16 @@ This property is read/write.
 
 ## -parameters
 
+### -param retval [in]
+
+Type: <b>VARIANT_BOOL</b>
+
+<b>VARIANT_TRUE</b> if the update is to be hidden, <b>VARIANT_FALSE</b> if not.
+
+## -returns
+
+If this method succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+
 ## -remarks
 
 An attempt to mark a mandatory update as hidden causes an error.

--- a/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
+++ b/sdk-api-src/content/wuapi/nf-wuapi-iupdate-put_ishidden.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-Gets a Boolean value that indicates whether an update is hidden by a user. Administrators, users, and power users can retrieve the value of this property. However, only administrators and members of the Power Users administrative group can set the value of this property.
+Sets a Boolean value that indicates whether an update is hidden by a user. Administrators, users, and power users can retrieve the value of this property. However, only administrators and members of the Power Users administrative group can set the value of this property.
 
 This property is read/write.
 


### PR DESCRIPTION
I hope that the commit messages shed some light on my reasoning.

My primary concern was linking from a getter such as `IUpdate::get_DownloadPriority` to its enum type (`DownloadPriority` in this case), since I sorely missed these when navigating the Windows Update API docs, but I made a few more changes.