### PR TITLE
Fix broken links

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfinalpathnamebyhandlea.md
@@ -237,7 +237,7 @@ Invalid flags were specified for <i>dwFlags</i>.
 The Server Message Block (SMB) Protocol does not support queries for normalized paths. Consequently, when you call this function passing the handle of a file opened using SMB, and with the FILE_NAME_NORMALIZED flag, the function splits the path into its components and tries to query for the normalized name of each of those components in turn. If the user lacks access permission to any one of those components, then the function call fails with ERROR_ACCESS_DENIED.
 
 > [!NOTE]
-> Windows 10 version 1709 and later and Windows Server version 1709 and later support the **FileNormalizedNameInformation** information class via SMB. See the [MS-SMB2 specification] (/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_414) Appendix A, Section 3.3.5.20.1 for more information.
+> Windows 10 version 1709 and later and Windows Server version 1709 and later support the **FileNormalizedNameInformation** information class via SMB. See the [MS-SMB2 specification](/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_414) Appendix A, Section 3.3.5.20.1 for more information.
 
  A final path is the path that is returned when a path is fully resolved. For example, for a symbolic link 
      named "C:\tmp\mydir" that points to "D:\yourdir", the final path would be 

--- a/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamea.md
@@ -125,7 +125,7 @@ It is possible to have access to a file or directory but not have access to some
     fail when it is unable to query the parent directory of a path component to determine the long name for that 
     component. This check can be skipped for directory components that have file extensions longer than 3 characters, 
     or total lengths longer than 12 characters. For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getlongpathnamew.md
@@ -135,7 +135,7 @@ It is possible to have access to a file or directory but not have access to some
     fail when it is unable to query the parent directory of a path component to determine the long name for that 
     component. This check can be skipped for directory components that have file extensions longer than 3 characters, 
     or total lengths longer than 12 characters. For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/fileapi/nf-fileapi-getshortpathnamew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getshortpathnamew.md
@@ -145,7 +145,7 @@ It is possible to have access to a file or directory but not have access to some
     may fail when it is unable to query the parent directory of a path component  to determine the short name for that 
     component. This check can be skipped for directory components that already meet the requirements of a short name. 
     For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/winbase/nf-winbase-getlongpathnametransacteda.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getlongpathnametransacteda.md
@@ -136,7 +136,7 @@ It is possible to have access to a file or directory but not have access to some
     unable to query the parent directory of a path component to determine the long name for that component. This check 
     can be skipped for directory components that have file extensions longer than 3 characters, or total lengths 
     longer than 12 characters. For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/winbase/nf-winbase-getlongpathnametransactedw.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getlongpathnametransactedw.md
@@ -137,7 +137,7 @@ It is possible to have access to a file or directory but not have access to some
     unable to query the parent directory of a path component to determine the long name for that component. This check 
     can be skipped for directory components that have file extensions longer than 3 characters, or total lengths 
     longer than 12 characters. For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.

--- a/sdk-api-src/content/winbase/nf-winbase-getshortpathnamea.md
+++ b/sdk-api-src/content/winbase/nf-winbase-getshortpathnamea.md
@@ -143,7 +143,7 @@ It is possible to have access to a file or directory but not have access to some
     may fail when it is unable to query the parent directory of a path component  to determine the short name for that 
     component. This check can be skipped for directory components that already meet the requirements of a short name. 
     For more information, see the 
-    <a href="/windows/desktop/FileIO/naming-a-file">Short vs. Long Names</a> section of 
+    <a href="/windows/desktop/FileIO/naming-a-file#short-vs-long-names">Short vs. Long Names</a> section of 
     <a href="/windows/desktop/FileIO/naming-a-file">Naming Files, Paths, and Namespaces</a>.
 
 In Windows 8 and Windows Server 2012, this function is supported by the following technologies.


### PR DESCRIPTION
Fix broken link in https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlea and to Short vs. Long Names section of Naming Files, Paths, and Namespaces