### PR TITLE
Add E_NOTIMPL as a return value in IDataObject::SetData

### DIFF
--- a/sdk-api-src/content/objidl/nf-objidl-idataobject-setdata.md
+++ b/sdk-api-src/content/objidl/nf-objidl-idataobject-setdata.md
@@ -174,6 +174,17 @@ There was insufficient memory available for this operation.
 
 </td>
 </tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>E_NOTIMPL</b></dt>
+</dl>
+</td>
+<td width="60%">
+This data object does not support receiving data from another object.
+
+</td>
+</tr>
 </table>
 
 ## -remarks


### PR DESCRIPTION
`E_NOTIMPL` was already documented in `IDataObject::SetData`'s Remarks, but was missing in its Return Values table.