### PR TITLE
Add DPAPI GUI deprecation notice (February 2027)

### DIFF
--- a/sdk-api-src/content/dpapi/nf-dpapi-cryptprotectdata.md
+++ b/sdk-api-src/content/dpapi/nf-dpapi-cryptprotectdata.md
@@ -73,6 +73,9 @@ Reserved for future use and must be set to **NULL**.
 
 A pointer to a [CRYPTPROTECT_PROMPTSTRUCT](nf-dpapi-cryptprotect_promptstruct.md) structure that provides information about where and when prompts are to be displayed and what the content of those prompts should be. This parameter can be set to **NULL** in both the encryption and decryption phases.
 
+> [!IMPORTANT]
+> The prompt-based flow controlled by this parameter is deprecated and will be removed in **February 2027**. Pass **NULL**, or pass a struct with `dwPromptFlags` set to 0, to use the non-interactive path which is unaffected. See [CRYPTPROTECT_PROMPTSTRUCT](/windows/win32/api/dpapi/ns-dpapi-cryptprotect_promptstruct) for migration guidance.
+
 ### -param dwFlags [in]
 
 This parameter can be one of the following flags. If no flags are required, this parameter can be set to `0`.

--- a/sdk-api-src/content/dpapi/nf-dpapi-cryptunprotectdata.md
+++ b/sdk-api-src/content/dpapi/nf-dpapi-cryptunprotectdata.md
@@ -74,6 +74,9 @@ This parameter is reserved for future use and must be set to <b>NULL</b>.
 
 A pointer to a <a href="/windows/win32/api/dpapi/ns-dpapi-cryptprotect_promptstruct">CRYPTPROTECT_PROMPTSTRUCT</a> structure that provides information about where and when prompts are to be displayed and what the content of those prompts should be. This parameter can be set to <b>NULL</b>.
 
+> [!IMPORTANT]
+> The prompt-based flow controlled by this parameter is deprecated and will be removed in **February 2027**. Pass **NULL**, or pass a struct with `dwPromptFlags` set to 0, to use the non-interactive path which is unaffected. See [CRYPTPROTECT_PROMPTSTRUCT](/windows/win32/api/dpapi/ns-dpapi-cryptprotect_promptstruct) for migration guidance.
+
 ### -param dwFlags [in]
 
 A <b>DWORD</b> value that specifies options for this function. This parameter can be zero, in which case no option is set, or the following flag.

--- a/sdk-api-src/content/dpapi/ns-dpapi-cryptprotect_promptstruct.md
+++ b/sdk-api-src/content/dpapi/ns-dpapi-cryptprotect_promptstruct.md
@@ -52,6 +52,13 @@ api_name:
 
 # CRYPTPROTECT_PROMPTSTRUCT structure
 
+> [!IMPORTANT]
+> **Deprecated — removal date: February 2027.** The interactive prompt-based encryption and decryption flow provided by this structure (`CRYPTPROTECT_PROMPT_ON_PROTECT` and `CRYPTPROTECT_PROMPT_ON_UNPROTECT`) will be removed in February 2027. Applications that rely on prompt-based flows must migrate before that date; after removal, decryption attempts that depend on those flows will fail and the data will no longer be recoverable through them.
+>
+> **What is NOT affected:** Non-interactive use of [CryptProtectData](/windows/desktop/api/dpapi/nf-dpapi-cryptprotectdata) and [CryptUnprotectData](/windows/desktop/api/dpapi/nf-dpapi-cryptunprotectdata) (passing `NULL` for `pPromptStruct`, or supplying a struct with `dwPromptFlags` set to 0) is unaffected.
+>
+> **Migrate to:** [DPAPI-NG (NCryptProtectSecret)](/windows/win32/seccng/cng-dpapi) for Win32 apps, or [DataProtectionProvider](/uwp/api/Windows.Security.Cryptography.DataProtection.DataProtectionProvider) for UWP and WinUI apps.
+
 
 ## -description
 


### PR DESCRIPTION
## Summary

Adds a deprecation notice to the correct Win32 API reference pages for the DPAPI GUI component removal (February 2027).

**Replaces:** MicrosoftDocs/windows-dev-docs-pr#6703 (closed — that PR incorrectly targeted the .NET `data-protection.md` page; the .NET DataProtectionProvider API does not expose `CRYPTPROTECT_PROMPTSTRUCT` at all).

## Pages changed

- `ns-dpapi-cryptprotect_promptstruct.md` — main deprecation notice with migration guidance
- `nf-dpapi-cryptprotectdata.md` — IMPORTANT callout on `pPromptStruct` parameter
- `nf-dpapi-cryptunprotectdata.md` — IMPORTANT callout on `pPromptStruct` parameter

## What is deprecated
- Interactive prompt flows using `CRYPTPROTECT_PROMPT_ON_PROTECT` / `CRYPTPROTECT_PROMPT_ON_UNPROTECT`

## What is NOT affected
- Non-interactive use of `CryptProtectData`/`CryptUnprotectData` (NULL or dwPromptFlags=0)