### PR TITLE
Update nf-memoryapi-virtualalloc2.md

### DIFF
--- a/sdk-api-src/content/memoryapi/nf-memoryapi-virtualalloc2.md
+++ b/sdk-api-src/content/memoryapi/nf-memoryapi-virtualalloc2.md
@@ -23,7 +23,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: onecore.lib
-req.dll: Kernel32.dll
+req.dll: KernelBase.dll
 req.irql: 
 targetos: Windows
 req.typenames: 
@@ -44,7 +44,7 @@ api_location:
  - api-ms-win-core-memory-l1-1-8.dll
  - api-ms-win-core-memory-l1-1-7.dll
  - api-ms-win-core-memory-l1-1-6.dll
- - Kernel32.dll
+ - KernelBase.dll
  - onecore.lib
 api_name:
  - VirtualAlloc2


### PR DESCRIPTION
On my Windows 11 system, kernel32.dll does not export this function, but kernelbase.dll does.