### PR TITLE
Fix and improve CreateIconFromResource(Ex) and LookupIconIdFromDirectory(Ex) documentation

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -65,9 +65,7 @@ To specify a desired height or width, use the [CreateIconFromResourceEx](/window
 
 Type: **PBYTE**
 
-The buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory), [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex), and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions.
-
-See [Cursor and Icon Resources](/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources) for more info on icon and cursor resource format.
+The buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory), [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex), and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions. For the buffer formats this parameter accepts, see the Remarks section of [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex).
 
 ### -param dwResSize [in]
 
@@ -80,8 +78,6 @@ The size, in bytes, of the set of bits pointed to by the *presbits* parameter.
 Type: **BOOL**
 
 Indicates whether an icon or a cursor is to be created. If this parameter is **TRUE**, an icon is to be created. If it is **FALSE**, a cursor is to be created.
-
-The [LOCALHEADER](/windows/win32/menurc/localheader) structure defines cursor hotspot and is the first data read from the cursor resource bits.
 
 ### -param dwVer [in]
 
@@ -99,11 +95,13 @@ If the function fails, the return value is **NULL**. To get extended error infor
 
 ## -remarks
 
-The **CreateIconFromResource**, [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex), [CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect), [GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo), [LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory), and [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) functions allow shell applications and icon browsers to examine and use resources throughout the system.
-
-The **CreateIconFromResource** function calls [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex) passing `LR_DEFAULTSIZE|LR_SHARED` as flags.
+The **CreateIconFromResource** function calls [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex) passing `LR_DEFAULTSIZE|LR_SHARED` as flags. Because **LR_DEFAULTSIZE** is included, the icon or cursor is always created at the default system size (**SM_CXICON**/**SM_CYICON** for icons, **SM_CXCURSOR**/**SM_CYCURSOR** for cursors), regardless of the dimensions of the image in *presbits*. To create an icon or cursor at a specific size, call [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex) and specify *cxDesired* and *cyDesired*.
 
 You should call [DestroyIcon](/windows/win32/api/winuser/nf-winuser-destroyicon) for icons or [DestroyCursor](/windows/win32/api/winuser/nf-winuser-destroycursor) for cursors created with **CreateIconFromResource**.
+
+#### Examples
+
+For an example, see [Sharing Icon Resources](/windows/win32/menurc/using-icons#sharing-icon-resources).
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresource.md
@@ -11,8 +11,8 @@ ms.keywords: CreateIconFromResource, CreateIconFromResource function [Menus and 
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
-req.target-min-winversvr: Windows 2000 Server [desktop apps only]
+req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
+req.target-min-winversvr: Windows 2000 Server [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -57,86 +57,66 @@ api_name:
 
 Creates an icon or cursor from resource bits describing the icon.
 
-To specify a desired height or width, use the <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a> function.
+To specify a desired height or width, use the [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex) function.
 
 ## -parameters
 
 ### -param presbits [in]
 
-Type: <b>PBYTE</b>
+Type: **PBYTE**
 
-The buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>, and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The buffer pointer containing the icon or cursor resource bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory), [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex), and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions.
 
-See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
+See [Cursor and Icon Resources](/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources) for more info on icon and cursor resource format.
 
 ### -param dwResSize [in]
 
-Type: <b>DWORD</b>
+Type: **DWORD**
 
-The size, in bytes, of the set of bits pointed to by the <i>presbits</i> parameter.
+The size, in bytes, of the set of bits pointed to by the *presbits* parameter.
 
 ### -param fIcon [in]
 
-Type: <b>BOOL</b>
+Type: **BOOL**
 
-Indicates whether an icon or a cursor is to be created. If this parameter is <b>TRUE</b>, an icon is to be created. If it is <b>FALSE</b>, a cursor is to be created. 
+Indicates whether an icon or a cursor is to be created. If this parameter is **TRUE**, an icon is to be created. If it is **FALSE**, a cursor is to be created.
 
-The <a href="/windows/win32/menurc/localheader">LOCALHEADER</a> structure defines cursor hotspot and is the first data read from the cursor resource bits.
+The [LOCALHEADER](/windows/win32/menurc/localheader) structure defines cursor hotspot and is the first data read from the cursor resource bits.
 
 ### -param dwVer [in]
 
-Type: <b>DWORD</b>
+Type: **DWORD**
 
-The version number of the icon or cursor format for the resource bits pointed to by the <i>presbits</i> parameter. The value must be greater than or equal to 0x00020000 and less than or equal to 0x00030000. This parameter is generally set to 0x00030000.
+The version number of the icon or cursor format for the resource bits pointed to by the *presbits* parameter. The value must be greater than or equal to 0x00020000 and less than or equal to 0x00030000. This parameter is generally set to 0x00030000.
 
 ## -returns
 
-Type: <b>HICON</b>
+Type: **HICON**
 
 If the function succeeds, the return value is a handle to the icon or cursor.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is **NULL**. To get extended error information, call [GetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 
-The <b>CreateIconFromResource</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system. 
+The **CreateIconFromResource**, [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex), [CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect), [GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo), [LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory), and [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) functions allow shell applications and icon browsers to examine and use resources throughout the system.
 
-The <b>CreateIconFromResource</b> function calls <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a> passing <code>LR_DEFAULTSIZE|LR_SHARED</code> as flags.
+The **CreateIconFromResource** function calls [CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex) passing `LR_DEFAULTSIZE|LR_SHARED` as flags.
 
-You should call <a href="/windows/win32/api/winuser/nf-winuser-destroyicon">DestroyIcon</a> for icons or <a href="/windows/win32/api/winuser/nf-winuser-destroycursor">DestroyCursor</a> for cursors created with <b>CreateIconFromResource</b>.
+You should call [DestroyIcon](/windows/win32/api/winuser/nf-winuser-destroyicon) for icons or [DestroyCursor](/windows/win32/api/winuser/nf-winuser-destroycursor) for cursors created with **CreateIconFromResource**.
 
 ## -see-also
 
-<b>Conceptual</b>
+[CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex)
 
+[CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect)
 
+[GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>
+[Icons](/windows/desktop/menurc/icons)
 
+[LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource)
 
+[LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>
-
-
-
-<b>Reference</b>
+[LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex)

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.CreateIconFromResourceEx
 title: CreateIconFromResourceEx function (winuser.h)
 description: Creates an icon or cursor from resource bits describing the icon. (CreateIconFromResourceEx)
-helpviewer_keywords: ["CreateIconFromResourceEx","CreateIconFromResourceEx function [Menus and Other Resources]","LR_DEFAULTCOLOR","LR_DEFAULTSIZE","LR_MONOCHROME","LR_SHARED","_win32_CreateIconFromResourceEx","_win32_createiconfromresourceex_cpp","menurc.createiconfromresourceex","winui._win32_createiconfromresourceex","winuser/CreateIconFromResourceEx"]
+helpviewer_keywords: ["CreateIconFromResourceEx","CreateIconFromResourceEx function [Menus and Other Resources]","LR_DEFAULTCOLOR","LR_DEFAULTSIZE","LR_MONOCHROME","_win32_CreateIconFromResourceEx","_win32_createiconfromresourceex_cpp","menurc.createiconfromresourceex","winui._win32_createiconfromresourceex","winuser/CreateIconFromResourceEx"]
 old-location: menurc\createiconfromresourceex.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\createiconfromresourceex.htm
 ms.date: 12/05/2018
-ms.keywords: CreateIconFromResourceEx, CreateIconFromResourceEx function [Menus and Other Resources], LR_DEFAULTCOLOR, LR_DEFAULTSIZE, LR_MONOCHROME, LR_SHARED, _win32_CreateIconFromResourceEx, _win32_createiconfromresourceex_cpp, menurc.createiconfromresourceex, winui._win32_createiconfromresourceex, winuser/CreateIconFromResourceEx
+ms.keywords: CreateIconFromResourceEx, CreateIconFromResourceEx function [Menus and Other Resources], LR_DEFAULTCOLOR, LR_DEFAULTSIZE, LR_MONOCHROME, _win32_CreateIconFromResourceEx, _win32_createiconfromresourceex_cpp, menurc.createiconfromresourceex, winui._win32_createiconfromresourceex, winuser/CreateIconFromResourceEx
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -58,7 +58,7 @@ Creates an icon or cursor from resource bits describing the icon.
 
 Type: **PBYTE**
 
-The buffer pointer containing the icon (**RT_ICON**) or cursor (**RT_CURSOR**) resource bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions.
+A pointer to the buffer containing the image bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions. For the buffer formats this function accepts, see the Remarks section.
 
 See [Cursor and Icon Resources](/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources) for more info on icon and cursor resource format.
 
@@ -74,8 +74,6 @@ Type: **BOOL**
 
 Indicates whether an icon or a cursor is to be created. If this parameter is **TRUE**, an icon is to be created. If it is **FALSE**, a cursor is to be created.
 
-The [LOCALHEADER](/windows/win32/menurc/localheader) structure defines cursor hotspot and is the first data read from the cursor resource bits.
-
 ### -param dwVer [in]
 
 Type: **DWORD**
@@ -86,13 +84,13 @@ The version number of the icon or cursor format for the resource bits pointed to
 
 Type: **int**
 
-The width, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CXICON** or **SM_CXCURSOR** system metric value to set the width. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function uses the actual resource width.
+The width, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CXICON** or **SM_CXCURSOR** system metric value to set the width. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function creates the icon or cursor at the width stored in *presbits*, without scaling.
 
 ### -param cyDesired [in]
 
 Type: **int**
 
-The height, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CYICON** or **SM_CYCURSOR** system metric value to set the height. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function uses the actual resource height.
+The height, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CYICON** or **SM_CYCURSOR** system metric value to set the height. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function creates the icon or cursor at the height stored in *presbits*, without scaling.
 
 ### -param Flags [in]
 
@@ -105,7 +103,6 @@ A combination of the following values.
 | **LR_DEFAULTCOLOR** 0x00000000 | Uses the default color format. |
 | **LR_DEFAULTSIZE** 0x00000040 | Uses the width or height specified by the system metric values for cursors or icons, if the *cxDesired* or *cyDesired* values are set to zero. If this flag is not specified and *cxDesired* and *cyDesired* are set to zero, the function uses the actual resource size. |
 | **LR_MONOCHROME** 0x00000001 | Creates a monochrome icon or cursor. |
-| **LR_SHARED** 0x00008000 | Shares the icon or cursor handle if the icon or cursor is created multiple times. If **LR_SHARED** is not set, a second call to **CreateIconFromResourceEx** for the same resource will create the icon or cursor again and return a different handle. When you use this flag, the system will destroy the resource when it is no longer needed. Do not use **LR_SHARED** for icons or cursors that have non-standard sizes, that may change after loading, or that are loaded from a file. |
 
 ## -returns
 
@@ -117,7 +114,13 @@ If the function fails, the return value is **NULL**. To get extended error infor
 
 ## -remarks
 
-The [CreateIconFromResource](/windows/desktop/api/winuser/nf-winuser-createiconfromresource), **CreateIconFromResourceEx**, [CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect), [GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo), and [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) functions allow shell applications and icon browsers to examine and use resources throughout the system.
+The *presbits* buffer holds a single icon (**RT_ICON**) or cursor (**RT_CURSOR**) image — not an icon or cursor resource group directory. Several buffer formats are accepted:
+
+-   **A device-independent bitmap (DIB) image.** The image data begins with a [BITMAPINFOHEADER](/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader); other header versions are not accepted. For a cursor (*fIcon* = **FALSE**), the image is preceded by the cursor hotspot ([LOCALHEADER](/windows/win32/menurc/localheader)).
+-   **A PNG image.** Pass the raw bytes of a PNG file to create an icon directly from PNG data without first writing it to a file. This is supported only for icons (*fIcon* = **TRUE**).
+-   **A complete animated cursor or animated icon** — the contents of an `.ani` file (RIFF/ACON data). This is the same data stored in a module's animated-cursor (**RT_ANICURSOR**) or animated-icon (**RT_ANIICON**) resource. When *cxDesired* and *cyDesired* are zero and **LR_DEFAULTSIZE** is not used, the icon or cursor is created at the first size stored in the animation, without scaling. For this format, *fIcon* is ignored; the result type (icon or cursor) is determined by the animation data itself.
+
+For all formats, *cxDesired*, *cyDesired*, and **LR_DEFAULTSIZE** select the image size as described for those parameters.
 
 You should call [DestroyIcon](/windows/win32/api/winuser/nf-winuser-destroyicon) for icons or [DestroyCursor](/windows/win32/api/winuser/nf-winuser-destroycursor) for cursors created with **CreateIconFromResourceEx**.
 

--- a/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-createiconfromresourceex.md
@@ -11,8 +11,8 @@ ms.keywords: CreateIconFromResourceEx, CreateIconFromResourceEx function [Menus 
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
-req.target-min-winversvr: Windows 2000 Server [desktop apps only]
+req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
+req.target-min-winversvr: Windows 2000 Server [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -56,163 +56,89 @@ Creates an icon or cursor from resource bits describing the icon.
 
 ### -param presbits [in]
 
-Type: <b>PBYTE</b>
+Type: **PBYTE**
 
-The buffer pointer containing the icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) resource bits. These bits are typically loaded by calls to the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> and <a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> functions.
+The buffer pointer containing the icon (**RT_ICON**) or cursor (**RT_CURSOR**) resource bits. These bits are typically loaded by calls to the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) and [LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource) functions.
 
-See <a href="/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources">Cursor and Icon Resources</a> for more info on icon and cursor resource format.
+See [Cursor and Icon Resources](/windows/win32/menurc/resource-file-formats#cursor-and-icon-resources) for more info on icon and cursor resource format.
 
 ### -param dwResSize [in]
 
-Type: <b>DWORD</b>
+Type: **DWORD**
 
-The size, in bytes, of the set of bits pointed to by the <i>pbIconBits</i> parameter.
+The size, in bytes, of the set of bits pointed to by the *pbIconBits* parameter.
 
 ### -param fIcon [in]
 
-Type: <b>BOOL</b>
+Type: **BOOL**
 
-Indicates whether an icon or a cursor is to be created. If this parameter is <b>TRUE</b>, an icon is to be created. If it is <b>FALSE</b>, a cursor is to be created.
+Indicates whether an icon or a cursor is to be created. If this parameter is **TRUE**, an icon is to be created. If it is **FALSE**, a cursor is to be created.
 
-The <a href="/windows/win32/menurc/localheader">LOCALHEADER</a> structure defines cursor hotspot and is the first data read from the cursor resource bits.
+The [LOCALHEADER](/windows/win32/menurc/localheader) structure defines cursor hotspot and is the first data read from the cursor resource bits.
 
 ### -param dwVer [in]
 
-Type: <b>DWORD</b>
+Type: **DWORD**
 
-The version number of the icon or cursor format for the resource bits pointed to by the <i>presbits</i> parameter. The value must be greater than or equal to 0x00020000 and less than or equal to 0x00030000. This parameter is generally set to 0x00030000.
+The version number of the icon or cursor format for the resource bits pointed to by the *presbits* parameter. The value must be greater than or equal to 0x00020000 and less than or equal to 0x00030000. This parameter is generally set to 0x00030000.
 
 ### -param cxDesired [in]
 
-Type: <b>int</b>
+Type: **int**
 
-The width, in pixels, of the icon or cursor. If this parameter is zero and the <i>Flags</i> parameter is <b>LR_DEFAULTSIZE</b>, the function uses the <b>SM_CXICON</b> or <b>SM_CXCURSOR</b> system metric value to set the width. If this parameter is zero and <b>LR_DEFAULTSIZE</b> is not used, the function uses the actual resource width.
+The width, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CXICON** or **SM_CXCURSOR** system metric value to set the width. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function uses the actual resource width.
 
 ### -param cyDesired [in]
 
-Type: <b>int</b>
+Type: **int**
 
-The height, in pixels, of the icon or cursor. If this parameter is zero and the <i>Flags</i> parameter is <b>LR_DEFAULTSIZE</b>, the function uses the <b>SM_CYICON</b> or <b>SM_CYCURSOR</b> system metric value to set the height. If this parameter is zero and <b>LR_DEFAULTSIZE</b> is not used, the function uses the actual resource height.
+The height, in pixels, of the icon or cursor. If this parameter is zero and the *Flags* parameter is **LR_DEFAULTSIZE**, the function uses the **SM_CYICON** or **SM_CYCURSOR** system metric value to set the height. If this parameter is zero and **LR_DEFAULTSIZE** is not used, the function uses the actual resource height.
 
 ### -param Flags [in]
 
-Type: <b>UINT</b>
+Type: **UINT**
 
 A combination of the following values.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="LR_DEFAULTCOLOR"></a><a id="lr_defaultcolor"></a><dl>
-<dt><b>LR_DEFAULTCOLOR</b></dt>
-<dt>0x00000000</dt>
-</dl>
-</td>
-<td width="60%">
-Uses the default color format.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="LR_DEFAULTSIZE"></a><a id="lr_defaultsize"></a><dl>
-<dt><b>LR_DEFAULTSIZE</b></dt>
-<dt>0x00000040</dt>
-</dl>
-</td>
-<td width="60%">
-Uses the width or height specified by the system metric values for cursors or icons, if the <i>cxDesired</i> or <i>cyDesired</i> values are set to zero. If this flag is not specified and <i>cxDesired</i> and <i>cyDesired</i> are set to zero, the function uses the actual resource size.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="LR_MONOCHROME"></a><a id="lr_monochrome"></a><dl>
-<dt><b>LR_MONOCHROME</b></dt>
-<dt>0x00000001</dt>
-</dl>
-</td>
-<td width="60%">
-Creates a monochrome icon or cursor. 
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="LR_SHARED"></a><a id="lr_shared"></a><dl>
-<dt><b>LR_SHARED</b></dt>
-<dt>0x00008000</dt>
-</dl>
-</td>
-<td width="60%">
-Shares the icon or cursor handle if the icon or cursor is created multiple times. If <b>LR_SHARED</b> is not set, a second call to <b>CreateIconFromResourceEx</b> for the same resource will create the icon or cursor again and return a different handle.
-
-When you use this flag, the system will destroy the resource when it is no longer needed. 
-
-Do not use <b>LR_SHARED</b> for icons or cursors that have non-standard sizes, that may change after loading, or that are loaded from a file.
-
-</td>
-</tr>
-</table>
+| Value | Meaning |
+|---|---|
+| **LR_DEFAULTCOLOR** 0x00000000 | Uses the default color format. |
+| **LR_DEFAULTSIZE** 0x00000040 | Uses the width or height specified by the system metric values for cursors or icons, if the *cxDesired* or *cyDesired* values are set to zero. If this flag is not specified and *cxDesired* and *cyDesired* are set to zero, the function uses the actual resource size. |
+| **LR_MONOCHROME** 0x00000001 | Creates a monochrome icon or cursor. |
+| **LR_SHARED** 0x00008000 | Shares the icon or cursor handle if the icon or cursor is created multiple times. If **LR_SHARED** is not set, a second call to **CreateIconFromResourceEx** for the same resource will create the icon or cursor again and return a different handle. When you use this flag, the system will destroy the resource when it is no longer needed. Do not use **LR_SHARED** for icons or cursors that have non-standard sizes, that may change after loading, or that are loaded from a file. |
 
 ## -returns
 
-Type: <b>HICON</b>
+Type: **HICON**
 
 If the function succeeds, the return value is a handle to the icon or cursor.
 
-If the function fails, the return value is <b>NULL</b>. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is **NULL**. To get extended error information, call [GetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 
-The <a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>, <b>CreateIconFromResourceEx</b>, <a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>, <a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> functions allow shell applications and icon browsers to examine and use resources throughout the system. 
+The [CreateIconFromResource](/windows/desktop/api/winuser/nf-winuser-createiconfromresource), **CreateIconFromResourceEx**, [CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect), [GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo), and [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) functions allow shell applications and icon browsers to examine and use resources throughout the system.
 
-You should call <a href="/windows/win32/api/winuser/nf-winuser-destroyicon">DestroyIcon</a> for icons or <a href="/windows/win32/api/winuser/nf-winuser-destroycursor">DestroyCursor</a> for cursors created with <b>CreateIconFromResourceEx</b>.
+You should call [DestroyIcon](/windows/win32/api/winuser/nf-winuser-destroyicon) for icons or [DestroyCursor](/windows/win32/api/winuser/nf-winuser-destroycursor) for cursors created with **CreateIconFromResourceEx**.
 
 #### Examples
 
-For an example, see <a href="/windows/desktop/menurc/using-icons#sharing-icon-resources">Sharing Icon Resources</a>.
+For an example, see [Sharing Icon Resources](/windows/desktop/menurc/using-icons#sharing-icon-resources).
 
 ## -see-also
 
-<a href="/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader">BITMAPINFOHEADER</a>
+[BITMAPINFOHEADER](/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader)
 
+[CreateIconFromResource](/windows/desktop/api/winuser/nf-winuser-createiconfromresource)
 
+[CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect)
 
-<b>Conceptual</b>
+[DestroyIcon](/windows/desktop/api/winuser/nf-winuser-destroyicon)
 
+[GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo)
 
+[Icons](/windows/desktop/menurc/icons)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
+[LoadResource](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource)
 
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>
-
-
-
-<b>Other Resources</b>
-
-
-
-<b>Reference</b>
+[LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex)

--- a/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectory.md
+++ b/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectory.md
@@ -57,7 +57,7 @@ api_name:
 
 Searches through icon (**RT_GROUP_ICON**) or cursor (**RT_GROUP_CURSOR**) resource data for the icon or cursor that best fits the current display device.
 
-To specify a desired height or width, use the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) function. This function calls it by passing zero in the **cxDesired**/**cyDesired** parameters.
+To specify a desired height or width, use the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) function. This function calls it passing zero for *cxDesired*, *cyDesired*, and *Flags*. Because no size is requested and **LR_DEFAULTSIZE** is not used, size does not take part in the selection; the image is chosen by color depth as described for [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex).
 
 ## -parameters
 

--- a/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectory.md
+++ b/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectory.md
@@ -11,8 +11,8 @@ ms.keywords: LookupIconIdFromDirectory, LookupIconIdFromDirectory function [Menu
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
-req.target-min-winversvr: Windows 2000 Server [desktop apps only]
+req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
+req.target-min-winversvr: Windows 2000 Server [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -55,88 +55,60 @@ api_name:
 
 ## -description
 
-Searches through icon (<b>RT_GROUP_ICON</b>) or cursor (<b>RT_GROUP_CURSOR</b>) resource data for the icon or cursor that best fits the current display device.
+Searches through icon (**RT_GROUP_ICON**) or cursor (**RT_GROUP_CURSOR**) resource data for the icon or cursor that best fits the current display device.
 
-To specify a desired height or width, use the <a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a> function. This function calls it by passing zero in the <b>cxDesired</b>/<b>cyDesired</b> parameters.
+To specify a desired height or width, use the [LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex) function. This function calls it by passing zero in the **cxDesired**/**cyDesired** parameters.
 
 ## -parameters
 
 ### -param presbits [in]
 
-Type: <b>PBYTE</b>
+Type: **PBYTE**
 
-The icon or cursor directory data. Because this function does not validate the resource data, it causes a general protection (GP) fault or returns an undefined value if <i>presbits</i> is not pointing to valid resource data.
+The icon or cursor directory data. Because this function does not validate the resource data, it causes a general protection (GP) fault or returns an undefined value if *presbits* is not pointing to valid resource data.
 
 ### -param fIcon [in]
 
-Type: <b>BOOL</b>
+Type: **BOOL**
 
-Indicates whether an icon or a cursor is sought. If this parameter is <b>TRUE</b>, the function is searching for an icon; if the parameter is <b>FALSE</b>, the function is searching for a cursor.
+Indicates whether an icon or a cursor is sought. If this parameter is **TRUE**, the function is searching for an icon; if the parameter is **FALSE**, the function is searching for a cursor.
 
 ## -returns
 
-Type: <b>int</b>
+Type: **int**
 
-If the function succeeds, the return value is an integer resource identifier for the icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) that best fits the current display device. 
+If the function succeeds, the return value is an integer resource identifier for the icon (**RT_ICON**) or cursor (**RT_CURSOR**) that best fits the current display device.
 
-If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is zero. To get extended error information, call [GetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 
-A resource file of type <b>RT_GROUP_ICON</b> (<b>RT_GROUP_CURSOR</b> indicates cursors) contains icon (or cursor) data in several device-dependent and device-independent formats. <b>LookupIconIdFromDirectory</b> searches the resource file for the icon (or cursor) that best fits the current display device and returns its integer identifier. The <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> and <a href="/windows/desktop/api/winbase/nf-winbase-findresourceexa">FindResourceEx</a> functions use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro with this identifier to locate the resource in the module. 
+A resource file of type **RT_GROUP_ICON** (**RT_GROUP_CURSOR** indicates cursors) contains icon (or cursor) data in several device-dependent and device-independent formats. **LookupIconIdFromDirectory** searches the resource file for the icon (or cursor) that best fits the current display device and returns its integer identifier. The [FindResource](/windows/desktop/api/winbase/nf-winbase-findresourcea) and [FindResourceEx](/windows/desktop/api/winbase/nf-winbase-findresourceexa) functions use the [MAKEINTRESOURCE](/windows/desktop/api/winuser/nf-winuser-makeintresourcea) macro with this identifier to locate the resource in the module.
 
-The icon directory is loaded from a resource file with resource type <b>RT_GROUP_ICON</b> (or <b>RT_GROUP_CURSOR</b> for cursors), and an integer resource name for the specific icon to be loaded. <b>LookupIconIdFromDirectory</b> returns an integer identifier that is the resource name of the icon that best fits the current display device. 
+The icon directory is loaded from a resource file with resource type **RT_GROUP_ICON** (or **RT_GROUP_CURSOR** for cursors), and an integer resource name for the specific icon to be loaded. **LookupIconIdFromDirectory** returns an integer identifier that is the resource name of the icon that best fits the current display device.
 
-The <a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>, <a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a> functions use this function to search the specified resource data for the icon or cursor that best fits the current display device.
+The [LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadicona), [LoadCursor](/windows/desktop/api/winuser/nf-winuser-loadcursora), and [LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagea) functions use this function to search the specified resource data for the icon or cursor that best fits the current display device.
 
 ## -see-also
 
-<b>Conceptual</b>
+[CreateIconFromResource](/windows/desktop/api/winuser/nf-winuser-createiconfromresource)
 
+[CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect)
 
+[FindResource](/windows/desktop/api/winbase/nf-winbase-findresourcea)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresource">CreateIconFromResource</a>
+[FindResourceEx](/windows/desktop/api/winbase/nf-winbase-findresourceexa)
 
+[GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo)
 
+[Icons](/windows/desktop/menurc/icons)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
+[LoadCursor](/windows/desktop/api/winuser/nf-winuser-loadcursora)
 
+[LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadicona)
 
+[LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagea)
 
-<a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>
+[LookupIconIdFromDirectoryEx](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex)
 
-
-
-<a href="/windows/desktop/api/winbase/nf-winbase-findresourceexa">FindResourceEx</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectoryex">LookupIconIdFromDirectoryEx</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
-
-
-
-<b>Reference</b>
+[MAKEINTRESOURCE](/windows/desktop/api/winuser/nf-winuser-makeintresourcea)

--- a/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectoryex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectoryex.md
@@ -2,12 +2,12 @@
 UID: NF:winuser.LookupIconIdFromDirectoryEx
 title: LookupIconIdFromDirectoryEx function (winuser.h)
 description: Searches through icon or cursor data for the icon or cursor that best fits the current display device. (LookupIconIdFromDirectoryEx)
-helpviewer_keywords: ["LR_DEFAULTCOLOR","LR_MONOCHROME","LookupIconIdFromDirectoryEx","LookupIconIdFromDirectoryEx function [Menus and Other Resources]","_win32_LookupIconIdFromDirectoryEx","_win32_lookupiconidfromdirectoryex_cpp","menurc.lookupiconidfromdirectoryex","winui._win32_lookupiconidfromdirectoryex","winuser/LookupIconIdFromDirectoryEx"]
+helpviewer_keywords: ["LR_DEFAULTCOLOR","LR_DEFAULTSIZE","LR_MONOCHROME","LookupIconIdFromDirectoryEx","LookupIconIdFromDirectoryEx function [Menus and Other Resources]","_win32_LookupIconIdFromDirectoryEx","_win32_lookupiconidfromdirectoryex_cpp","menurc.lookupiconidfromdirectoryex","winui._win32_lookupiconidfromdirectoryex","winuser/LookupIconIdFromDirectoryEx"]
 old-location: menurc\lookupiconidfromdirectoryex.htm
 tech.root: menurc
 ms.assetid: VS|winui|~\winui\windowsuserinterface\resources\icons\iconreference\iconfunctions\lookupiconidfromdirectoryex.htm
 ms.date: 12/05/2018
-ms.keywords: LR_DEFAULTCOLOR, LR_MONOCHROME, LookupIconIdFromDirectoryEx, LookupIconIdFromDirectoryEx function [Menus and Other Resources], _win32_LookupIconIdFromDirectoryEx, _win32_lookupiconidfromdirectoryex_cpp, menurc.lookupiconidfromdirectoryex, winui._win32_lookupiconidfromdirectoryex, winuser/LookupIconIdFromDirectoryEx
+ms.keywords: LR_DEFAULTCOLOR, LR_DEFAULTSIZE, LR_MONOCHROME, LookupIconIdFromDirectoryEx, LookupIconIdFromDirectoryEx function [Menus and Other Resources], _win32_LookupIconIdFromDirectoryEx, _win32_lookupiconidfromdirectoryex_cpp, menurc.lookupiconidfromdirectoryex, winui._win32_lookupiconidfromdirectoryex, winuser/LookupIconIdFromDirectoryEx
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
@@ -52,10 +52,12 @@ api_name:
 
 Searches through icon (**RT_GROUP_ICON**) or cursor (**RT_GROUP_CURSOR**) resource data for the icon or cursor that best fits the current display device.
 
-If more than one image exists in the resource group, the function uses the following criteria to choose an image:
--   Size and color depth are considered together, not as separate steps: the image chosen is the one that most closely matches the requested width and height along with the color depth of the current display device.
--   An image smaller than the requested size is treated as a poorer match than one larger by the same amount, so when two images are equally close in size, the larger one is preferred.
--   When two images match equally well, the one with the greater color depth is chosen.
+If the resource group contains more than one image, the function assigns each candidate a score measuring how far it departs from the target, and returns the entry with the lowest score (a score of zero is an exact match). The target is the requested width and height (or, when those are zero, the system-metric size — see *cxDesired*) together with the color depth of the current display device. The score is the sum of three terms:
+-   the absolute difference in width, in pixels — doubled if the candidate is narrower than the target;
+-   the absolute difference in height, in pixels — doubled if the candidate is shorter than the target;
+-   the absolute difference in color depth, in bits per pixel — always doubled.
+
+Because the width and height terms are doubled only when the candidate is undersized, an image smaller than the requested size scores worse than one larger by the same amount (reducing size is preferred over enlarging it). Because the color-depth term is always doubled, a closer match in color depth is preferred over an equally close match in size. When two candidates score equally, the one with the greater color depth is chosen; if they are still equal, the earlier entry in the directory wins.
 
 ## -parameters
 
@@ -75,13 +77,13 @@ Indicates whether an icon or a cursor is sought. If this parameter is **TRUE**, 
 
 Type: **int**
 
-The desired width, in pixels, of the icon. If this parameter is zero, the function uses the **SM_CXICON** or **SM_CXCURSOR** system metric value.
+The desired width, in pixels, of the icon or cursor. If this parameter is zero, the width used depends on the **LR_DEFAULTSIZE** flag; see the *Flags* parameter.
 
 ### -param cyDesired [in]
 
 Type: **int**
 
-The desired height, in pixels, of the icon. If this parameter is zero, the function uses the **SM_CYICON** or **SM_CYCURSOR** system metric value.
+The desired height, in pixels, of the icon or cursor. If this parameter is zero, the height used depends on the **LR_DEFAULTSIZE** flag; see the *Flags* parameter.
 
 ### -param Flags [in]
 
@@ -92,7 +94,8 @@ A combination of the following values.
 | Value | Meaning |
 |---|---|
 | **LR_DEFAULTCOLOR** 0x00000000 | Uses the default color format. |
-| **LR_MONOCHROME** 0x00000001 | Creates a monochrome icon or cursor. |
+| **LR_DEFAULTSIZE** 0x00000040 | If *cxDesired* or *cyDesired* is zero, uses the **SM_CXICON**/**SM_CXCURSOR** or **SM_CYICON**/**SM_CYCURSOR** system-metric size for that dimension. If this flag is not specified and both are zero, size does not take part in the selection (see the selection criteria above). |
+| **LR_MONOCHROME** 0x00000001 | Searches for a monochrome icon or cursor. |
 
 ## -returns
 

--- a/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectoryex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-lookupiconidfromdirectoryex.md
@@ -11,8 +11,8 @@ ms.keywords: LR_DEFAULTCOLOR, LR_MONOCHROME, LookupIconIdFromDirectoryEx, Lookup
 req.header: winuser.h
 req.include-header: Windows.h
 req.target-type: Windows
-req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
-req.target-min-winversvr: Windows 2000 Server [desktop apps only]
+req.target-min-winverclnt: Windows 2000 Professional [desktop apps only]
+req.target-min-winversvr: Windows 2000 Server [desktop apps only]
 req.kmdf-ver: 
 req.umdf-ver: 
 req.ddi-compliance: 
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Searches through icon (<b>RT_GROUP_ICON</b>) or cursor (<b>RT_GROUP_CURSOR</b>) resource data for the icon or cursor that best fits the current display device.
+Searches through icon (**RT_GROUP_ICON**) or cursor (**RT_GROUP_CURSOR**) resource data for the icon or cursor that best fits the current display device.
 
 If more than one image exists in the resource group, the function uses the following criteria to choose an image:
 -   Size and color depth are considered together, not as separate steps: the image chosen is the one that most closely matches the requested width and height along with the color depth of the current display device.
@@ -61,132 +61,79 @@ If more than one image exists in the resource group, the function uses the follo
 
 ### -param presbits [in]
 
-Type: <b>PBYTE</b>
+Type: **PBYTE**
 
-The icon or cursor directory data. Because this function does not validate the resource data, it causes a general protection (GP) fault or returns an undefined value if <i>presbits</i> is not pointing to valid resource data.
+The icon or cursor directory data. Because this function does not validate the resource data, it causes a general protection (GP) fault or returns an undefined value if *presbits* is not pointing to valid resource data.
 
 ### -param fIcon [in]
 
-Type: <b>BOOL</b>
+Type: **BOOL**
 
-Indicates whether an icon or a cursor is sought. If this parameter is <b>TRUE</b>, the function is searching for an icon; if the parameter is <b>FALSE</b>, the function is searching for a cursor.
+Indicates whether an icon or a cursor is sought. If this parameter is **TRUE**, the function is searching for an icon; if the parameter is **FALSE**, the function is searching for a cursor.
 
 ### -param cxDesired [in]
 
-Type: <b>int</b>
+Type: **int**
 
-The desired width, in pixels, of the icon. If this parameter is zero, the function uses the <b>SM_CXICON</b> or <b>SM_CXCURSOR</b> system metric value.
+The desired width, in pixels, of the icon. If this parameter is zero, the function uses the **SM_CXICON** or **SM_CXCURSOR** system metric value.
 
 ### -param cyDesired [in]
 
-Type: <b>int</b>
+Type: **int**
 
-The desired height, in pixels, of the icon. If this parameter is zero, the function uses the <b>SM_CYICON</b> or <b>SM_CYCURSOR</b> system metric value.
+The desired height, in pixels, of the icon. If this parameter is zero, the function uses the **SM_CYICON** or **SM_CYCURSOR** system metric value.
 
 ### -param Flags [in]
 
-Type: <b>UINT</b>
+Type: **UINT**
 
 A combination of the following values.
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td width="40%"><a id="LR_DEFAULTCOLOR"></a><a id="lr_defaultcolor"></a><dl>
-<dt><b>LR_DEFAULTCOLOR</b></dt>
-<dt>0x00000000</dt>
-</dl>
-</td>
-<td width="60%">
-Uses the default color format.
-
-</td>
-</tr>
-<tr>
-<td width="40%"><a id="LR_MONOCHROME"></a><a id="lr_monochrome"></a><dl>
-<dt><b>LR_MONOCHROME</b></dt>
-<dt>0x00000001</dt>
-</dl>
-</td>
-<td width="60%">
-Creates a monochrome icon or cursor. 
-
-</td>
-</tr>
-</table>
+| Value | Meaning |
+|---|---|
+| **LR_DEFAULTCOLOR** 0x00000000 | Uses the default color format. |
+| **LR_MONOCHROME** 0x00000001 | Creates a monochrome icon or cursor. |
 
 ## -returns
 
-Type: <b>int</b>
+Type: **int**
 
-If the function succeeds, the return value is an integer resource identifier for the icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) that best fits the current display device. 
+If the function succeeds, the return value is an integer resource identifier for the icon (**RT_ICON**) or cursor (**RT_CURSOR**) that best fits the current display device.
 
-If the function fails, the return value is zero. To get extended error information, call <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.
+If the function fails, the return value is zero. To get extended error information, call [GetLastError](/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror).
 
 ## -remarks
 
-A resource file of type <b>RT_GROUP_ICON</b> (<b>RT_GROUP_CURSOR</b> indicates cursors) contains icon (or cursor) data in several device-dependent and device-independent formats. <b>LookupIconIdFromDirectoryEx</b> searches the resource file for the icon (or cursor) that best fits the current display device and returns its integer identifier. The <a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a> and <a href="/windows/desktop/api/winbase/nf-winbase-findresourceexa">FindResourceEx</a> functions use the <a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro with this identifier to locate the resource in the module. 
+A resource file of type **RT_GROUP_ICON** (**RT_GROUP_CURSOR** indicates cursors) contains icon (or cursor) data in several device-dependent and device-independent formats. **LookupIconIdFromDirectoryEx** searches the resource file for the icon (or cursor) that best fits the current display device and returns its integer identifier. The [FindResource](/windows/desktop/api/winbase/nf-winbase-findresourcea) and [FindResourceEx](/windows/desktop/api/winbase/nf-winbase-findresourceexa) functions use the [MAKEINTRESOURCE](/windows/desktop/api/winuser/nf-winuser-makeintresourcea) macro with this identifier to locate the resource in the module.
 
-The icon directory is loaded from a resource file with resource type <b>RT_GROUP_ICON</b> (or <b>RT_GROUP_CURSOR</b> for cursors), and an integer resource name for the specific icon (<b>RT_ICON</b>) or cursor (<b>RT_CURSOR</b>) to be loaded. 
-<a href="/windows/win32/api/libloaderapi/nf-libloaderapi-loadresource">LoadResource</a> and <a href="/windows/win32/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a> functions may be used to create a corresponding icon or cursor. 
+The icon directory is loaded from a resource file with resource type **RT_GROUP_ICON** (or **RT_GROUP_CURSOR** for cursors), and an integer resource name for the specific icon (**RT_ICON**) or cursor (**RT_CURSOR**) to be loaded. [LoadResource](/windows/win32/api/libloaderapi/nf-libloaderapi-loadresource) and [CreateIconFromResourceEx](/windows/win32/api/winuser/nf-winuser-createiconfromresourceex) functions may be used to create a corresponding icon or cursor.
 
-The <a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>, <a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>, and <a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a> functions use this function to search the specified resource data for the icon or cursor that best fits the current display device. <a href="/windows/win32/api/commctrl/nf-commctrl-loadiconwithscaledown">LoadIconWithScaleDown</a> uses alternative search criteria for a best fit.
+The [LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadicona), [LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagea), and [LoadCursor](/windows/desktop/api/winuser/nf-winuser-loadcursora) functions use this function to search the specified resource data for the icon or cursor that best fits the current display device. [LoadIconWithScaleDown](/windows/win32/api/commctrl/nf-commctrl-loadiconwithscaledown) uses alternative search criteria for a best fit.
 
 #### Examples
 
-For an example, see <a href="/windows/win32/menurc/using-icons#sharing-icon-resources">Sharing Icon Resources</a>.
+For an example, see [Sharing Icon Resources](/windows/win32/menurc/using-icons#sharing-icon-resources).
 
 ## -see-also
 
-<b>Conceptual</b>
+[CreateIconFromResourceEx](/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex)
 
+[CreateIconIndirect](/windows/desktop/api/winuser/nf-winuser-createiconindirect)
 
+[FindResource](/windows/desktop/api/winbase/nf-winbase-findresourcea)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconfromresourceex">CreateIconFromResourceEx</a>
+[FindResourceEx](/windows/desktop/api/winbase/nf-winbase-findresourceexa)
 
+[GetIconInfo](/windows/desktop/api/winuser/nf-winuser-geticoninfo)
 
+[Icons](/windows/desktop/menurc/icons)
 
-<a href="/windows/desktop/api/winuser/nf-winuser-createiconindirect">CreateIconIndirect</a>
+[LoadCursor](/windows/desktop/api/winuser/nf-winuser-loadcursora)
 
+[LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadicona)
 
+[LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagea)
 
-<a href="/windows/desktop/api/winbase/nf-winbase-findresourcea">FindResource</a>
+[LookupIconIdFromDirectory](/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory)
 
-
-
-<a href="/windows/desktop/api/winbase/nf-winbase-findresourceexa">FindResourceEx</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-geticoninfo">GetIconInfo</a>
-
-
-
-<a href="/windows/desktop/menurc/icons">Icons</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadcursora">LoadCursor</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadicona">LoadIcon</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-loadimagea">LoadImage</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-lookupiconidfromdirectory">LookupIconIdFromDirectory</a>
-
-
-
-<a href="/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a>
-
-
-
-<b>Reference</b>
+[MAKEINTRESOURCE](/windows/desktop/api/winuser/nf-winuser-makeintresourcea)


### PR DESCRIPTION
CreateIconFromResourceEx:
- presbits: clarify the parameter accepts a single RT_ICON/RT_CURSOR image, not a
  resource group directory; redirect buffer format details to Remarks
- fIcon: remove misplaced LOCALHEADER sentence (covered in the DIB format bullet in Remarks)
- cxDesired/cyDesired: clarify that zero without LR_DEFAULTSIZE uses the size stored in
  presbits without scaling, rather than vaguely "the actual resource size"
- Flags: remove LR_SHARED — it does not produce sharing or caching for this function
  and makes the handle impossible to destroy; remove from keyword metadata as well
- Remarks: replace boilerplate sentence with a proper description of the three accepted
  buffer formats (DIB, PNG, ANI/RIFF-ACON); add ANI sizing and fIcon-ignored notes

CreateIconFromResource:
- presbits: redirect buffer format details to CreateIconFromResourceEx Remarks
- fIcon: remove misplaced LOCALHEADER sentence
- Remarks: remove boilerplate sentence; expand the wrapper description to explain the
  LR_DEFAULTSIZE consequence (always default system size) and how to get a specific size
- Add Examples link

LookupIconIdFromDirectoryEx:
- cxDesired/cyDesired: document that the SM_* metric is only used when LR_DEFAULTSIZE is
  set; without it, zero returns the first directory entry without size scoring
- Flags table: add the missing LR_DEFAULTSIZE entry; fix LR_MONOCHROME description
  ("Searches for" rather than "Creates")
- Add LR_DEFAULTSIZE to keyword metadata

LookupIconIdFromDirectory:
- Description: clarify that this wrapper passes Flags=0 (not LR_DEFAULTSIZE), so it
  always returns the first directory entry without size scoring

Related: https://devblogs.microsoft.com/oldnewthing/?p=108925