### PR TITLE
Fix missing closing italic tag

### DIFF
--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-getcopyablefootprints.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device-getcopyablefootprints.md
@@ -80,7 +80,7 @@ The number of subresources in the resource.  The range of valid values is 0 to (
 
 Type: <b>UINT64</b>
 
-The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts<i> array.
+The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts</i> array.
 
 ### -param pLayouts [out, optional]
 

--- a/sdk-api-src/content/d3d12/nf-d3d12-id3d12device8-getcopyablefootprints1.md
+++ b/sdk-api-src/content/d3d12/nf-d3d12-id3d12device8-getcopyablefootprints1.md
@@ -68,7 +68,7 @@ The number of subresources in the resource. The range of valid values is 0 to (D
 
 Type: <b>UINT64</b>
 
-The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts<i> array.
+The offset, in bytes, that is added to the <i>Offset</i> of each <a href="/windows/desktop/api/d3d12/ns-d3d12-d3d12_placed_subresource_footprint">D3D12_PLACED_SUBRESOURCE_FOOTPRINT</a> in the <i>pLayouts</i> array.
 
 ### -param pLayouts
 


### PR DESCRIPTION
Before half of the page was displayed in italics.
Introduced in #2131.