### PR TITLE
Updates to WinCrypt docs for composite PQC algorithms

### DIFF
--- a/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
@@ -1876,7 +1876,7 @@ Composite algorithm combining Module-Lattice-Based Digital Signature Algorithm (
 </td>
 </tr>
 <tr>
-<td width="40%"><a id="_szoid_mldsa65_ecdsa_p256_sha512"></a><a id="_szoid_mldsa54_ecdsa_p256_sha512"></a><a id="_szOID_MLDSA65_ECDSA_P256_SHA512"></a><dl>
+<td width="40%"><a id="_szoid_mldsa65_ecdsa_p256_sha512"></a><a id="_szoid_mldsa65_ecdsa_p256_sha512"></a><a id="_szOID_MLDSA65_ECDSA_P256_SHA512"></a><dl>
 <dt><b> szOID_MLDSA65_ECDSA_P256_SHA512</b></dt>
 <dt>  "1.3.6.1.5.5.7.6.45"
 

--- a/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
@@ -1852,6 +1852,58 @@ Secure hashing algorithm KECCAK (SHAKE) that uses a 256 bit key.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="_szoid_mldsa44_ecdsa_p256_sha256"></a><a id="_szoid_mldsa44_ecdsa_p256_sha256"></a><a id="_szOID_MLDSA44_ECDSA_P256_SHA256"></a><dl>
+<dt><b> szOID_MLDSA44_ECDSA_P256_SHA256</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.40"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Digital Signature Algorithm (ML-DSA) parameter set 44 and Elliptic Curve Digital Signature Algorithm (ECDSA) p256 with SHA-256 Hash Algorithm.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szoid_mldsa65_ecdsa_p256_sha512"></a><a id="_szoid_mldsa54_ecdsa_p256_sha512"></a><a id="_szOID_MLDSA65_ECDSA_P256_SHA512"></a><dl>
+<dt><b> szOID_MLDSA65_ECDSA_P256_SHA512</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.45"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Digital Signature Algorithm (ML-DSA) parameter set 65 and Elliptic Curve Digital Signature Algorithm (ECDSA) p256 with SHA-512 Hash Algorithm.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szoid_mldsa65_ecdsa_p384_sha512"></a><a id="_szoid_mldsa65_ecdsa_p384_sha512"></a><a id="_szOID_MLDSA65_ECDSA_P384_SHA512"></a><dl>
+<dt><b> szOID_MLDSA65_ECDSA_P384_SHA512</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.46"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Digital Signature Algorithm (ML-DSA) parameter set 65 and Elliptic Curve Digital Signature Algorithm (ECDSA) p384 with SHA-512 Hash Algorithm.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szoid_mldsa87_ecdsa_p384_sha512"></a><a id="_szoid_mldsa87_ecdsa_p384_sha512"></a><a id="_szOID_MLDSA87_ECDSA_P384_SHA512"></a><dl>
+<dt><b> szOID_MLDSA87_ECDSA_P384_SHA512</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.49"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Digital Signature Algorithm (ML-DSA) parameter set 87 and Elliptic Curve Digital Signature Algorithm (ECDSA) p384 with SHA-512 Hash Algorithm.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="szOID_PKIX_NO_SIGNATURE"></a><a id="szoid_pkix_no_signature"></a><a id="SZOID_PKIX_NO_SIGNATURE"></a><dl>
 <dt><b>szOID_PKIX_NO_SIGNATURE</b></dt>
 <dt>"1.3.6.1.5.5.7.6.2"</dt>
@@ -1859,6 +1911,84 @@ Secure hashing algorithm KECCAK (SHAKE) that uses a 256 bit key.
 </td>
 <td width="60%">
 No signature.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_NIST_ml_kem_512"></a><a id="_szoid_nist_ml_kem_512"></a><a id="_SZOID_NIST_ML_KEM_512"></a><dl>
+<dt><b> szOID_NIST_ml_kem_512</b></dt>
+<dt>  "2.16.840.1.101.3.4.4.1"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) that uses NIST parameter set 512.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_NIST_ml_kem_768"></a><a id="_szoid_nist_ml_kem_768"></a><a id="_SZOID_NIST_ML_KEM_768"></a><dl>
+<dt><b> szOID_NIST_ml_kem_768</b></dt>
+<dt>  "2.16.840.1.101.3.4.4.2"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) that uses NIST parameter set 768.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_NIST_ml_kem_1024"></a><a id="_szoid_nist_ml_kem_1024"></a><a id="_SZOID_NIST_ML_KEM_1024"></a><dl>
+<dt><b> szOID_NIST_ml_kem_1024</b></dt>
+<dt>  "2.16.840.1.101.3.4.4.3"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) that uses NIST parameter set 1024.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_mlkem768_x25519_sha3_256"></a><a id="_szoid_mlkem768_x25519_sha3_256"></a><a id="_SZOID_MLKEM768_X25519_SHA3_256"></a><dl>
+<dt><b> szOID_MLKEM768_X25519_SHA3_256</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.58"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) 768 and Curve 25519 with SHA3 256-bit hash algorithm.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_mlkem768_ecdh_p256_sha3_256"></a><a id="_szoid_mlkem768_ecdh_p256_sha3_256"></a><a id="_SZOID_MLKEM768_ECDH_P256_SHA3_256"></a><dl>
+<dt><b> szOID_MLKEM768_ECDH_P256_SHA3_256</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.59"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) 768 and Elliptic Curve Diffie-Hellman P256 with SHA3 256-bit hash algorithm.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="_szOID_mlkem1024_ecdh_p384_sha3_256"></a><a id="_szoid_mlkem1024_ecdh_p384_sha3_256"></a><a id="_SZOID_MLKEM1024_ECDH_P384_SHA3_256"></a><dl>
+<dt><b> szOID_MLKEM1024_ECDH_P384_SHA3_256</b></dt>
+<dt>  "1.3.6.1.5.5.7.6.63"
+
+</dt>
+</dl>
+</td>
+<td width="60%">
+Composite algorithm combining Module-Lattice-Based Key Encapsulation Mechanism (ML-KEM) 1024 and Elliptic Curve Diffie-Hellman P384 with SHA3 256-bit hash algorithm.
 
 </td>
 </tr>

--- a/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_algorithm_identifier.md
@@ -904,6 +904,17 @@ An OID that indicates that no hash algorithm is used.
 </td>
 </tr>
 <tr>
+<td width="40%"><a id="szOID_PREHASH"></a><a id="szoid_prehash"></a><a id="SZOID_PREHASH"></a><dl>
+<dt><b>szOID_PREHASH</b></dt>
+<dt>"1.3.6.1.4.1.311.73.2"</dt>
+</dl>
+</td>
+<td width="60%">
+An OID that indicates that the bytes to be signed have been pre-hashed.
+
+</td>
+</tr>
+<tr>
 <td width="40%"><a id="szOID_NIST_AES128_CBC"></a><a id="szoid_nist_aes128_cbc"></a><a id="SZOID_NIST_AES128_CBC"></a><dl>
 <dt><b>szOID_NIST_AES128_CBC</b></dt>
 <dt>"2.16.840.1.101.3.4.1.2"</dt>

--- a/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_oid_info.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_oid_info.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["*PCRYPT_OID_INFO","CCRYPT_OID_INFO","CCRYPT_OID_INFO stru
 old-location: security\crypt_oid_info.htm
 tech.root: security
 ms.assetid: 06ba0f60-778d-450b-8f71-23471b8c4e2c
-ms.date: 05/14/2025
+ms.date: 05/26/2026
 ms.keywords: '*PCRYPT_OID_INFO, CCRYPT_OID_INFO, CCRYPT_OID_INFO structure [Security], CRYPT_ENCRYPT_ALG_OID_GROUP_ID, CRYPT_ENHKEY_USAGE_OID_GROUP_ID, CRYPT_EXT_OR_ATTR_OID_GROUP_ID, CRYPT_HASH_ALG_OID_GROUP_ID, CRYPT_OID_INFO, CRYPT_OID_INFO structure [Security], CRYPT_OID_INFO_ECC_PARAMETERS_ALGORITHM, CRYPT_OID_INFO_ECC_WRAP_PARAMETERS_ALGORITHM, CRYPT_OID_INFO_HASH_PARAMETERS_ALGORITHM, CRYPT_OID_INFO_MGF1_PARAMETERS_ALGORITHM, CRYPT_OID_INFO_NO_SIGN_ALGORITHM, CRYPT_OID_INFO_OAEP_PARAMETERS_ALGORITHM, CRYPT_OID_INHIBIT_SIGNATURE_FORMAT_FLAG, CRYPT_OID_NO_NULL_ALGORITHM_PARA_FLAG, CRYPT_OID_PUBKEY_ENCRYPT_ONLY_FLAG, CRYPT_OID_PUBKEY_SIGN_ONLY_FLAG, CRYPT_OID_USE_PUBKEY_PARA_FOR_PKCS7_FLAG, CRYPT_POLICY_OID_GROUP_ID, CRYPT_PUBKEY_ALG_OID_GROUP_ID, CRYPT_RDN_ATTR_OID_GROUP_ID, CRYPT_SIGN_ALG_OID_GROUP_ID, PCCRYPT_OID_INFO, PCCRYPT_OID_INFO structure pointer [Security], PCRYPT_OID_INFO, PCRYPT_OID_INFO structure pointer [Security], _crypto2_crypt_oid_info, security.crypt_oid_info, wincrypt/CCRYPT_OID_INFO, wincrypt/CRYPT_OID_INFO, wincrypt/PCCRYPT_OID_INFO, wincrypt/PCRYPT_OID_INFO'
 req.header: wincrypt.h
 req.include-header: 
@@ -273,6 +273,61 @@ Include the parameters of the public key algorithm in the <i>digestEncryptionAlg
 
 </td>
 </tr>
+<tr>
+<td width="40%"><a id="CRYPT_OID_USE_CURVE_NAME_FOR_ENCODE_FLAG"></a><a id="crypt_oid_use_curve_name_for_encode_flag"></a><dl>
+<dt><b>CRYPT_OID_USE_CURVE_NAME_FOR_ENCODE_FLAG</b></dt>
+<dt></dt>
+</dl>
+</td>
+<td width="60%">
+Use the CNG curve name for the encoding.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="CRYPT_OID_USE_CURVE_PARAMETERS_FOR_ENCODE_FLAG"></a><a id="crypt_oid_use_curve_parameters_for_encode_flag"></a><dl>
+<dt><b>CRYPT_OID_USE_CURVE_PARAMETERS_FOR_ENCODE_FLAG</b></dt>
+<dt></dt>
+</dl>
+</td>
+<td width="60%">
+Use the CNG curve parameters for the encoding.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="CRYPT_OID_PUBKEY_PURE_ONLY_FLAG"></a><a id="crypt_oid_pubkey_pure_only_flag"></a><dl>
+<dt><b>CRYPT_OID_PUBKEY_PURE_ONLY_FLAG</b></dt>
+<dt></dt>
+</dl>
+</td>
+<td width="60%">
+A post-quantum key that should only be used for "Pure" signing.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="CRYPT_OID_PUBKEY_PREHASH_ONLY_FLAG"></a><a id="crypt_oid_pubkey_prehash_only_flag"></a><dl>
+<dt><b>CRYPT_OID_PUBKEY_PREHASH_ONLY_FLAG</b></dt>
+<dt></dt>
+</dl>
+</td>
+<td width="60%">
+A post-quantum key that should only be used for "PreHash" signing. Uses a single hash algorithm per PQ parameter set.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="CRYPT_OID_COMPOSITE_ECDSA_FLAG"></a><a id="crypt_oid_composite_ecdsa_flag"></a><dl>
+<dt><b>CRYPT_OID_COMPOSITE_ECDSA_FLAG</b></dt>
+<dt></dt>
+</dl>
+</td>
+<td width="60%">
+A composite signature key that uses both a post-quantum and ECDSA signature algorithm. When set, the Signature Byte Length is the Max Length.
+
+</td>
+</tr>
 </table>
 
 #### Post-quantum use
@@ -327,10 +382,20 @@ The *pwszCNGAlgid* member can also be set to a string value that is not passed d
 | **CRYPT_OID_INFO_MGF1_PARAMETERS_ALGORITHM** | The PKCS #1 v2.1 mask generation hash algorithm is obtained from the encoded parameters of the OID algorithm. |
 | **CRYPT_OID_INFO_NO_SIGN_ALGORITHM** | A public key algorithm that indicates the signature value is an unsigned hash. |
 | **CRYPT_OID_INFO_OAEP_PARAMETERS_ALGORITHM** | The RSAES-OAEP padding hash algorithm is obtained from the encoded parameters of the OID algorithm. |
-| **CRYPT32_MLDSA_44_ALGORITHM**<br/>`L"ML-DSA:44"` | The ML-DSA algorithm combines the CNG algorithm name for ML-DSA and the CNG parameter set 44 (NIST security category 2). |
-| **CRYPT32_MLDSA_65_ALGORITHM**<br/>`L"ML-DSA:65"` | The ML-DSA algorithm combines the CNG algorithm name for ML-DSA and the CNG parameter set 65(NIST security category 3). |
-| **CRYPT32_MLDSA_87_ALGORITHM**<br/>`L"ML-DSA:87"` | The ML-DSA algorithm combines the CNG algorithm name for ML-DSA and the CNG parameter set 87 (NIST security category 5). |
+| **CRYPT32_MLDSA_44_ALGORITHM**<br/>`L"ML-DSA:44"` | The ML-DSA algorithm with parameter set 44 (NIST security category 2). |
+| **CRYPT32_MLDSA_65_ALGORITHM**<br/>`L"ML-DSA:65"` | The ML-DSA algorithm  with parameter set 65 (NIST security category 3). |
+| **CRYPT32_MLDSA_87_ALGORITHM**<br/>`L"ML-DSA:87"` | The ML-DSA algorithm with parameter set 87 (NIST security category 5). |
 | **CRYPT_OID_INFO_NO_HASH_ALGORITHM**<br/>`L"NoHash"` | For PQ digital signatures, indicates there is no hash before signing, and the PQ key will directly sign the ToBeSigned bytes. |
+| **CRYPT32_COMPOSITE_MLDSA_44_ECDSA_P256_SHA256_ALGORITHM**<br/>`L"Composite-ML-DSA:44-ECDSA-P256-SHA256"` | This composite algorithm combines CNG ML-DSA 44 and ECDSA P-256 into one key. |
+| **CRYPT32_COMPOSITE_MLDSA_65_ECDSA_P256_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:65-ECDSA-P256-SHA512""` | This composite algorithm combines CNG ML-DSA 65 and ECDSA P-256 into one key. |
+| **CRYPT32_COMPOSITE_MLDSA_65_ECDSA_P384_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:65-ECDSA-P384-SHA512"` | This composite algorithm combines CNG ML-DSA 65 and ECDSA P-384 into one key. |
+| **CRYPT32_COMPOSITE_MLDSA_87_ECDSA_P384_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:87-ECDSA-P384-SHA512"` | This composite algorithm combines CNG ML-DSA 87 and ECDSA P-384 into one key. |
+| **CRYPT32_MLKEM_512_ALGORITHM**<br/>`L"ML-KEM:512"` | The ML-KEM algorithm with parameter set 512 (NIST security category 2). |
+| **CRYPT32_MLKEM_768_ALGORITHM**<br/>`L"ML-KEM:768"` | The ML-KEM algorithm with parameter set 768 (NIST security category 3). |
+| **CRYPT32_MLKEM_1024_ALGORITHM**<br/>`L"ML-KEM:1024"` | The ML-KEM algorithm with parameter set 1024 (NIST security category 5). |
+| **CRYPT32_COMPOSITE_MLKEM_768_P256_ALGORITHM**<br/>`L"Composite-ML-KEM:768-P256"` | This composite algorithm combines ML-KEM 512 and ECDH P256 into one key. |
+| **CRYPT32_COMPOSITE_MLKEM_768_X25519_ALGORITHM**<br/>`L"Composite-ML-KEM:768-X25519"` | This composite algorithm combines ML-KEM 768 and curve25519 into one key. |
+| **CRYPT32_COMPOSITE_MLKEM_1024_P384_ALGORITHM**<br/>`L"Composite-ML-KEM:1024-P384"` | This composite algorithm combines ML-KEM 1024 and ECDH P384 into one key. |
 
 ### -field pwszCNGExtraAlgid
 

--- a/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_oid_info.md
+++ b/sdk-api-src/content/wincrypt/ns-wincrypt-crypt_oid_info.md
@@ -383,17 +383,17 @@ The *pwszCNGAlgid* member can also be set to a string value that is not passed d
 | **CRYPT_OID_INFO_NO_SIGN_ALGORITHM** | A public key algorithm that indicates the signature value is an unsigned hash. |
 | **CRYPT_OID_INFO_OAEP_PARAMETERS_ALGORITHM** | The RSAES-OAEP padding hash algorithm is obtained from the encoded parameters of the OID algorithm. |
 | **CRYPT32_MLDSA_44_ALGORITHM**<br/>`L"ML-DSA:44"` | The ML-DSA algorithm with parameter set 44 (NIST security category 2). |
-| **CRYPT32_MLDSA_65_ALGORITHM**<br/>`L"ML-DSA:65"` | The ML-DSA algorithm  with parameter set 65 (NIST security category 3). |
+| **CRYPT32_MLDSA_65_ALGORITHM**<br/>`L"ML-DSA:65"` | The ML-DSA algorithm with parameter set 65 (NIST security category 3). |
 | **CRYPT32_MLDSA_87_ALGORITHM**<br/>`L"ML-DSA:87"` | The ML-DSA algorithm with parameter set 87 (NIST security category 5). |
 | **CRYPT_OID_INFO_NO_HASH_ALGORITHM**<br/>`L"NoHash"` | For PQ digital signatures, indicates there is no hash before signing, and the PQ key will directly sign the ToBeSigned bytes. |
 | **CRYPT32_COMPOSITE_MLDSA_44_ECDSA_P256_SHA256_ALGORITHM**<br/>`L"Composite-ML-DSA:44-ECDSA-P256-SHA256"` | This composite algorithm combines CNG ML-DSA 44 and ECDSA P-256 into one key. |
-| **CRYPT32_COMPOSITE_MLDSA_65_ECDSA_P256_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:65-ECDSA-P256-SHA512""` | This composite algorithm combines CNG ML-DSA 65 and ECDSA P-256 into one key. |
+| **CRYPT32_COMPOSITE_MLDSA_65_ECDSA_P256_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:65-ECDSA-P256-SHA512"` | This composite algorithm combines CNG ML-DSA 65 and ECDSA P-256 into one key. |
 | **CRYPT32_COMPOSITE_MLDSA_65_ECDSA_P384_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:65-ECDSA-P384-SHA512"` | This composite algorithm combines CNG ML-DSA 65 and ECDSA P-384 into one key. |
 | **CRYPT32_COMPOSITE_MLDSA_87_ECDSA_P384_SHA512_ALGORITHM**<br/>`L"Composite-ML-DSA:87-ECDSA-P384-SHA512"` | This composite algorithm combines CNG ML-DSA 87 and ECDSA P-384 into one key. |
 | **CRYPT32_MLKEM_512_ALGORITHM**<br/>`L"ML-KEM:512"` | The ML-KEM algorithm with parameter set 512 (NIST security category 2). |
 | **CRYPT32_MLKEM_768_ALGORITHM**<br/>`L"ML-KEM:768"` | The ML-KEM algorithm with parameter set 768 (NIST security category 3). |
 | **CRYPT32_MLKEM_1024_ALGORITHM**<br/>`L"ML-KEM:1024"` | The ML-KEM algorithm with parameter set 1024 (NIST security category 5). |
-| **CRYPT32_COMPOSITE_MLKEM_768_P256_ALGORITHM**<br/>`L"Composite-ML-KEM:768-P256"` | This composite algorithm combines ML-KEM 512 and ECDH P256 into one key. |
+| **CRYPT32_COMPOSITE_MLKEM_768_P256_ALGORITHM**<br/>`L"Composite-ML-KEM:768-P256"` | This composite algorithm combines ML-KEM 768 and ECDH P256 into one key. |
 | **CRYPT32_COMPOSITE_MLKEM_768_X25519_ALGORITHM**<br/>`L"Composite-ML-KEM:768-X25519"` | This composite algorithm combines ML-KEM 768 and curve25519 into one key. |
 | **CRYPT32_COMPOSITE_MLKEM_1024_P384_ALGORITHM**<br/>`L"Composite-ML-KEM:1024-P384"` | This composite algorithm combines ML-KEM 1024 and ECDH P384 into one key. |
 


### PR DESCRIPTION
Composite algorithms being released for Build to Windows 11 client and later to Windows server. Updating algorithm identifiers and OID info including psuedo handles.