### PR TITLE
Fix LoadImage docs: image selection, LR_SHARED behavior, DPI guidance

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagea.md
@@ -237,15 +237,15 @@ Loads the image in black and white.
 </dl>
 </td>
 <td width="60%">
-Shares the image handle if the image is loaded multiple times. If <b>LR_SHARED</b> is not set, a second call to <b>LoadImage</b> for the same resource will load the image again and return a different handle. 
+Shares the image handle if the image is loaded multiple times. If <b>LR_SHARED</b> is not set, a second call to <b>LoadImage</b> for the same resource will load the image again and return a different handle.
 
 When you use this flag, the system will destroy the resource when it is no longer needed.
 
 Do not use <b>LR_SHARED</b> for images that have non-standard sizes, that may change after loading, or that are loaded from a file.
 
-When loading a system icon or cursor, you must use <b>LR_SHARED</b> or the function will fail to load the resource.
+When loading a predefined system icon or cursor (an <b>IDI_</b> or <b>IDC_</b> identifier with <i>hInst</i> set to <b>NULL</b>), use <b>LR_SHARED</b> so that the system manages the handle lifetime.
 
-This function finds the first image in the cache with the requested resource name, regardless of the size requested.
+The shared cache is keyed by resource name and module, regardless of the size requested. If a matching entry is already cached at a different size, that cached handle is returned rather than loading a new image. Do not use <b>LR_SHARED</b> when you need a specific size or when loading the same resource at multiple sizes (for example, for per-monitor DPI scaling).
 
 </td>
 </tr>
@@ -309,6 +309,11 @@ When you are finished using a bitmap, cursor, or icon you loaded without specify
 
 The system automatically deletes these resources when the process that created them terminates; however, calling the appropriate function saves memory and decreases the size of the process's working set.
 
+### Image selection and sizing
+
+Icon and cursor resources (and standalone .ico/.cur files) typically contain multiple images at different sizes and color depths. When *cx* and *cy* are non-zero, **LoadImage** uses [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) to select the image whose size and color depth best match the requested values, then scales it to exactly *cx*×*cy* pixels if no exact-size image is present. When both *cx* and *cy* are zero and **LR_DEFAULTSIZE** is set, the function uses the system metric values to determine the size: **SM_CXICON**/**SM_CYICON** for icons, and the effective system cursor size (which reflects the user's cursor-size setting in Settings) for cursors. When both *cx* and *cy* are zero and **LR_DEFAULTSIZE** is not set, the function uses the actual dimensions of the first image in the resource.
+
+When scaling is required because no exact-size image is available, the resize is a basic stretch. The resulting image may look soft, especially when scaling up. For sharper icons on high-DPI displays, use [LoadIconWithScaleDown](/windows/desktop/api/commctrl/nf-commctrl-loadiconwithscaledown), which picks a larger image and scales it down rather than scaling a small image up.
 
 #### Examples
 
@@ -345,6 +350,14 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-classes">Using
 
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
+
+
+
+<a href="/windows/desktop/api/commctrl/nf-commctrl-loadiconwithscaledown">LoadIconWithScaleDown</a>
+
+
+
+<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
@@ -237,15 +237,15 @@ Loads the image in black and white.
 </dl>
 </td>
 <td width="60%">
-Shares the image handle if the image is loaded multiple times. If <b>LR_SHARED</b> is not set, a second call to <b>LoadImage</b> for the same resource will load the image again and return a different handle. 
+Shares the image handle if the image is loaded multiple times. If <b>LR_SHARED</b> is not set, a second call to <b>LoadImage</b> for the same resource will load the image again and return a different handle.
 
 When you use this flag, the system will destroy the resource when it is no longer needed.
 
 Do not use <b>LR_SHARED</b> for images that have non-standard sizes, that may change after loading, or that are loaded from a file.
 
-When loading a system icon or cursor, you must use <b>LR_SHARED</b> or the function will fail to load the resource.
+When loading a predefined system icon or cursor (an <b>IDI_</b> or <b>IDC_</b> identifier with <i>hInst</i> set to <b>NULL</b>), use <b>LR_SHARED</b> so that the system manages the handle lifetime.
 
-This function finds the first image in the cache with the requested resource name, regardless of the size requested.
+The shared cache is keyed by resource name and module, regardless of the size requested. If a matching entry is already cached at a different size, that cached handle is returned rather than loading a new image. Do not use <b>LR_SHARED</b> when you need a specific size or when loading the same resource at multiple sizes (for example, for per-monitor DPI scaling).
 
 </td>
 </tr>
@@ -311,6 +311,11 @@ When you are finished using a bitmap, cursor, or icon you loaded without specify
 
 The system automatically deletes these resources when the process that created them terminates; however, calling the appropriate function saves memory and decreases the size of the process's working set.
 
+### Image selection and sizing
+
+Icon and cursor resources (and standalone .ico/.cur files) typically contain multiple images at different sizes and color depths. When *cx* and *cy* are non-zero, **LoadImage** uses [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) to select the image whose size and color depth best match the requested values, then scales it to exactly *cx*×*cy* pixels if no exact-size image is present. When both *cx* and *cy* are zero and **LR_DEFAULTSIZE** is set, the function uses the system metric values to determine the size: **SM_CXICON**/**SM_CYICON** for icons, and the effective system cursor size (which reflects the user's cursor-size setting in Settings) for cursors. When both *cx* and *cy* are zero and **LR_DEFAULTSIZE** is not set, the function uses the actual dimensions of the first image in the resource.
+
+When scaling is required because no exact-size image is available, the resize is a basic stretch. The resulting image may look soft, especially when scaling up. For sharper icons on high-DPI displays, use [LoadIconWithScaleDown](/windows/desktop/api/commctrl/nf-commctrl-loadiconwithscaledown), which picks a larger image and scales it down rather than scaling a small image up.
 
 #### Examples
 
@@ -347,6 +352,14 @@ For an example, see <a href="/windows/desktop/winmsg/using-window-classes">Using
 
 
 <a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
+
+
+
+<a href="/windows/desktop/api/commctrl/nf-commctrl-loadiconwithscaledown">LoadIconWithScaleDown</a>
+
+
+
+<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>
 
 
 

--- a/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
+++ b/sdk-api-src/content/winuser/nf-winuser-loadimagew.md
@@ -243,7 +243,7 @@ When you use this flag, the system will destroy the resource when it is no longe
 
 Do not use <b>LR_SHARED</b> for images that have non-standard sizes, that may change after loading, or that are loaded from a file.
 
-When loading a predefined system icon or cursor (an <b>IDI_</b> or <b>IDC_</b> identifier with <i>hInst</i> set to <b>NULL</b>), use <b>LR_SHARED</b> so that the system manages the handle lifetime.
+When loading a predefined system icon or cursor (an <b>IDI_</b>, <b>IDC_</b>, <b>OIC_</b>, or <b>OCR_</b> identifier with <i>hInst</i> set to <b>NULL</b>), use <b>LR_SHARED</b> so that the system manages the handle lifetime.
 
 The shared cache is keyed by resource name and module, regardless of the size requested. If a matching entry is already cached at a different size, that cached handle is returned rather than loading a new image. Do not use <b>LR_SHARED</b> when you need a specific size or when loading the same resource at multiple sizes (for example, for per-monitor DPI scaling).
 


### PR DESCRIPTION
- Rewrote LR_SHARED flag description: removed the inaccurate "must use LR_SHARED or the function will fail" claim for system icons/cursors; replaced with a recommendation. Added explicit warning that the shared cache is keyed by resource name and ignores requested size, making LR_SHARED unsuitable when multiple sizes or per-monitor DPI variants are needed.
- Added "Image selection and sizing" Remarks section explaining that LoadImage uses LookupIconIdFromDirectoryEx to pick the best-matching image from a multi-image resource and scales it if no exact size exists. Notes that the built-in scaling is a basic stretch; recommends LoadIconWithScaleDown for high-DPI icons.
- Added LoadIconWithScaleDown and LookupIconIdFromDirectoryEx to see-also.