### PR TITLE
Mark lpFilePart of GetFullPathName as optional

### DIFF
--- a/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamea.md
@@ -92,12 +92,12 @@ The size of the buffer to receive the null-terminated string for the drive and p
 
 A pointer to a buffer that receives the null-terminated string for the  drive and path.
 
-### -param lpFilePart [out]
+### -param lpFilePart [out, optional]
 
 A pointer to a buffer that receives the address (within <i>lpBuffer</i>) of the final 
       file name component in the path. 
 
-This parameter can be  <b>NULL</b>.
+This parameter can be <b>NULL</b>.
 
 If <i>lpBuffer</i> 
       refers to a directory and not a file, <i>lpFilePart</i> receives zero.

--- a/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamew.md
+++ b/sdk-api-src/content/fileapi/nf-fileapi-getfullpathnamew.md
@@ -96,12 +96,12 @@ The size of the buffer to receive the null-terminated string for the drive and p
 
 A pointer to a buffer that receives the null-terminated string for the  drive and path.
 
-### -param lpFilePart [out]
+### -param lpFilePart [out, optional]
 
 A pointer to a buffer that receives the address (within <i>lpBuffer</i>) of the final 
       file name component in the path. 
 
-This parameter can be  <b>NULL</b>.
+This parameter can be <b>NULL</b>.
 
 If <i>lpBuffer</i> 
       refers to a directory and not a file, <i>lpFilePart</i> receives zero.


### PR DESCRIPTION
Mark parameter lpFilePart of GetFullPathName that "can be NULL" and is defined in the header with \_Outptr\_opt\_ as optional