### PR TITLE
Enhance alignment field description in resource desc

### DIFF
--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_resource_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_resource_desc.md
@@ -59,7 +59,7 @@ One member of <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_dimens
 
 ### -field Alignment
 
-Specifies the alignment.
+Specifies the alignment. When `D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT` is set, this value will be used as the floor for how tightly the runtime will align the resource. The [spec](https://microsoft.github.io/DirectX-Specs/d3d/D3D12TightPlacedResourceAlignment.html#non-zero-alignment-as-a-target-floor) outlines some interesting scenarios where you may want to do this.
 
 ### -field Width
 

--- a/sdk-api-src/content/d3d12/ns-d3d12-d3d12_resource_desc.md
+++ b/sdk-api-src/content/d3d12/ns-d3d12-d3d12_resource_desc.md
@@ -59,7 +59,7 @@ One member of <a href="/windows/desktop/api/d3d12/ne-d3d12-d3d12_resource_dimens
 
 ### -field Alignment
 
-Specifies the alignment. When `D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT` is set, this value will be used as the floor for how tightly the runtime will align the resource. The [spec](https://microsoft.github.io/DirectX-Specs/d3d/D3D12TightPlacedResourceAlignment.html#non-zero-alignment-as-a-target-floor) outlines some interesting scenarios where you may want to do this.
+Specifies the alignment of the resource, in bytes. Use 0 to let the runtime select the alignment automatically. When `D3D12_RESOURCE_FLAG_USE_TIGHT_ALIGNMENT` is set, this value serves as a minimum alignment floor; see the [D3D12 Tight Placed Resource Alignment specification](https://microsoft.github.io/DirectX-Specs/d3d/D3D12TightPlacedResourceAlignment.html#non-zero-alignment-as-a-target-floor) for details.
 
 ### -field Width
 


### PR DESCRIPTION
Expanded the description for the alignment field to include details about the use of tight alignment and reference to the specification.

Accounts for changes in AgilitySDK 1.619.4