### PR TITLE
winldap: Clarify SDK differences in VERIFYSERVERCERT prototype

### DIFF
--- a/sdk-api-src/content/winldap/nc-winldap-verifyservercert.md
+++ b/sdk-api-src/content/winldap/nc-winldap-verifyservercert.md
@@ -83,9 +83,12 @@ conn, LDAP_OPT_SERVER_CERTIFICATE, &CertRoutine
 
 The server calls <b>VERIFYSERVERCERT</b> after the secure connection has been established. The server's certificate context is supplied for examination by the client.
 
+
+Even though in some old SDKs <b>VERIFYSERVERCERT</b> is declared as receiving a <a href="/windows/desktop/api/wincrypt/ns-wincrypt-cert_context">PCCERT_CONTEXT</a>, it in fact receives a <b>PCCERT_CONTEXT</b>*.
+
 An application should use the <i>ppServerCert</i> parameter as: <code>PCCERT_CONTEXT* ppServerCert = (PCCERT_CONTEXT*)pServerCert;</code>
 
-Even though <b>VERIFYSERVERCERT</b> is declared as receiving a <a href="/windows/desktop/api/wincrypt/ns-wincrypt-cert_context">PCCERT_CONTEXT</a>, it in fact receives a <b>PCCERT_CONTEXT</b>*. The <i>ppServerCert</i> can be used to verify the certificate. <a href="/windows/desktop/api/wincrypt/nf-wincrypt-certfreecertificatecontext">CertFreeCertificateContext</a> should be called before this function returns. The call to this function should be made as follows:
+The <i>ppServerCert</i> can be used to verify the certificate. <a href="/windows/desktop/api/wincrypt/nf-wincrypt-certfreecertificatecontext">CertFreeCertificateContext</a> should be called before this function returns. The call to this function should be made as follows:
 
 
 ```cpp


### PR DESCRIPTION
- Clarify that the incorrect VERIFYSERVERCERT function prototype is limited to some older SDKs.

Prior to this change the doc implied that the bad prototype was always declared, but any recent SDK (including what is used to generate the function prototype for the doc) does not have this issue.

Ref: https://github.com/curl/curl/pull/22152#discussion_r3466825612

Closes #xxxx
