### PR TITLE
Fix GetSystemWow64Directory2: link lib is OneCore.lib, not Kernel32.lib

### DIFF
--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2a.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2a.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.lib
-req.dll: Kernel32.dll
+req.lib: OneCore.lib
+req.dll: KernelBase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 

--- a/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
+++ b/sdk-api-src/content/wow64apiset/nf-wow64apiset-getsystemwow64directory2w.md
@@ -22,8 +22,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: Kernel32.lib
-req.dll: Kernel32.dll
+req.lib: OneCore.lib
+req.dll: KernelBase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
Resolves the merge conflict in #1244 by applying the valid factual fixes to the current `docs` branch.

**Changes (both W and A variants):**
- `req.lib`: `Kernel32.lib` → `OneCore.lib` — the function is not in Kernel32.lib; the correct import library is OneCore.lib (or mincore.lib), as verified against the Windows 10 21H2 and Windows 11 SDKs.
- `req.dll`: `Kernel32.dll` → `KernelBase.dll` — the implementation lives in KernelBase.dll (Kernel32.dll forwards to it).

The `api_location` conflict from #1244 is already resolved in the current `docs` branch (kernel32.lib is no longer listed there).

Closes #1244