### PR TITLE
winbase/ReadDirectoryChangesExW: Fix to say it's supported in UWP apps

### DIFF
--- a/sdk-api-src/content/winbase/nf-winbase-readdirectorychangesexw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-readdirectorychangesexw.md
@@ -11,8 +11,8 @@ ms.keywords: FILE_NOTIFY_CHANGE_ATTRIBUTES, FILE_NOTIFY_CHANGE_CREATION, FILE_NO
 req.header: winbase.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 10, version 1709 [desktop apps only]
-req.target-min-winversvr: Windows Server 2019 [desktop apps only]
+req.target-min-winverclnt: Windows 10, version 1709 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2019 [desktop apps \| UWP apps]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 


### PR DESCRIPTION
Both ReadDirectoryChangesExW and ...ChangesW without the Ex are declared within WINAPI_PARTITION_APP in winbase.h, meaning they're both available to UWP apps just the same as desktop/Win32 apps. (Checked in SDK versions 10.0.26100.7705 and 10.0.22621.2040.)

Update ...ChangesExW's minimum required versions accordingly.