### PR TITLE
Update remarks section to use wcslen instead of strlen

### DIFF
--- a/sdk-api-src/content/oleauto/nf-oleauto-sysstringlen.md
+++ b/sdk-api-src/content/oleauto/nf-oleauto-sysstringlen.md
@@ -64,7 +64,7 @@ The number of characters in <i>bstr</i>, not including the terminating null char
 
 ## -remarks
 
-The returned value may be different from <b>strlen</b>(bstr) if the BSTR contains embedded Null characters. This function always returns the number of characters specified in the cch parameter of the <a href="/previous-versions/windows/desktop/api/oleauto/nf-oleauto-sysallocstringlen">SysAllocStringLen</a> function used to allocate the BSTR.
+The returned value may be different from <b>wcslen</b>(bstr) if the BSTR contains embedded Null characters. This function always returns the number of characters specified in the cch parameter of the <a href="/previous-versions/windows/desktop/api/oleauto/nf-oleauto-sysallocstringlen">SysAllocStringLen</a> function used to allocate the BSTR.
 
 ## -see-also
 


### PR DESCRIPTION
`BSTR` contains `WCHAR`s, you probably mean `wcslen` here.