### PR TITLE
Fix FwpmConnectionPolicyAdd0 docs: add routing prerequisite and byte-order clarification

### DIFF
--- a/sdk-api-src/content/fwpmtypes/ns-fwpmtypes-fwpm_network_connection_policy_setting0.md
+++ b/sdk-api-src/content/fwpmtypes/ns-fwpmtypes-fwpm_network_connection_policy_setting0.md
@@ -56,11 +56,11 @@ A type of connection policy setting. See [FWP_NETWORK_CONNECTION_POLICY_SETTING_
 
 The value of a connection policy setting.
 
-**FWP_NETWORK_CONNECTION_POLICY_SOURCE_ADDRESS**. The source address to use for the connection. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.
+**FWP_NETWORK_CONNECTION_POLICY_SOURCE_ADDRESS**. The source address to use for the connection, in network-byte order. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.
  
 **FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP_INTERFACE**. The LUID of the outgoing interface to use for the connection. The value should be a **FWP_UINT64**.
  
-**FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP**. The nexthop address (or gateway) to use for the connection. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.          
+**FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP**. The nexthop address (or gateway) to use for the connection, in network-byte order. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.          
 
 ## -remarks
 

--- a/sdk-api-src/content/fwpmu/nf-fwpmu-fwpmconnectionpolicyadd0.md
+++ b/sdk-api-src/content/fwpmu/nf-fwpmu-fwpmconnectionpolicyadd0.md
@@ -46,6 +46,9 @@ helpviewer_keywords:
 
 The TCP/IP stack supports destination address-based routing for outbound connections. **FwpmConnectionPolicyAdd0API** allows you to configure more expressive routing policies for outbound connections, and thereby to enable more complex scenarios such as source address-based routing, process-based routing, port-based routing, and others. A connection policy consists of an array of match conditions, an array of route settings, and an associated weight. You can configure multiple policies, and they are evaluated based on their configured weights for an outbound connection (a higher weight takes precedence). The route setting of the first policy whose conditions (ANDed) matches the outbound connection is applied.
 
+> [!IMPORTANT]
+> In order for connection policies to take effect, you must first enable policy-based routing via `netsh int ipv4 set gl routepolicies=enabled` (or `netsh int ipv6 set gl routepolicies=enabled` for IPv6 traffic).
+
 ## -parameters
 
 ### -param engineHandle
@@ -110,12 +113,15 @@ The security information.
 
 ## -remarks
 
+> [!IMPORTANT]
+> In order for connection policies to take effect, you must first enable policy-based routing via `netsh int ipv4 set gl routepolicies=enabled` (or `netsh int ipv6 set gl routepolicies=enabled` for IPv6 traffic).
+
 These are the supported route settings (see [FWP_NETWORK_CONNECTION_POLICY_SETTING_TYPE](/windows/win32/api/fwptypes/ne-fwptypes-fwp_network_connection_policy_setting_type)):
 
-**FWP_NETWORK_CONNECTION_POLICY_SOURCE_ADDRESS**. The source address to use for the connection. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.
+**FWP_NETWORK_CONNECTION_POLICY_SOURCE_ADDRESS**. The source address to use for the connection, in network-byte order. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.
 
 **FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP_INTERFACE**. The LUID of the outgoing interface to use for the connection. The value should be a **FWP_UINT64**.
  
-**FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP**. The nexthop address (or gateway) to use for the connection. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.          
+**FWP_NETWORK_CONNECTION_POLICY_NEXT_HOP**. The nexthop address (or gateway) to use for the connection, in network-byte order. The value should be a **FWP_UINT32** for an IPv4 address, and a **FWP_BYTE_ARRAY16_TYPE** for an IPv6 address.          
 
 ## -see-also


### PR DESCRIPTION
## Summary

This PR fixes documentation gaps in the FwpmConnectionPolicyAdd0 and FWPM_NETWORK_CONNECTION_POLICY_SETTING0 pages.

### Changes

1. **Added prerequisite note** — Policy-based routing must be enabled via `netsh int ipv4 set gl routepolicies=enabled` (or ipv6 equivalent) before connection policies take effect. This is noted in both the description and remarks sections.

2. **Clarified byte order** — SOURCE_ADDRESS and NEXT_HOP values in the settings struct are in network-byte order. This is an important distinction because the filter *conditions* use host-byte order, but the route *settings* use network-byte order.

### Affected pages
- [FwpmConnectionPolicyAdd0](https://learn.microsoft.com/windows/win32/api/fwpmu/nf-fwpmu-fwpmconnectionpolicyadd0)
- [FWPM_NETWORK_CONNECTION_POLICY_SETTING0](https://learn.microsoft.com/windows/win32/api/fwpmtypes/ns-fwpmtypes-fwpm_network_connection_policy_setting0)

Fixes OS ADO #62726211 / msft-skilling/Content #592785