### PR TITLE
winldap: Fix ldap_get_dn function prototype

### DIFF
--- a/sdk-api-src/content/winldap/nf-winldap-ldap_get_dn.md
+++ b/sdk-api-src/content/winldap/nf-winldap-ldap_get_dn.md
@@ -50,6 +50,15 @@ api_name:
 # ldap_get_dn function
 
 
+## -syntax
+
+```cpp
+WINLDAPAPI PTCHAR LDAPAPI ldap_get_dn(
+  [in] LDAP        *ld,
+  [in] LDAPMessage *entry
+);
+```
+
 ## -description
 
 The <b>ldap_get_dn</b> function retrieves the distinguished name for a given entry.

--- a/sdk-api-src/content/winldap/nf-winldap-ldap_get_dn.md
+++ b/sdk-api-src/content/winldap/nf-winldap-ldap_get_dn.md
@@ -53,10 +53,23 @@ api_name:
 ## -syntax
 
 ```cpp
-WINLDAPAPI PTCHAR LDAPAPI ldap_get_dn(
+WINLDAPAPI PWCHAR LDAPAPI ldap_get_dnW(
   [in] LDAP        *ld,
   [in] LDAPMessage *entry
 );
+
+#if LDAP_UNICODE
+
+#define ldap_get_dn ldap_get_dnW
+
+#else
+
+WINLDAPAPI PCHAR LDAPAPI ldap_get_dn(
+  [in] LDAP        *ld,
+  [in] LDAPMessage *entry
+);
+
+#endif
 ```
 
 ## -description
@@ -86,6 +99,9 @@ The <b>ldap_get_dn</b> function retrieves the distinguished name for an entry th
 <a href="/previous-versions/windows/desktop/api/winldap/nf-winldap-ldap_first_entry">ldap_first_entry</a>, or 
 <a href="/previous-versions/windows/desktop/api/winldap/nf-winldap-ldap_next_entry">ldap_next_entry</a>. When the returned name is no longer needed, free the string by calling 
 <a href="/previous-versions/windows/desktop/api/winldap/nf-winldap-ldap_memfree">ldap_memfree</a>.
+
+The SDK sets <b>LDAP_UNICODE</b> to 1 or 0 depending on whether <b>UNICODE</b>
+is defined. You may override that behavior by setting it yourself.
 
 ## -see-also
 


### PR DESCRIPTION
- Override the syntax manually to declare ldap_get_dn returns PTCHAR.

Prior to this change the auto-generated syntax erroneously said that ldap_get_dn returned PCHAR instead of PTCHAR.

The bad syntax probably has to do with the way the unusual way ldap functions are declared in winldap.h. ldap_get_dn is either a macro that maps to ldap_get_dnW (LDAP_UNICODE defined, returns PWCHAR) or given its own protoype the same as ldap_get_dnA (no LDAP_UNICODE, returns PCHAR).

Closes #xxxx

---

AFAICT, LDAP_UNICODE is only used internally and set depending on UNICODE. They are different symbols so LDAP_UNICODE can be different from UNICODE. This presents a dilemma because LDAP_UNICODE does not have specific dependent types like TCHAR. It may be more correct (but also confusing) to add in remarks that if LDAP_UNICODE is defined to 0 then the return type is PCHAR. 

### **Many ldap functions have incorrect prototype documentation but I only changed one. There is no way to open an issue so I opened a PR with this one change to notify. I suggest MS rather tackle this issue wholesale.** 