### PR TITLE
Clarify EnableCertPaddingCheck is opt-in; fix advisory link

### DIFF
--- a/sdk-api-src/content/wintrust/nf-wintrust-winverifytrust.md
+++ b/sdk-api-src/content/wintrust/nf-wintrust-winverifytrust.md
@@ -216,7 +216,7 @@ For example, a trust provider might indicate that the subject is not trusted, or
 <td width="60%">
 The subject failed the specified verification action. Most trust providers return a more detailed error code that describes the reason for the failure.
 
-<div class="alert"><b>Note</b>  <p class="note">The <b>TRUST_E_SUBJECT_NOT_TRUSTED</b> return code may be returned depending on the value of the <b>EnableCertPaddingCheck</b> registry key under <b>HKLM\Software\Microsoft\Cryptography\Wintrust\Config</b>. If <b>EnableCertPaddingCheck</b> is set to "1", then an additional check is performed to verify that the <b>WIN_CERTIFICATE</b> structure does not contain extraneous information. The check validates that there is no non-zero data beyond the PKCS #7 structure.  For more information, please refer to the following security advisory: <a href="/security-updates/SecurityAdvisories/2014/2915720">http://technet.microsoft.com/security/advisory/2915720#section1</a>.
+<div class="alert"><b>Note</b>  <p class="note">The <b>TRUST_E_SUBJECT_NOT_TRUSTED</b> return code may be returned depending on the value of the <b>EnableCertPaddingCheck</b> registry key under <b>HKLM\Software\Microsoft\Cryptography\Wintrust\Config</b>. If <b>EnableCertPaddingCheck</b> is set to "1", then an additional check is performed to verify that the <b>WIN_CERTIFICATE</b> structure does not contain extraneous information. The check validates that there is no non-zero data beyond the PKCS #7 structure.  Setting the <b>EnableCertPaddingCheck</b> key to &quot;1&quot; is opt-in. For more information, please refer to the following security advisory: <a href="/security-updates/securityadvisories/2014/2915720">Microsoft Security Advisory 2915720</a>.
 
 </div>
 <div> </div>

--- a/sdk-api-src/content/wintrust/nf-wintrust-winverifytrustex.md
+++ b/sdk-api-src/content/wintrust/nf-wintrust-winverifytrustex.md
@@ -227,7 +227,7 @@ For example, a trust provider might indicate that the subject is not trusted, or
 <td width="60%">
 The subject failed the specified verification action. Most trust providers return a more detailed error code that describes the reason for the failure.
 
-<div class="alert"><b>Note</b>  <p class="note">The <b>TRUST_E_SUBJECT_NOT_TRUSTED</b> return code may be returned depending on the value of the <b>EnableCertPaddingCheck</b> registry key under <b>HKLM\Software\Microsoft\Cryptography\Wintrust\Config</b>. If <b>EnableCertPaddingCheck</b> is set to "1", then an additional check is performed to verify that the <b>WIN_CERTIFICATE</b> structure does not contain extraneous information. The check validates that there is no non-zero data beyond the PKCS #7 structure. For more information, please refer to the following security advisory: <a href="/security-updates/SecurityAdvisories/2014/2915720">http://technet.microsoft.com/security/advisory/2915720#section1</a>.
+<div class="alert"><b>Note</b>  <p class="note">The <b>TRUST_E_SUBJECT_NOT_TRUSTED</b> return code may be returned depending on the value of the <b>EnableCertPaddingCheck</b> registry key under <b>HKLM\Software\Microsoft\Cryptography\Wintrust\Config</b>. If <b>EnableCertPaddingCheck</b> is set to "1", then an additional check is performed to verify that the <b>WIN_CERTIFICATE</b> structure does not contain extraneous information. The check validates that there is no non-zero data beyond the PKCS #7 structure. Setting the <b>EnableCertPaddingCheck</b> key to &quot;1&quot; is opt-in. For more information, please refer to the following security advisory: <a href="/security-updates/securityadvisories/2014/2915720">Microsoft Security Advisory 2915720</a>.
 
 </div>
 <div> </div>


### PR DESCRIPTION
Applies the correct changes from #1018 (which has unresolvable merge conflicts after 3 years).

**Changes:**
- Add 'opt-in' clarification — Security Advisory 2915720 was amended; EnableCertPaddingCheck was never made mandatory by default. The original text 'will be set to "1" by default on June 10, 2014' was already removed from main, but no replacement wording was added.
- Fix advisory link: replace old `http://technet.microsoft.com/security/advisory/2915720#section1` raw URL with proper link text 'Microsoft Security Advisory 2915720' pointing to the current docs URL.

Closes #1018