### PR TITLE
Update note on Kerberos encryption type order

### DIFF
--- a/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
+++ b/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
@@ -290,7 +290,7 @@ Values greater than 127 are reserved for local values and may change without not
 </table>
 
 > [!NOTE]
-> This field adjusts the Kerberos preferred encryption type order. However, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers. For more information, see this blog post <a href = "https://techcommunity.microsoft.com/blog/askds/whats-the-deal-with-kerb3961/4420109"> What's the deal with Kerb3961 </a> on the Microsoft Community Hub.
+> This field adjusts the Kerberos preferred encryption type order. However, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers. For more information, see this blog post [What's the deal with Kerb3961](https://techcommunity.microsoft.com/blog/askds/whats-the-deal-with-kerb3961/4420109) on the Microsoft Community Hub.
 
 ### -field CredentialsHandle
 

--- a/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
+++ b/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
@@ -289,6 +289,9 @@ Values greater than 127 are reserved for local values and may change without not
 </tr>
 </table>
 
+> [!NOTE]
+> This field adjusts the Kerberos preferred encryption type order however, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers.
+
 ### -field CredentialsHandle
 
 An SSPI credentials handle used in place of a logon session identifier.

--- a/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
+++ b/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
@@ -290,7 +290,7 @@ Values greater than 127 are reserved for local values and may change without not
 </table>
 
 > [!NOTE]
-> This field adjusts the Kerberos preferred encryption type order. However, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers.
+> This field adjusts the Kerberos preferred encryption type order. However, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers. For more information, see this blog post <a href = "https://techcommunity.microsoft.com/blog/askds/whats-the-deal-with-kerb3961/4420109"> What's the deal with Kerb3961 </a> on the Microsoft Community Hub.
 
 ### -field CredentialsHandle
 

--- a/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
+++ b/sdk-api-src/content/ntsecapi/ns-ntsecapi-kerb_retrieve_tkt_request.md
@@ -290,7 +290,7 @@ Values greater than 127 are reserved for local values and may change without not
 </table>
 
 > [!NOTE]
-> This field adjusts the Kerberos preferred encryption type order however, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers.
+> This field adjusts the Kerberos preferred encryption type order. However, this order is no longer honored by Windows Server 2025 and newer Kerberos Key Distribution Centers.
 
 ### -field CredentialsHandle
 


### PR DESCRIPTION
Clarified note about Kerberos encryption type order in Windows Server 2025 and newer.