### PR TITLE
Remove inaccurate "DWORD-aligned" requirement for presbits parameter

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -65,7 +65,7 @@ To specify a desired height or width, use the <a href="/windows/desktop/api/winu
 
 Type: <b>PBYTE</b>
 
-The DWORD-aligned buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
 See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -58,7 +58,7 @@ Creates an icon or cursor from resource bits describing the icon.
 
 Type: <b>PBYTE</b>
 
-The DWORD-aligned buffer pointer containing the icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The buffer pointer containing the icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
 
 See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
 


### PR DESCRIPTION
## Remove inaccurate "DWORD-aligned" requirement for `presbits` parameter

### Summary

This PR corrects the description of the `presbits` parameter in `CreateIconFromResourceEx` (and the related `CreateIconFromResource`) by removing the claim that the buffer pointer must be **DWORD-aligned**.

**Before:**
> The DWORD-aligned buffer pointer containing the icon or cursor resource bits.

**After:**
> The buffer pointer containing the icon or cursor resource bits.

### Background

I originally added the "DWORD-aligned" wording in a previous PR #1536, based on a pattern I observed in the .NET Framework `System.Drawing.Icon` source code, which copies icon bits into an aligned scratch buffer before calling `CreateIconFromResourceEx` (see [`Icon.cs`](https://github.com/dotnet/corefx/blob/4d34be89f3812919306f1003fa6c035c9caf8970/src/System.Drawing.Common/src/System/Drawing/Icon.cs#L760), comment referencing internal bug `DevDivBugs 17509`). At the time I assumed this reflected an actual API contract.

Having since investigated this more closely, I believe that assumption was incorrect. The `IntPtr.Size`-based alignment check in `System.Drawing.Icon` most likely dates back to the era when .NET Framework officially supported **Itanium (IA64)** as a target platform (Windows Server 2003 IA64, .NET Framework 1.1/2.0-era), where unaligned memory access could genuinely fault on certain load instructions. IA64 has not been a supported platform for many years, but the defensive code - and, transitively, the wording I contributed to this doc - outlived the reason it was written.

### Testing performed

To verify whether `CreateIconFromResourceEx` actually enforces alignment on the pointer at runtime, I wrote a small native test harness that:

1. Extracts real `RT_ICON` resource bits from a multi-entry `.ico` file, for both PNG-based and legacy BMP-based icon formats.
2. Copies those bytes into a scratch buffer at every byte offset from 0 to 15 (covering all alignments relative to both 4-byte and 8-byte boundaries).
3. Calls `CreateIconFromResourceEx` (and, for completeness, `CreateIconFromResource`, `LookupIconIdFromDirectory`, and `LookupIconIdFromDirectoryEx`) on each offset and records success/failure and `GetLastError()`.
4. Validates successful handles via `GetIconInfo`.

### Test harness

Full harness (including `.ico`-parsing and the `LookupIconIdFromDirectory[Ex]`/`CreateIconFromResource` variants) [available here](https://gist.github.com/DJm00n/dc443ccde88c6bcc78050a1bfd0a8856).

**Results** (Windows 11, x64, tested against both PNG-based and legacy BMP-based `RT_ICON` data extracted from a real multi-entry `.ico` file):

| Function | Offsets tested | Succeeded | Failed |
|---|---|---|---|
| `CreateIconFromResourceEx` (PNG-based) | 0–15 | 16/16 | 0 |
| `CreateIconFromResourceEx` (BMP-based) | 0–15 | 16/16 | 0 |
| `CreateIconFromResource` (BMP-based) | 0–15 | 16/16 | 0 |
| `LookupIconIdFromDirectory` | 0–15 | 16/16 | 0 |
| `LookupIconIdFromDirectoryEx` | 0–15 | 16/16 | 0 |

Every offset — including fully misaligned addresses (`addr % 4 != 0`, `addr % 8 != 0`) — succeeded, with `GetLastError() == 0` and a valid, `GetIconInfo`-verified `HICON`.

### Scope / caveats

- Testing was performed on **x86/x64** only, where unaligned memory access is transparently handled by hardware. I have not verified behavior on **ARM64**, so I'm not claiming the function *never* cares about alignment on every architecture — only that the current wording overstates a hard requirement that doesn't hold on the most common platforms, and isn't reflected in any documented error code or exception if violated.
- I'm not aware of any Windows documentation or public source describing `CreateIconFromResourceEx`'s internals that ties this requirement to a specific failure mode (crash, `GetLastError` code, etc.), which further suggests the original wording described a *caller convention* (i.e., "this is how `LookupIconIdFromDirectoryEx`/`LoadResource` naturally hand you the buffer") rather than an *enforced contract*.