### PR TITLE
Deprecate Winsock helpers unsafe for dual-stack sockets

### DIFF
--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetipusermtu.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetipusermtu.md
@@ -63,6 +63,9 @@ On success, the function returns 0. Otherwise, a value of [SOCKET_ERROR](/window
 
 ## -remarks
 
-This functionality is supported through the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) socket option. **WSAGetIPUserMtu** is a type-safe wrapper for getting this socket option, and we recommend it over [getsockopt](../winsock/nf-winsock-getsockopt.md).
+> [!IMPORTANT]
+> This API is deprecated. **WSAGetIPUserMtu** does not properly support dual-stack sockets. Use the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_USER_MTU**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [getsockopt](../winsock/nf-winsock-getsockopt.md) instead.
+
+On a dual-stack socket, applications need to get both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_USER_MTU** option applies.
 
 ## -see-also

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetipusermtu.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetipusermtu.md
@@ -66,6 +66,6 @@ On success, the function returns 0. Otherwise, a value of [SOCKET_ERROR](/window
 > [!IMPORTANT]
 > This API is deprecated. **WSAGetIPUserMtu** does not properly support dual-stack sockets. Use the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_USER_MTU**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [getsockopt](../winsock/nf-winsock-getsockopt.md) instead.
 
-On a dual-stack socket, applications need to get both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_USER_MTU** option applies.
+On a dual-stack socket that is unbound or bound to a wildcard address, applications need to get both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately. If the socket is bound to a specific IPv6 address, only the **IPV6_USER_MTU** option should be get. If the socket is bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), only the **IP_USER_MTU** option should be get.
 
 ## -see-also

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetrecvipecn.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetrecvipecn.md
@@ -68,7 +68,7 @@ If the function succeeds, then the return value is 0. Otherwise, a value of **SO
 > [!IMPORTANT]
 > This API is deprecated. **WSAGetRecvIPEcn** does not properly support dual-stack sockets. Use the [**IP_ECN**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_ECN**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [getsockopt](../winsock/nf-winsock-getsockopt.md) instead.
 
-On a dual-stack socket, applications need to get both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_ECN** option applies.
+On a dual-stack socket that is unbound or bound to a wildcard address, applications need to get both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately. If the socket is bound to a specific IPv6 address, only the **IPV6_ECN** option should be get. If the socket is bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), only the **IP_ECN** option should be get.
 
 ## -see-also
 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetrecvipecn.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsagetrecvipecn.md
@@ -65,6 +65,11 @@ If the function succeeds, then the return value is 0. Otherwise, a value of **SO
 
 ## -remarks
 
+> [!IMPORTANT]
+> This API is deprecated. **WSAGetRecvIPEcn** does not properly support dual-stack sockets. Use the [**IP_ECN**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_ECN**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [getsockopt](../winsock/nf-winsock-getsockopt.md) instead.
+
+On a dual-stack socket, applications need to get both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_ECN** option applies.
+
 ## -see-also
 
 * [Winsock explicit congestion notification (ECN)](/windows/win32/winsock/winsock-ecn)

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetipusermtu.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetipusermtu.md
@@ -66,6 +66,6 @@ On success, the function returns 0. Otherwise, a value of [SOCKET_ERROR](/window
 > [!IMPORTANT]
 > This API is deprecated. **WSASetIPUserMtu** does not properly support dual-stack sockets. Use the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_USER_MTU**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [setsockopt](../winsock/nf-winsock-setsockopt.md) instead.
 
-On a dual-stack socket, applications need to set both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_USER_MTU** option applies.
+On a dual-stack socket that is unbound or bound to a wildcard address, applications need to set both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately. If the socket is bound to a specific IPv6 address, only the **IPV6_USER_MTU** option should be set. If the socket is bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), only the **IP_USER_MTU** option should be set.
 
 ## -see-also

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetipusermtu.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetipusermtu.md
@@ -63,6 +63,9 @@ On success, the function returns 0. Otherwise, a value of [SOCKET_ERROR](/window
 
 ## -remarks
 
-This functionality is supported through the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) socket option. **WSASetIPUserMtu** is a type-safe wrapper for setting this socket option, and we recommend it over [setsockopt](../winsock/nf-winsock-setsockopt.md).
+> [!IMPORTANT]
+> This API is deprecated. **WSASetIPUserMtu** does not properly support dual-stack sockets. Use the [**IP_USER_MTU**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_USER_MTU**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [setsockopt](../winsock/nf-winsock-setsockopt.md) instead.
+
+On a dual-stack socket, applications need to set both the **IP_USER_MTU** (level **IPPROTO_IP**) and **IPV6_USER_MTU** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_USER_MTU** option applies.
 
 ## -see-also

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetrecvipecn.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetrecvipecn.md
@@ -70,7 +70,7 @@ If the function succeeds, then the return value is 0. Otherwise, a value of **SO
 > [!IMPORTANT]
 > This API is deprecated. **WSASetRecvIPEcn** does not properly support dual-stack sockets. Use the [**IP_ECN**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_ECN**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [setsockopt](../winsock/nf-winsock-setsockopt.md) instead.
 
-On a dual-stack socket, applications need to set both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_ECN** option applies.
+On a dual-stack socket that is unbound or bound to a wildcard address, applications need to set both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately. If the socket is bound to a specific IPv6 address, only the **IPV6_ECN** option should be set. If the socket is bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), only the **IP_ECN** option should be set.
 
 ## -see-also
 

--- a/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetrecvipecn.md
+++ b/sdk-api-src/content/ws2tcpip/nf-ws2tcpip-wsasetrecvipecn.md
@@ -67,6 +67,11 @@ If the function succeeds, then the return value is 0. Otherwise, a value of **SO
 
 ## -remarks
 
+> [!IMPORTANT]
+> This API is deprecated. **WSASetRecvIPEcn** does not properly support dual-stack sockets. Use the [**IP_ECN**](/windows/win32/winsock/ipproto-ip-socket-options) and [**IPV6_ECN**](/windows/win32/winsock/ipproto-ipv6-socket-options) socket options directly with [setsockopt](../winsock/nf-winsock-setsockopt.md) instead.
+
+On a dual-stack socket, applications need to set both the **IP_ECN** (level **IPPROTO_IP**) and **IPV6_ECN** (level **IPPROTO_IPV6**) socket options separately, unless the socket is currently bound to an IPv4-mapped IPv6 address (for example, `::ffff:192.0.2.1`), in which case only the **IP_ECN** option applies.
+
 ## -see-also
 
 * [Winsock explicit congestion notification (ECN)](/windows/win32/winsock/winsock-ecn)


### PR DESCRIPTION
Several Winsock helper functions are not compatible with dual-stack sockets, so document their deprecation and recommended alternatives.