### PR TITLE
Update WTD_CACHE_ONLY_URL_RETRIEVAL to note that it governs AIA too

### DIFF
--- a/sdk-api-src/content/wintrust/ns-wintrust-wintrust_data.md
+++ b/sdk-api-src/content/wintrust/ns-wintrust-wintrust_data.md
@@ -463,7 +463,7 @@ If this flag is not set,  all time stamped signatures are considered valid forev
 </dl>
 </td>
 <td width="60%">
-Use only the local cache for revocation checks. Prevents revocation checks over the network. 
+Use only the local cache for revocation checks. Prevents revocation checks and fetching of intermediate certificates over the network. 
 
 <b>Windows XP:  </b>This value is not supported.
 


### PR DESCRIPTION
Expanded explanation of the flag's behavior for correctness.