### PR TITLE
Docs: Rename CONTEXT structure files to fix URL encoding routing issues

### DIFF
--- a/sdk-api-src/content/winnt/ns-winnt-arm64_nt_context.md
+++ b/sdk-api-src/content/winnt/ns-winnt-arm64_nt_context.md
@@ -59,8 +59,8 @@ Contains processor-specific register data. The system uses <b>CONTEXT</b> struct
 | Architecture | API reference page |
 |--------------|--------------------|
 | x86 64-bit | [CONTEXT structure (x86 64-bit)](ns-winnt-context.md) |
-| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context~r2.md) |
-| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context~r1.md) |
+| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context-r2.md) |
+| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context-r1.md) |
 
 
 ## -struct-fields

--- a/sdk-api-src/content/winnt/ns-winnt-context-r1.md
+++ b/sdk-api-src/content/winnt/ns-winnt-context-r1.md
@@ -55,7 +55,7 @@ Contains processor-specific register data. The system uses <b>CONTEXT</b> struct
 | Architecture | API reference page |
 |--------------|--------------------|
 | x86 64-bit | [CONTEXT structure (x86 64-bit)](ns-winnt-context.md) |
-| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context~r2.md) |
+| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context-r2.md) |
 | Arm64 | [ARM64_NT_CONTEXT structure](ns-winnt-arm64_nt_context.md) |
 
 

--- a/sdk-api-src/content/winnt/ns-winnt-context-r2.md
+++ b/sdk-api-src/content/winnt/ns-winnt-context-r2.md
@@ -52,7 +52,7 @@ Contains processor-specific register data. The system uses <b>CONTEXT</b> struct
 | Architecture | API reference page |
 |--------------|--------------------|
 | x86 64-bit | [CONTEXT structure (x86 64-bit)](ns-winnt-context.md) |
-| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context~r1.md) |
+| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context-r1.md) |
 | Arm64 | [ARM64_NT_CONTEXT structure](ns-winnt-arm64_nt_context.md) |
 
 

--- a/sdk-api-src/content/winnt/ns-winnt-context.md
+++ b/sdk-api-src/content/winnt/ns-winnt-context.md
@@ -59,8 +59,8 @@ Contains processor-specific register data. The system uses <b>CONTEXT</b> struct
 
 | Architecture | API reference page |
 |--------------|--------------------|
-| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context~r2.md) |
-| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context~r1.md) |
+| x86 32-bit | [CONTEXT structure (x86 32-bit)](ns-winnt-context-r2.md) |
+| Arm32 | [CONTEXT structure (Arm32)](ns-winnt-context-r1.md) |
 | Arm64 | [ARM64_NT_CONTEXT structure](ns-winnt-arm64_nt_context.md) |
 
 


### PR DESCRIPTION
The architecture table used relative links with tildes (like ns-winnt-context~r2.md). While these resolve in GitHub, the live Microsoft Learn build system seems to convert tildes in file names to hyphens, but doesn't update the relative markdown links, resulting in links that lead to 404 pages on the live site.

Renamed the files to use hyphens (-r1, -r2) and updated the cross-references in the x86 and ARM context documentation.