### PR TITLE
Fix 'wab wab wab' typo in wabiab/index.md

### DIFF
--- a/sdk-api-src/content/wabiab/index.md
+++ b/sdk-api-src/content/wabiab/index.md
@@ -6,7 +6,7 @@ ms.date: 03/03/2021
 ms.keywords: 
 ms.topic: overview
 ms.update-cycle: 1095-days
-tech.root: wab wab wab
+tech.root: wab
 f1_keywords:
  - wabiab
  - wabiab/wabiab


### PR DESCRIPTION
The value of the tech.root field in sdk-api-src/content/wabiab/index.md is currently "wab wab wab". The correct value is "wab". See e.g. wabapi\index.md ("tech.root: wab") and wabdefs\index.md ("tech.root: wab")