### PR TITLE
Update SDK API docs with changes for ML-DSA and ML-KEM in Bcrypt

### DIFF
--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
@@ -47,9 +47,6 @@ api_name:
 
 # BCryptDecapsulate function
 
-> [!NOTE]
-> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
-
 The **BCryptDecapsulate** function performs the Decapsulation operation of a Key Encapsulation Mechanism (KEM).
 It takes a KEM ciphertext and it decrypts with the provided private key, returning the shared secret key.
 

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
@@ -1,0 +1,138 @@
+---
+UID: NF:bcrypt.BCryptDecapsulate
+title: BCryptDecapsulate function (bcrypt.h)
+description: Performs the Decapsulation operation of a KEM algorithm, decrypting a ciphertext and returning the shared secret key.
+helpviewer_keywords: ["BCryptDecapsulate","BCryptDecapsulate function [Security]","bcrypt/BCryptDecapsulate","security.bcryptdecapsulate", "BCrypt KEM"]
+old-location: security\bcryptdecapsulate.htm
+tech.root: security
+ms.assetid:
+ms.date: 5/22/2025
+ms.keywords: BCryptDecapsulate, BCryptDecapsulate function [Security], bcrypt/BCryptDecapsulate, security.bcryptdecapsulate, BCrypt KEM
+req.header: bcrypt.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 7 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2008 R2 [desktop apps \| UWP apps]
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: Bcrypt.lib
+req.dll: Bcrypt.dll
+req.irql: 
+targetos: Windows
+req.typenames: 
+req.redist: 
+ms.custom: 24H2
+f1_keywords:
+ - BCryptDecapsulate
+ - bcrypt/BCryptDecapsulate
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - DllExport
+api_location:
+ - Bcrypt.dll
+api_name:
+ - BCryptDecapsulate
+original_content_git_url: https://github.com/MicrosoftDocs/win32-pr/blob/live/desktop-src/SecCNG/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+---
+
+# BCryptDecapsulate function
+
+> [!NOTE]
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+
+The **BCryptDecapsulate** function performs the Decapsulation operation of a Key Encapsulation Mechanism (KEM).
+It takes a KEM ciphertext and it decrypts with the provided private key, returning the shared secret key.
+
+If the ciphertext is correctly formatted but does not match the decapsulation key, this API will succeed but a random shared secret key will be generated.
+
+## Syntax
+
+```cpp
+NTSTATUS BCryptDecapsulate(
+  _In_  BCRYPT_KEY_HANDLE hKey,
+  _In_reads_bytes_(cbCipherText)
+        PUCHAR            pbCipherText,
+  _In_  ULONG             cbCipherText,
+  _Out_writes_bytes_to_opt_(cbSecretKey, *pcbSecretKey)
+        PUCHAR            pbSecretKey,
+  _In_  ULONG             cbSecretKey,
+  _Out_ ULONG             *pcbSecretKey,
+  _In_  ULONG             dwFlags
+);
+```
+
+## Parameters
+
+*hKey* `[in]`
+
+The handle of the key to use to decapsulate the KEM ciphertext. This must be the private (decapsulation) key which corresponds to the public (encapsulation) key used to produce the KEM ciphertext. The key handle is obtained from one of the keypair creation functions, such as [BCryptGenerateKeyPair](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair) or [BCryptImportKeyPair](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptimportkeypair).
+
+*pbCipherText* `[in]`
+
+A pointer to a buffer that contains the KEM ciphertext. The [BCryptEncapsulate](nf-bcrypt-bcryptencapsulate.md) function may be used to create a KEM ciphertext.
+
+*cbCipherText* `[in]`
+
+The size, in bytes, of the *pbCipherText* buffer.
+
+*pbSecretKey* `[out]`
+
+A pointer to a buffer that receives the shared secret key. See [remarks](#remarks) for more information.
+
+*cbSecretKey* `[in]`
+
+The size, in bytes, of the *pbSecretKey* buffer.
+
+*pcbSecretKey* `[out]`
+
+A pointer to a **ULONG** variable that the receives the number of bytes written to *pbSecretKey* buffer.
+
+If *pbSecretKey* is `NULL`, this receives the size, in bytes, required for the shared secret key.
+See [remarks](#remarks) for more information.
+
+*dwFlags* `[in]`
+
+Reserved, must be zero.
+
+## Return value
+
+Returns a status code that indicates the success or failure of the function.
+
+Possible return codes include, but are not limited to, the following.
+
+| Return Code | Description |
+|--|--|
+| `STATUS_SUCCESS` | The function was successful. |
+| `STATUS_INVALID_PARAMETER` | One or more required parameters (*hKey*, *pcbSecretKey*, *pbCipherText*) is `NULL`, or one of the parameters has an invalid value. |
+| `STATUS_INVALID_BUFFER_SIZE` | A buffer size (*cbSecretKey*, *cbCipherText*) does not match the expected size for the KEM parameters associated with the decapsulation key. |
+| `STATUS_BUFFER_TOO_SMALL` | An output buffer size (*cbSecretKey*) is too small for the result decapsulation operation for the KEM parameters associated with the decapsulation key. *pcbSecretKey* receives the number of bytes required for *pbSecretKey*. |
+
+## Remarks
+
+To query the required size of the *pbSecretKey* buffer needed for the KEM shared secret key, call **BCryptDecapsulate** with a `NULL` *pbSecretKey*. The required size will be returned in *pcbSecretKey*. This query is efficient and returns the size without performing the decapsulation.
+Equivalently, use [BCryptGetProperty](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT_KEM_SHARED_SECRET_LENGTH** property of the algorithm or key handle.
+For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm.
+
+### Additional remarks
+
+Given an invalid, but correctly-sized, ciphertext, the ML-KEM decapsulation operation will *implicitly reject* the ciphertext by returning success in equal time to a valid decapsulation operation, with pseudo-random shared secret key output. This forces higher-level protocols to fail later when symmetric keys of peers don't match. So, decapsulate will only ever fail if there are programming errors (i.e. incorrect size, use of uninitialized *hKey*), or something fundamentally goes wrong with the environment (i.e. internal memory allocation fails, or and internal consistency test detects hardware error).
+
+## Requirements
+
+| Requirement | Value |
+| ---- | ---- |
+| **Minimum supported client** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Library** | `Bcrypt.lib` |
+| **DLL** | `Bcrypt.dll` |

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
@@ -43,7 +43,6 @@ api_location:
  - Bcrypt.dll
 api_name:
  - BCryptDecapsulate
-original_content_git_url: https://github.com/MicrosoftDocs/win32-pr/blob/live/desktop-src/SecCNG/bcrypt/nf-bcrypt-bcryptdecapsulate.md
 ---
 
 # BCryptDecapsulate function

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
@@ -11,8 +11,8 @@ ms.keywords: BCryptDecapsulate, BCryptDecapsulate function [Security], bcrypt/BC
 req.header: bcrypt.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 11 24H2
+req.target-min-winversvr: Windows Server 2025
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -132,7 +132,7 @@ Given an invalid, but correctly-sized, ciphertext, the ML-KEM decapsulation oper
 
 | Requirement | Value |
 | ---- | ---- |
-| **Minimum supported client** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
-| **Minimum supported server** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported client** | **Windows 11 24H2:** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Server 2025:** Support for ML-KEM begins. [desktop apps only] |
 | **Library** | `Bcrypt.lib` |
 | **DLL** | `Bcrypt.dll` |

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptdecapsulate.md
@@ -76,7 +76,7 @@ NTSTATUS BCryptDecapsulate(
 
 *hKey* `[in]`
 
-The handle of the key to use to decapsulate the KEM ciphertext. This must be the private (decapsulation) key which corresponds to the public (encapsulation) key used to produce the KEM ciphertext. The key handle is obtained from one of the keypair creation functions, such as [BCryptGenerateKeyPair](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair) or [BCryptImportKeyPair](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptimportkeypair).
+The handle of the key to use to decapsulate the KEM ciphertext. This must be the private (decapsulation) key which corresponds to the public (encapsulation) key used to produce the KEM ciphertext. The key handle is obtained from one of the keypair creation functions, such as [BCryptGenerateKeyPair](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair) or [BCryptImportKeyPair](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptimportkeypair).
 
 *pbCipherText* `[in]`
 
@@ -121,7 +121,7 @@ Possible return codes include, but are not limited to, the following.
 ## Remarks
 
 To query the required size of the *pbSecretKey* buffer needed for the KEM shared secret key, call **BCryptDecapsulate** with a `NULL` *pbSecretKey*. The required size will be returned in *pcbSecretKey*. This query is efficient and returns the size without performing the decapsulation.
-Equivalently, use [BCryptGetProperty](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT_KEM_SHARED_SECRET_LENGTH** property of the algorithm or key handle.
+Equivalently, use [BCryptGetProperty](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT_KEM_SHARED_SECRET_LENGTH** property of the algorithm or key handle.
 For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm.
 
 ### Additional remarks

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
@@ -11,8 +11,8 @@ ms.keywords: BCryptEncapsulate, BCryptEncapsulate function [Security], bcrypt/BC
 req.header: bcrypt.h
 req.include-header: 
 req.target-type: Windows
-req.target-min-winverclnt: Windows 7 [desktop apps \| UWP apps]
-req.target-min-winversvr: Windows Server 2008 R2 [desktop apps \| UWP apps]
+req.target-min-winverclnt: Windows 11 24H2
+req.target-min-winversvr: Windows Server 2025
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -75,7 +75,7 @@ NTSTATUS BCryptEncapsulate(
 
 *hKey*`[in]`
 
-The handle of the key to use for the encapsulation operation. This key must contain a public (encapsulation) key, and the handle would typically be obtained by using [BCryptImportKeyPair](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptimportkeypair) with a [public key](/en-us/windows/win32/SecGloss/p-gly) BLOB for the KEM algorithm. It is also possible to use a private key handle for the encapsulation operation, as KEM private key handles represent a key pair.
+The handle of the key to use for the encapsulation operation. This key must contain a public (encapsulation) key, and the handle would typically be obtained by using [BCryptImportKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptimportkeypair) with a [public key](/en-us/windows/desktop/SecGloss/p-gly) BLOB for the KEM algorithm. It is also possible to use a private key handle for the encapsulation operation, as KEM private key handles represent a key pair.
 
 *pbSecretKey*`[out]`
 
@@ -124,13 +124,13 @@ Possible return codes include, but are not limited to, the following.
 
 ## Remarks
 
-To query the required sizes of the *pbSecretKey* and *pbCipherText* buffers, callers may call **BCryptEncapsulate** with `NULL`*pbSecretKey* and *pbCipherText*. The required sizes will be returned in *pcbSecretKey* and *pcbCipherText*, respectively. This query is efficient and returns the size without performing the encapsulation. Equivalently, use [BCryptGetProperty](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT\_KEM\_SHARED\_SECRET\_LENGTH** property of the algorithm or key handle, and the **BCRYPT\_KEM\_CIPHERTEXT\_LENGTH** property of the key handle. For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm and the KEM ciphertext length is a constant size for a given parameter set.
+To query the required sizes of the *pbSecretKey* and *pbCipherText* buffers, callers may call **BCryptEncapsulate** with `NULL`*pbSecretKey* and *pbCipherText*. The required sizes will be returned in *pcbSecretKey* and *pcbCipherText*, respectively. This query is efficient and returns the size without performing the encapsulation. Equivalently, use [BCryptGetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT\_KEM\_SHARED\_SECRET\_LENGTH** property of the algorithm or key handle, and the **BCRYPT\_KEM\_CIPHERTEXT\_LENGTH** property of the key handle. For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm and the KEM ciphertext length is a constant size for a given parameter set.
 
 ## Requirements
 
 | Requirement | Value |
 | --- | --- |
-| **Minimum supported client** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
-| **Minimum supported server** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported client** | **Windows 11 24H2:** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Server 2025:** Support for ML-KEM begins. [desktop apps only] |
 | **Library** | `Bcrypt.lib` |
 | **DLL** | `Bcrypt.dll` |

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
@@ -1,0 +1,136 @@
+---
+UID: NF:bcrypt.BCryptEncapsulate
+title: BCryptEncapsulate function (bcrypt.h)
+description: Uses a key encapsulation mechanism (KEM) to generate a shared secret key and encrypt it to produce a KEM ciphertext.
+helpviewer_keywords: ["BCryptEncapsulate","BCryptEncapsulate function [Security]","bcrypt/BCryptEncapsulate","security.bcryptencapsulate", "BCrypt KEM"]
+old-location: security\bcryptencapsulate.htm
+tech.root: security
+ms.assetid:
+ms.date: 5/22/2025
+ms.keywords: BCryptEncapsulate, BCryptEncapsulate function [Security], bcrypt/BCryptEncapsulate, security.bcryptencapsulate, BCrypt KEM
+req.header: bcrypt.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 7 [desktop apps \| UWP apps]
+req.target-min-winversvr: Windows Server 2008 R2 [desktop apps \| UWP apps]
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: Bcrypt.lib
+req.dll: Bcrypt.dll
+req.irql: 
+targetos: Windows
+req.typenames: 
+req.redist: 
+ms.custom: 24H2
+f1_keywords:
+ - BCryptEncapsulate
+ - bcrypt/BCryptEncapsulate
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - DllExport
+api_location:
+ - Bcrypt.dll
+api_name:
+ - BCryptEncapsulate
+original_content_git_url: https://github.com/MicrosoftDocs/win32-pr/blob/live/desktop-src/SecCNG/bcrypt/nf-bcrypt-bcryptencapsulate.md
+---
+
+# BCryptEncapsulate function - Win32 apps | Microsoft Learn
+
+Note
+
+Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+
+The **BCryptEncapsulate** function performs the Encapsulation operation of a Key Encapsulation Mechanism (KEM). It generates a shared secret key and encrypts it with the provided public key to produce a KEM ciphertext, returning both the shared secret key and the KEM ciphertext.
+
+## Syntax
+
+```cpp
+NTSTATUS BCryptEncapsulate(
+  _In_  BCRYPT_KEY_HANDLE hKey,
+  _Out_writes_bytes_to_opt_(cbSecretKey ,*pcbSecretKey)
+        PUCHAR            pbSecretKey,
+  _In_  ULONG             cbSecretKey,
+  _Out_ ULONG             *pcbSecretKey,
+  _Out_writes_bytes_to_opt_(cbCipherText ,*pcbCipherText)
+        PUCHAR            pbCipherText,
+  _In_  ULONG             cbCipherText,
+  _Out_ ULONG             *pcbCipherText,
+  _In_  ULONG             dwFlags
+);
+```
+
+## Parameters
+
+*hKey*`[in]`
+
+The handle of the key to use for the encapsulation operation. This key must contain a public (encapsulation) key, and the handle would typically be obtained by using [BCryptImportKeyPair](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptimportkeypair) with a [public key](/en-us/windows/win32/SecGloss/p-gly) BLOB for the KEM algorithm. It is also possible to use a private key handle for the encapsulation operation, as KEM private key handles represent a key pair.
+
+*pbSecretKey*`[out]`
+
+A pointer to a buffer that receives the shared secret key. See remarks for more information.
+
+*cbSecretKey*`[in]`
+
+The size, in bytes, of the *pbSecretKey* buffer.
+
+*pcbSecretKey*`[out]`
+
+A pointer to a **ULONG** variable that the receives the number of bytes written to *pbSecretKey* buffer.
+
+If *pbSecretKey* is `NULL`, this receives the size, in bytes, required for the shared secret key. See remarks for more information.
+
+*pbCipherText*`[out]`
+
+A pointer to a buffer that receives the KEM ciphertext. See remarks for more information.
+
+*cbCipherText*`[in]`
+
+The size, in bytes, of the *pbCipherText* buffer.
+
+*pcbCipherText*`[out]`
+
+A pointer to a **ULONG** variable that the receives the number of bytes written to *pbCipherText* buffer.
+
+If *pbCipherText* is `NULL`, this receives the size, in bytes, required for the KEM ciphertext. See remarks for more information.
+
+*dwFlags*`[in]`
+
+Reserved, must be zero.
+
+## Return value
+
+Returns a status code that indicates the success or failure of the function.
+
+Possible return codes include, but are not limited to, the following.
+
+| Return Code | Description |
+| --- | --- |
+| `STATUS_SUCCESS` | The function was successful. |
+| `STATUS_INVALID_PARAMETER` | One or more required parameters (*hKey*, *pcbSecretKey*, *pcbCipherText*) is `NULL`, or one of the parameters has an invalid value. |
+| `STATUS_INVALID_BUFFER_SIZE` | A buffer size (*cbSecretKey*, *cbCipherText*) does not match the expected size for the KEM parameters associated with the encapsulation key. \*pcbSecretKey receives the number of bytes required for *pbSecretKey*, *pcbCipherText* receives the number of bytes required for *pbCipherText*. |
+| `STATUS_BUFFER_TOO_SMALL` | An output buffer size (*cbSecretKey*, *cbCipherText*) is too small for the result encapsulation operation for the KEM parameters associated with the encapsulation key. *pcbSecretKey* receives the number of bytes required for *pbSecretKey*, *pcbCipherText* receives the number of bytes required for *pbCipherText*. |
+
+## Remarks
+
+To query the required sizes of the *pbSecretKey* and *pbCipherText* buffers, callers may call **BCryptEncapsulate** with `NULL`*pbSecretKey* and *pbCipherText*. The required sizes will be returned in *pcbSecretKey* and *pcbCipherText*, respectively. This query is efficient and returns the size without performing the encapsulation. Equivalently, use [BCryptGetProperty](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT\_KEM\_SHARED\_SECRET\_LENGTH** property of the algorithm or key handle, and the **BCRYPT\_KEM\_CIPHERTEXT\_LENGTH** property of the key handle. For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm and the KEM ciphertext length is a constant size for a given parameter set.
+
+## Requirements
+
+| Requirement | Value |
+| --- | --- |
+| **Minimum supported client** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Insiders (build 27843):** Support for ML-KEM begins. [desktop apps only] |
+| **Library** | `Bcrypt.lib` |
+| **DLL** | `Bcrypt.dll` |

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
@@ -47,9 +47,6 @@ api_name:
 
 # BCryptEncapsulate function
 
-> [!Note]
-> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
-
 The **BCryptEncapsulate** function performs the Encapsulation operation of a Key Encapsulation Mechanism (KEM). It generates a shared secret key and encrypts it with the provided public key to produce a KEM ciphertext, returning both the shared secret key and the KEM ciphertext.
 
 ## Syntax

--- a/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
+++ b/sdk-api-src/content/bcrypt/nf-bcrypt-bcryptencapsulate.md
@@ -43,14 +43,12 @@ api_location:
  - Bcrypt.dll
 api_name:
  - BCryptEncapsulate
-original_content_git_url: https://github.com/MicrosoftDocs/win32-pr/blob/live/desktop-src/SecCNG/bcrypt/nf-bcrypt-bcryptencapsulate.md
 ---
 
-# BCryptEncapsulate function - Win32 apps | Microsoft Learn
+# BCryptEncapsulate function
 
-Note
-
-Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+> [!Note]
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
 
 The **BCryptEncapsulate** function performs the Encapsulation operation of a Key Encapsulation Mechanism (KEM). It generates a shared secret key and encrypts it with the provided public key to produce a KEM ciphertext, returning both the shared secret key and the KEM ciphertext.
 
@@ -119,12 +117,12 @@ Possible return codes include, but are not limited to, the following.
 | --- | --- |
 | `STATUS_SUCCESS` | The function was successful. |
 | `STATUS_INVALID_PARAMETER` | One or more required parameters (*hKey*, *pcbSecretKey*, *pcbCipherText*) is `NULL`, or one of the parameters has an invalid value. |
-| `STATUS_INVALID_BUFFER_SIZE` | A buffer size (*cbSecretKey*, *cbCipherText*) does not match the expected size for the KEM parameters associated with the encapsulation key. \*pcbSecretKey receives the number of bytes required for *pbSecretKey*, *pcbCipherText* receives the number of bytes required for *pbCipherText*. |
+| `STATUS_INVALID_BUFFER_SIZE` | A buffer size (*cbSecretKey*, *cbCipherText*) does not match the expected size for the KEM parameters associated with the encapsulation key. *pcbSecretKey* receives the number of bytes required for *pbSecretKey*, *pcbCipherText* receives the number of bytes required for *pbCipherText*. |
 | `STATUS_BUFFER_TOO_SMALL` | An output buffer size (*cbSecretKey*, *cbCipherText*) is too small for the result encapsulation operation for the KEM parameters associated with the encapsulation key. *pcbSecretKey* receives the number of bytes required for *pbSecretKey*, *pcbCipherText* receives the number of bytes required for *pbCipherText*. |
 
 ## Remarks
 
-To query the required sizes of the *pbSecretKey* and *pbCipherText* buffers, callers may call **BCryptEncapsulate** with `NULL`*pbSecretKey* and *pbCipherText*. The required sizes will be returned in *pcbSecretKey* and *pcbCipherText*, respectively. This query is efficient and returns the size without performing the encapsulation. Equivalently, use [BCryptGetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT\_KEM\_SHARED\_SECRET\_LENGTH** property of the algorithm or key handle, and the **BCRYPT\_KEM\_CIPHERTEXT\_LENGTH** property of the key handle. For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm and the KEM ciphertext length is a constant size for a given parameter set.
+To query the required sizes of the *pbSecretKey* and *pbCipherText* buffers, callers may call **BCryptEncapsulate** with `NULL`*pbSecretKey* and *pbCipherText*. The required sizes will be returned in *pcbSecretKey* and *pcbCipherText*, respectively. This query is efficient and returns the size without performing the encapsulation. Equivalently, use [BCryptGetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) to query the **BCRYPT_KEM_SHARED_SECRET_LENGTH** property of the algorithm or key handle, and the **BCRYPT_KEM_CIPHERTEXT_LENGTH** property of the key handle. For currently supported KEM algorithms (ML-KEM), the shared secret length is a constant size for a given algorithm and the KEM ciphertext length is a constant size for a given parameter set.
 
 ## Requirements
 

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_mlkem_key_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_mlkem_key_blob.md
@@ -50,7 +50,7 @@ api_name:
 # BCRYPT_MLKEM_KEY_BLOB structure
 
 > [!NOTE]
-> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The composite features described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
 
 The **BCRYPT_MLKEM_KEY_BLOB** structure is used as a header for an ML-KEM [public key](/windows/win32/SecGloss/p-gly) (byte-encoded encapsulation key) or [private key](/windows/win32/SecGloss/p-gly) [BLOB](/windows/win32/SecGloss/b-gly) in memory.
 
@@ -66,6 +66,16 @@ typedef struct _BCRYPT_MLKEM_KEY_BLOB {
 } BCRYPT_MLKEM_KEY_BLOB, *PBCRYPT_MLKEM_KEY_BLOB;
 ```
 
+```cpp
+typedef struct _BCRYPT_COMPOSITE_MLKEM_KEY_BLOB {
+  ULONG dwMagic;
+  ULONG cbParameterSet;             // Byte size of parameterSet[]
+  ULONG cbKey;                      // Byte size of key[]
+  // WCHAR parameterSet[cbParameterSet / sizeof(WCHAR)];  // Including \0-terminated
+  // BYTE key[cbKey];                                     // Key material
+} BCRYPT_COMPOSITE_MLKEM_KEY_BLOB, *PBCRYPT_COMPOSITE_MLKEM_KEY_BLOB;
+```
+
 ## Fields
 
 ### dwMagic
@@ -73,20 +83,26 @@ typedef struct _BCRYPT_MLKEM_KEY_BLOB {
 The **dwMagic** field is a 4-byte value that indicates the format of the key being used. The following values are defined:
 
 | Value | Meaning |
-|--|--|
+| --- | --- |
 | **BCRYPT_MLKEM_PUBLIC_MAGIC** `0x504B4C4D` | The structure represents a public key. |
 | **BCRYPT_MLKEM_PRIVATE_MAGIC** `0x524B4C4D` | The structure represents an expanded private key. |
 | **BCRYPT_MLKEM_PRIVATE_SEED_MAGIC** `0x534B4C4D` | The structure represents a private seed. |
+| **BCRYPT_COMPOSITE_MLKEM_PUBLIC_MAGIC** `0x504B4D43` | The structure represents a public key. |
+| **BCRYPT_COMPOSITE_MLKEM_PRIVATE_MAGIC** `0x524B4D43` | The structure represents a private key. |
+| **BCRYPT_COMPOSITE_MLKEM_PRIVATE_IRTF_SEED_MAGIC** `0x534B4D43` | The structure represents a private seed. Reference: [IRTF](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hybrid-kems-11#section-5.5) |
 
 ### cbParameterSet
 
 The length, in bytes, of the buffer **parameterSet** directly following the struct. This buffer contains a null-terminated Unicode string that identifies the parameter set of the key. The following values (per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf)) are currently supported:
 
 | parameterSet | cbParameterSet | Meaning |
-|--|--|--|
-| **BCRYPT_MLKEM_PARAMETER_SET_512** `L"512"` | 8 | ML-KEM-512, security category 1. |
-| **BCRYPT_MLKEM_PARAMETER_SET_768** `L"768"` | 8 | ML-KEM-768, security category 3. |
-| **BCRYPT_MLKEM_PARAMETER_SET_1024** `L"1024"` | 10 | ML-KEM-1024, security category 5. |
+| --- | --- |
+| **BCRYPT_MLKEM_PARAMETER_SET_512** `L"512"` | ML-KEM-512, security category 1. |
+| **BCRYPT_MLKEM_PARAMETER_SET_768** `L"768"` | ML-KEM-768, security category 3. |
+| **BCRYPT_MLKEM_PARAMETER_SET_1024** `L"1024"` | ML-KEM-1024, security category 5. |
+| **BCRYPT_COMPOSITE_MLKEM_PARAMETER_SET_768_P256** `L"768-P256"` | Composite ML-KEM-768 and ECDH P256 |
+| **BCRYPT_COMPOSITE_MLKEM_PARAMETER_SET_768_X25519** `L"768-X25519"` | Composite ML-KEM-768 and curve25519 |
+| **BCRYPT_COMPOSITE_MLKEM_PARAMETER_SET_1024_P384** `L"1024-P384"` | Composite ML-KEM-1024 and ECDH P384 |
 
 ### cbKey
 
@@ -94,18 +110,24 @@ The length, in bytes, of the buffer **key** directly following **parameterSet**.
 
 ## Remarks
 
-**BCRYPT_MLKEM_PRIVATE_SEED_BLOB** supports import and export of ML-KEM seeds. The blob has **dwMagic**  value `BCRYPT_MLKEM_PRIVATE_SEED_MAGIC` and the **key** field contains the KEM seed (defined as the 64-byte concatenation of `d || z` per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf)), so **cbKey** is currently always `64`.
-
-**BCRYPT_MLKEM_PRIVATE_BLOB** (also aliased as **BCRYPT_MLKEM_DECAPSULATION_BLOB**) supports import and export of standard byte-encoded ML-KEM decapsulation keys per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf). The blob has **dwMagic** value `BCRYPT_MLKEM_PRIVATE_MAGIC` and the **key** field contains the byte-encoded key. 
+**BCRYPT_MLKEM_PRIVATE_BLOB** (also aliased as **BCRYPT_MLKEM_DECAPSULATION_BLOB**) supports import and export of standard byte-encoded ML-KEM decapsulation keys per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf). The blob has **dwMagic** value `BCRYPT_MLKEM_PRIVATE_MAGIC` and the **key** field contains the byte-encoded key.
 
 **BCRYPT_MLKEM_PUBLIC_BLOB** (also aliased as **BCRYPT_MLKEM_ENCAPSULATION_BLOB**) supports import and export of standard byte-encoded ML-KEM encapsulation keys per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf). The blob has **dwMagic** value `BCRYPT_MLKEM_PUBLIC_MAGIC` and the **key** field contains the byte-encoded key.
 
+**BCRYPT_MLKEM_PRIVATE_SEED_BLOB** supports import and export of ML-KEM seeds. The blob has **dwMagic**  value `BCRYPT_MLKEM_PRIVATE_SEED_MAGIC` and the **key** field contains the KEM seed (defined as the 64-byte concatenation of `d || z` per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf)), so **cbKey** is currently always `64`.
+
 The byte sizes of the byte-encoded keys can be found in [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) Section 8 Table 3. Many callers can instead dynamically query the required blob sizes using **BCryptExportKey** with `NULL` *pbOutput*.
+
+**BCRYPT_COMPOSITE_MLKEM_PRIVATE_BLOB** supports import and export of standard byte-encoded ML-KEM decapsulation keys per [PQ Composite ML-KEM](https://datatracker.ietf.org/doc/html/draft-ietf-lamps-pq-composite-kem). The blob has **dwMagic** value `BCRYPT_COMPOSITE_MLKEM_PRIVATE_MAGIC` and the **key** field contains the byte-encoded key.
+
+**BCRYPT_COMPOSITE_MLKEM_PUBLIC_BLOB** supports import and export of standard byte-encoded ML-KEM encapsulation keys per [PQ Composite ML-KEM](https://datatracker.ietf.org/doc/html/draft-ietf-lamps-pq-composite-kem). The blob has **dwMagic** value `BCRYPT_COMPOSITE_MLKEM_PUBLIC_MAGIC` and the **key** field contains the byte-encoded key.
+
+**BCRYPT_COMPOSITE_MLKEM_PRIVATE_IRTF_SEED_BLOB** supports import and export of ML-KEM seeds. The blob has **dwMagic**  value `BCRYPT_COMPOSITE_MLKEM_PRIVATE_IRTF_SEED_MAGIC` and the **key** field contains the 32-byte IRTF Composite ML-KEM seed per [Concrete Hybrid PQ/T Key Encapsulation Mechanisms](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-concrete-hybrid-kems), so **cbKey** is currently always `32`.
 
 ## Requirements
 
 | Requirement | Value |
-| ---- | ---- |
+| --- | --- |
 | **Minimum supported client** | **Windows 11  24H2:** Support for ML-KEM begins. [desktop apps only] |
 | **Minimum supported server** | **Windows Server 2025:** Support for ML-KEM begins. [desktop apps only] |
 | **Header** | `bcrypt.h` |

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_mlkem_key_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_mlkem_key_blob.md
@@ -1,0 +1,129 @@
+---
+UID: NS:bcrypt._BCRYPT_MLKEM_KEY_BLOB
+title: BCRYPT_MLKEM_KEY_BLOB (bcrypt.h)
+description: Structure used for post-quantum ML-KEM algorithm key BLOBs.
+helpviewer_keywords: ["BCRYPT_MLKEM_KEY_BLOB","BCRYPT_MLKEM_KEY_BLOB structure [Security]","bcrypt/BCRYPT_MLKEM_KEY_BLOB","security.bcrypt_mlkem_key_blob"]
+old-location: 
+tech.root: security
+ms.assetid: 
+ms.date: 05/26/2026
+ms.keywords: BCRYPT_MLKEM_KEY_BLOB, BCRYPT_MLKEM_KEY_BLOB structure [Security], bcrypt/BCRYPT_MLKEM_KEY_BLOB, security.bcrypt_mlkem_key_blob
+req.header: bcrypt.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 11 24H2
+req.target-min-winversvr: Windows Server 2025
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: BCRYPT_MLKEM_KEY_BLOB
+req.redist: 
+ms.custom: 24H2
+f1_keywords:
+ - _BCRYPT_MLKEM_KEY_BLOB
+ - bcrypt/_BCRYPT_MLKEM_KEY_BLOB
+ - BCRYPT_MLKEM_KEY_BLOB
+ - bcrypt/BCRYPT_MLKEM_KEY_BLOB
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - Bcrypt.h
+api_name:
+ - BCRYPT_MLKEM_KEY_BLOB
+---
+
+# BCRYPT_MLKEM_KEY_BLOB structure
+
+> [!NOTE]
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+
+The **BCRYPT_MLKEM_KEY_BLOB** structure is used as a header for an ML-KEM [public key](/windows/win32/SecGloss/p-gly) (byte-encoded encapsulation key) or [private key](/windows/win32/SecGloss/p-gly) [BLOB](/windows/win32/SecGloss/b-gly) in memory.
+
+## Syntax
+
+```cpp
+typedef struct _BCRYPT_MLKEM_KEY_BLOB {
+  ULONG dwMagic;
+  ULONG cbParameterSet;             // Byte size of parameterSet[]
+  ULONG cbKey;                      // Byte size of key[]
+  // WCHAR parameterSet[cbParameterSet / sizeof(WCHAR)];  // Including \0-terminated
+  // BYTE key[cbKey];                                     // Key material
+} BCRYPT_MLKEM_KEY_BLOB, *PBCRYPT_MLKEM_KEY_BLOB;
+```
+
+## Fields
+
+### dwMagic
+
+The **dwMagic** field is a 4-byte value that indicates the format of the key being used. The following values are defined:
+
+| Value | Meaning |
+|--|--|
+| **BCRYPT_MLKEM_PUBLIC_MAGIC** `0x504B4C4D` | The structure represents a public key. |
+| **BCRYPT_MLKEM_PRIVATE_MAGIC** `0x524B4C4D` | The structure represents an expanded private key. |
+| **BCRYPT_MLKEM_PRIVATE_SEED_MAGIC** `0x534B4C4D` | The structure represents a private seed. |
+
+### cbParameterSet
+
+The length, in bytes, of the buffer **parameterSet** directly following the struct. This buffer contains a null-terminated Unicode string that identifies the parameter set of the key. The following values (per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf)) are currently supported:
+
+| parameterSet | cbParameterSet | Meaning |
+|--|--|--|
+| **BCRYPT_MLKEM_PARAMETER_SET_512** `L"512"` | 8 | ML-KEM-512, security category 1. |
+| **BCRYPT_MLKEM_PARAMETER_SET_768** `L"768"` | 8 | ML-KEM-768, security category 3. |
+| **BCRYPT_MLKEM_PARAMETER_SET_1024** `L"1024"` | 10 | ML-KEM-1024, security category 5. |
+
+### cbKey
+
+The length, in bytes, of the buffer **key** directly following **parameterSet**. This size is static and depends on the key format and parameter set in use.
+
+## Remarks
+
+**BCRYPT_MLKEM_PRIVATE_SEED_BLOB** supports import and export of ML-KEM seeds. The blob has **dwMagic**  value `BCRYPT_MLKEM_PRIVATE_SEED_MAGIC` and the **key** field contains the KEM seed (defined as the 64-byte concatenation of `d || z` per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf)), so **cbKey** is currently always `64`.
+
+**BCRYPT_MLKEM_PRIVATE_BLOB** (also aliased as **BCRYPT_MLKEM_DECAPSULATION_BLOB**) supports import and export of standard byte-encoded ML-KEM decapsulation keys per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf). The blob has **dwMagic** value `BCRYPT_MLKEM_PRIVATE_MAGIC` and the **key** field contains the byte-encoded key. 
+
+**BCRYPT_MLKEM_PUBLIC_BLOB** (also aliased as **BCRYPT_MLKEM_ENCAPSULATION_BLOB**) supports import and export of standard byte-encoded ML-KEM encapsulation keys per [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf). The blob has **dwMagic** value `BCRYPT_MLKEM_PUBLIC_MAGIC` and the **key** field contains the byte-encoded key.
+
+The byte sizes of the byte-encoded keys can be found in [FIPS 203](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) Section 8 Table 3. Many callers can instead dynamically query the required blob sizes using **BCryptExportKey** with `NULL` *pbOutput*.
+
+## Requirements
+
+| Requirement | Value |
+| ---- | ---- |
+| **Minimum supported client** | **Windows 11  24H2:** Support for ML-KEM begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Server 2025:** Support for ML-KEM begins. [desktop apps only] |
+| **Header** | `bcrypt.h` |
+
+## See also
+
+[BCryptGenerateKeyPair](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair)
+
+[BCryptImportKeyPair](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptimportkeypair)
+
+[BCryptFinalizeKeyPair](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinalizekeypair)
+
+[BCryptExportKey](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptexportkey)
+
+[BCryptGetProperty](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty)
+
+[BCryptSetProperty](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptsetproperty)
+
+[BCryptEncapsulate](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptencapsulate)
+
+[BCryptDecapsulate](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdecapsulate)

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_key_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_key_blob.md
@@ -1,0 +1,111 @@
+---
+UID: NS:bcrypt._BCRYPT_PQDSA_KEY_BLOB
+title: BCRYPT_PQDSA_KEY_BLOB (bcrypt.h)
+description: Structure used for post-quantum digital signature algorithm key BLOBs.
+helpviewer_keywords: ["BCRYPT_PQDSA_KEY_BLOB","BCRYPT_PQDSA_KEY_BLOB structure [Security]","bcrypt/BCRYPT_PQDSA_KEY_BLOB","security.bcrypt_pqdsa_key_blob"]
+old-location: 
+tech.root: security
+ms.assetid: 
+ms.date: 05/26/2026
+ms.keywords: BCRYPT_PQDSA_KEY_BLOB, BCRYPT_PQDSA_KEY_BLOB structure [Security], bcrypt/BCRYPT_PQDSA_KEY_BLOB, security.bcrypt_pqdsa_key_blob
+req.header: bcrypt.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 11 24H2
+req.target-min-winversvr: Windows Server 2025
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: BCRYPT_PQDSA_KEY_BLOB
+req.redist: 
+ms.custom: 24H2
+f1_keywords:
+ - _BCRYPT_PQDSA_KEY_BLOB
+ - bcrypt/_BCRYPT_PQDSA_KEY_BLOB
+ - BCRYPT_PQDSA_KEY_BLOB
+ - bcrypt/BCRYPT_PQDSA_KEY_BLOB
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - Bcrypt.h
+api_name:
+ - BCRYPT_PQDSA_KEY_BLOB
+---
+
+# BCRYPT_PQDSA_KEY_BLOB structure - Win32 apps | Microsoft Learn
+
+Note
+
+Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+
+This structure is used to import and export keys for Post-Quantum Digital Signature algorithms (PQDSA). The **BCRYPT\_PQDSA\_KEY\_BLOB** structure is used as a header for a Post-Quantum Digital Signature algorithm (PQDSA) [public key](/en-us/windows/win32/SecGloss/p-gly) (byte-encoded encapsulation key) or [private key](/en-us/windows/win32/SecGloss/p-gly) [BLOB](/en-us/windows/win32/SecGloss/b-gly) in memory.
+
+## Syntax
+
+```cpp
+typedef struct _BCRYPT_PQDSA_KEY_BLOB {
+  ULONG dwMagic;
+  ULONG cbParameterSet;                                   // Byte size of parameterSet[]
+  ULONG cbKey;                                            // Byte size of key[]
+  // WCHAR parameterSet[cbParameterSet / sizeof(WCHAR)];  // Including \0 terminator
+  // BYTE key[cbKey];                                     // Key material
+} BCRYPT_PQDSA_KEY_BLOB, *PBCRYPT_PQDSA_KEY_BLOB;
+```
+
+## Fields
+
+### dwMagic
+
+The **dwMagic** field is a 4-byte value that indicates the format of the key being used. The following values are defined:
+
+| Value | Meaning |
+| --- | --- |
+| **BCRYPT\_MLDSA\_PUBLIC\_MAGIC**`0x4B505344` | The structure represents a public key. |
+| **BCRYPT\_MLDSA\_PRIVATE\_MAGIC**`0x4B535344` | The structure represents an expanded private key. |
+| **BCRYPT\_MLDSA\_PRIVATE\_SEED\_MAGIC**`0x53535344` | The structure represents a private seed. |
+
+### cbParameterSet
+
+The length, in bytes, of the buffer `parameterSet` directly following the struct. This buffer contains a null-terminated Unicode string that identifies the parameter set of the key. The following values are currently supported:
+
+| parameterSet | cbParameterSet | Meaning |
+| --- | --- | --- |
+| **BCRYPT\_MLDSA\_PARAMETER\_SET\_44**`L"44"` | 6 | ML-DSA-44, security category 2. |
+| **BCRYPT\_MLDSA\_PARAMETER\_SET\_65**`L"65"` | 6 | ML-DSA-65, security category 3. |
+| **BCRYPT\_MLDSA\_PARAMETER\_SET\_87**`L"87"` | 6 | ML-DSA-87, security category 5. |
+
+### cbKey
+
+The length, in bytes, of the buffer **key** directly following **parameterSet**. This size is static and depends on the key format and parameter set in use.
+
+## Remarks
+
+The consumers of Post-Quantum Digital Signature algorithms will use the same subset of the BCrypt API as the existing (non-Post-Quantum) Digital Signature Algorithms supported by CNG in order to perform the operations the algorithms support. These are:
+
+- Algorithm handle manipulation: [BCryptOpenAlgorithmProvider](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider), [BCryptCloseAlgorithmProvider](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider)
+- Key management: [BCryptGenerateKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair), [BCryptImportKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptimportkeypair), [BCryptExportKey](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptexportkey), [BCryptDestroyKey](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroykey), [BCryptFinalizeKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinalizekeypair)
+- Signature generation/verification: [BCryptSignHash](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptsignhash), [BCryptVerifySignature](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptverifysignature)
+- Updating/Querying properties: [BCryptGetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty), [BCryptSetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptsetproperty)
+
+## Requirements
+
+| Requirement | Value |
+| --- | --- |
+| **Minimum supported client** | **Windows 11 24H2:** Support for ML-DSA begins. [desktop apps only] |
+| **Minimum supported server** | **Windows Server 2025:** Support for ML-DSA begins. [desktop apps only] |
+| **Header** | `bcrypt.h` |

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_key_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_key_blob.md
@@ -47,13 +47,12 @@ api_name:
  - BCRYPT_PQDSA_KEY_BLOB
 ---
 
-# BCRYPT_PQDSA_KEY_BLOB structure - Win32 apps | Microsoft Learn
+# BCRYPT_PQDSA_KEY_BLOB structure
 
-Note
+> [!Note]
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The composite features described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
 
-Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
-
-This structure is used to import and export keys for Post-Quantum Digital Signature algorithms (PQDSA). The **BCRYPT\_PQDSA\_KEY\_BLOB** structure is used as a header for a Post-Quantum Digital Signature algorithm (PQDSA) [public key](/en-us/windows/win32/SecGloss/p-gly) (byte-encoded encapsulation key) or [private key](/en-us/windows/win32/SecGloss/p-gly) [BLOB](/en-us/windows/win32/SecGloss/b-gly) in memory.
+This structure is used to import and export keys for Post-Quantum Digital Signature algorithms (PQDSA). The **BCRYPT_PQDSA_KEY_BLOB** structure is used as a header for a Post-Quantum Digital Signature algorithm (PQDSA) [public key](/en-us/windows/win32/SecGloss/p-gly) (byte-encoded encapsulation key) or [private key](/en-us/windows/win32/SecGloss/p-gly) [BLOB](/en-us/windows/win32/SecGloss/b-gly) in memory.
 
 ## Syntax
 
@@ -75,19 +74,25 @@ The **dwMagic** field is a 4-byte value that indicates the format of the key bei
 
 | Value | Meaning |
 | --- | --- |
-| **BCRYPT\_MLDSA\_PUBLIC\_MAGIC**`0x4B505344` | The structure represents a public key. |
-| **BCRYPT\_MLDSA\_PRIVATE\_MAGIC**`0x4B535344` | The structure represents an expanded private key. |
-| **BCRYPT\_MLDSA\_PRIVATE\_SEED\_MAGIC**`0x53535344` | The structure represents a private seed. |
+| **BCRYPT_MLDSA_PUBLIC_MAGIC**`0x4B505344` | The structure represents a public key. |
+| **BCRYPT_MLDSA_PRIVATE_MAGIC**`0x4B535344` | The structure represents an expanded private key. |
+| **BCRYPT_MLDSA_PRIVATE_SEED_MAGIC**`0x53535344` | The structure represents a private seed. |
+| **BCRYPT_COMPOSITE_MLDSA_PUBLIC_MAGIC** `0x4B504D43` | The structure represents a public key. |
+| **BCRYPT_COMPOSITE_MLDSA_PRIVATE_MAGIC** `0x4B534D43` | The structure represents a private key. |
 
 ### cbParameterSet
 
 The length, in bytes, of the buffer `parameterSet` directly following the struct. This buffer contains a null-terminated Unicode string that identifies the parameter set of the key. The following values are currently supported:
 
-| parameterSet | cbParameterSet | Meaning |
-| --- | --- | --- |
-| **BCRYPT\_MLDSA\_PARAMETER\_SET\_44**`L"44"` | 6 | ML-DSA-44, security category 2. |
-| **BCRYPT\_MLDSA\_PARAMETER\_SET\_65**`L"65"` | 6 | ML-DSA-65, security category 3. |
-| **BCRYPT\_MLDSA\_PARAMETER\_SET\_87**`L"87"` | 6 | ML-DSA-87, security category 5. |
+| parameterSet | Meaning |
+| --- | --- |
+| **BCRYPT_MLDSA_PARAMETER_SET_44**`L"44"` | ML-DSA-44, security category 2. |
+| **BCRYPT_MLDSA_PARAMETER_SET_65**`L"65"` | ML-DSA-65, security category 3. |
+| **BCRYPT_MLDSA_PARAMETER_SET_87**`L"87"` | ML-DSA-87, security category 5. |
+| **BCRYPT_COMPOSITE_MLDSA_PARAMETER_SET_44_ECDSA_P256_SHA256** `L"44-ECDSA-P256-SHA256"` | Composite ML-DSA-44 and ECDSA P256 |
+| **BCRYPT_COMPOSITE_MLDSA_PARAMETER_SET_65_ECDSA_P256_SHA512** `L"65-ECDSA-P256-SHA512"` | Composite ML-DSA-65 and ECDSA P256 |
+| **BCRYPT_COMPOSITE_MLDSA_PARAMETER_SET_65_ECDSA_P384_SHA512** `L"65-ECDSA-P384-SHA512"` | Composite ML-DSA-65 and ECDSA P384 |
+| **BCRYPT_COMPOSITE_MLDSA_PARAMETER_SET_87_ECDSA_P384_SHA512** `L"87-ECDSA-P384-SHA512"` | Composite ML-DSA-87 and ECDSA P384 |
 
 ### cbKey
 
@@ -97,7 +102,7 @@ The length, in bytes, of the buffer **key** directly following **parameterSet**.
 
 The consumers of Post-Quantum Digital Signature algorithms will use the same subset of the BCrypt API as the existing (non-Post-Quantum) Digital Signature Algorithms supported by CNG in order to perform the operations the algorithms support. These are:
 
-- Algorithm handle manipulation: [BCryptOpenAlgorithmProvider](/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider), [BCryptCloseAlgorithmProvider](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider)
+- Algorithm handle manipulation: [BCryptOpenAlgorithmProvider](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider), [BCryptCloseAlgorithmProvider](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider)
 - Key management: [BCryptGenerateKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgeneratekeypair), [BCryptImportKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptimportkeypair), [BCryptExportKey](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptexportkey), [BCryptDestroyKey](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroykey), [BCryptFinalizeKeyPair](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinalizekeypair)
 - Signature generation/verification: [BCryptSignHash](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptsignhash), [BCryptVerifySignature](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptverifysignature)
 - Updating/Querying properties: [BCryptGetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty), [BCryptSetProperty](/en-us/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptsetproperty)

--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_padding_info.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_pqdsa_padding_info.md
@@ -1,0 +1,89 @@
+---
+UID: NS:bcrypt._BCRYPT_PQDSA_PADDING_INFO
+title: BCRYPT_PQDSA_PADDING_INFO (bcrypt.h)
+description: Used to specify the padding scheme for post-quantum digital signature algorithms.
+helpviewer_keywords: ["BCRYPT_PQDSA_PADDING_INFO","BCRYPT_PQDSA_PADDING_INFO structure [Security]","bcrypt/BCRYPT_PQDSA_PADDING_INFO","security.bcrypt_pqdsa_padding_info"]
+old-location: 
+tech.root: security
+ms.assetid: 
+ms.date: 05/26/2026
+ms.keywords: BCRYPT_PQDSA_PADDING_INFO, BCRYPT_PQDSA_PADDING_INFO structure [Security], bcrypt/BCRYPT_PQDSA_PADDING_INFO, security.bcrypt_pqdsa_padding_info
+req.header: bcrypt.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: Windows 11 24H2
+req.target-min-winversvr: Windows Server 2025
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: BCRYPT_PQDSA_PADDING_INFO
+req.redist: 
+ms.custom: 24H2
+f1_keywords:
+ - _BCRYPT_PQDSA_PADDING_INFO
+ - bcrypt/_BCRYPT_PQDSA_PADDING_INFO
+ - BCRYPT_PQDSA_PADDING_INFO
+ - bcrypt/BCRYPT_PQDSA_PADDING_INFO
+dev_langs:
+ - c++
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - Bcrypt.h
+api_name:
+ - BCRYPT_PQDSA_PADDING_INFO
+---
+
+# BCRYPT_PQDSA_PADDING_INFO structure
+
+> [!NOTE]
+> Some information relates to a prerelease product which may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here. The feature described in this topic is available in pre-release versions of the [Windows Insider Preview](https://www.microsoft.com/software-download/windowsinsiderpreviewSDK).
+
+## -description
+
+The **BCRYPT_PQDSA_PADDING_INFO** structure is used to specify the padding scheme for Post-Quantum Digital Signature algorithms (PQDSA).
+
+## -struct-fields
+
+### -field pbCtx
+
+A pointer to the buffer that contains the context string.
+
+May be `NULL`. If **pbCtx** is `NULL`, then **cbCtx** must be set to `0`.
+
+### -field cbCtx
+
+The size, in bytes, of the context string pointed to by **pbCtx**. Its value must be `0` if **pbCtx** is `NULL`. Otherwise, it must be a non-zero integer less than `256`.
+
+### -field pszPrehashAlgId
+
+A CNG hash [algorithm identifier](/windows/win32/SecCNG/cng-algorithm-identifiers). This parameter indicates whether the pure (e.g. ML-DSA) or the pre-hash (e.g. HashML-DSA) variant will be used. A `NULL` value indicates the use of pure variant. To use a pre-hash variant, this identifier must refer to an approved hash algorithm: SHA-2, SHA-3, or SHAKE.
+
+## Remarks
+
+For many PQDSA signatures, the use of **BCRYPT_PQDSA_PADDING_INFO** is not required. Using `NULL` *pPaddingInfo* in calls to [BCryptSignHash](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptsignhash) and [BCryptVerifySignature](/windows/win32/api/Bcrypt/nf-bcrypt-bcryptverifysignature) is equivalent to using pure variant with an empty context string.
+
+## -see-also
+
+[CNG Algorithm Identifiers](/windows/win32/seccng/cng-algorithm-identifiers)
+
+[BCryptDecrypt](nf-bcrypt-bcryptdecrypt.md)
+
+[BCryptEncrypt](nf-bcrypt-bcryptencrypt.md)
+
+[BCryptSignHash](nf-bcrypt-bcryptsignhash.md)
+
+[BCryptVerifySignature](nf-bcrypt-bcryptverifysignature.md)


### PR DESCRIPTION
Brought over doc updates from Win32 that were updated last year and missed from the SDK docs.