### PR TITLE
Add backticks around paths for GetSystemWindowsDirectory documentation

### DIFF
--- a/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getsystemwindowsdirectorya.md
+++ b/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getsystemwindowsdirectorya.md
@@ -73,7 +73,7 @@ This function is provided primarily for compatibility. Applications should store
 
 ### -param lpBuffer [out]
 
-A pointer to the buffer to receive the path. This path does not end with a backslash unless the Windows directory is the root directory. For example, if the Windows directory is named Windows on drive C, the path of the Windows directory retrieved by this function is C:\Windows. If the system was installed in the root directory of drive C, the path retrieved is C:\.
+A pointer to the buffer to receive the path. This path does not end with a backslash unless the Windows directory is the root directory. For example, if the Windows directory is named Windows on drive C, the path of the Windows directory retrieved by this function is `C:\Windows`. If the system was installed in the root directory of drive C, the path retrieved is `C:\`.
 
 ### -param uSize [in]
 

--- a/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getsystemwindowsdirectoryw.md
+++ b/sdk-api-src/content/sysinfoapi/nf-sysinfoapi-getsystemwindowsdirectoryw.md
@@ -73,7 +73,7 @@ This function is provided primarily for compatibility. Applications should store
 
 ### -param lpBuffer [out]
 
-A pointer to the buffer to receive the path. This path does not end with a backslash unless the Windows directory is the root directory. For example, if the Windows directory is named Windows on drive C, the path of the Windows directory retrieved by this function is C:\Windows. If the system was installed in the root directory of drive C, the path retrieved is C:\.
+A pointer to the buffer to receive the path. This path does not end with a backslash unless the Windows directory is the root directory. For example, if the Windows directory is named Windows on drive C, the path of the Windows directory retrieved by this function is `C:\Windows`. If the system was installed in the root directory of drive C, the path retrieved is `C:\`.
 
 ### -param uSize [in]
 


### PR DESCRIPTION
In the documentation for `lpBuffer` in `GetSystemWindowsDirectory`, it calls out that if Windows is in the root directory of the drive, the returned path should end with a backslash. However, as it is rendered on the site, this doesn't have a backslash, which is confusing:

<img width="948" height="180" alt="image" src="https://github.com/user-attachments/assets/3ac16a82-5154-4ecc-bdb0-9fa7cb899d33" />

This is because markdown is escaping the period character, since that is used for unordered lists. I could have just done `C:\\` to escape the backslash, but I think the inline code backticks also make it clear that "." is not part of the path either.

This is not going to be the only instance of this problem in the docs, but it uniquely affected this sentence. This [query for instances of `C:\` and not `C:\\`](https://github.com/search?q=repo%3AMicrosoftDocs%2Fsdk-api+%22C%3A%5C%5C%22+AND+NOT+%22C%3A%5C%5C%5C%5C%22&type=code&p=1) might help find other cases that would need a similar fix, it only matters if the character after `\` can be escaped in Markdown.