### PR TITLE
[BCRYPT_ECCKEY_BLOB] Clarify that cbKey specifies the length of each individual scalar field of an elliptic curve key structure, not the entire key

### DIFF
--- a/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_ecckey_blob.md
+++ b/sdk-api-src/content/bcrypt/ns-bcrypt-bcrypt_ecckey_blob.md
@@ -188,7 +188,7 @@ The key is a 521 bit elliptic curve DSA private key.
 
 ### -field cbKey
 
-The length, in bytes, of the key.
+The length, in bytes, of each scalar field of the key.
 
 ## -remarks
 


### PR DESCRIPTION
The documentation further down that describes the fields is correct that `cbKey` is the size of each scalar field: `X`, `Y`, and `d` (when present). But the text here could suggest this is the size of the entire key, at least the public coordinates, which could mislead someone into thinking each scalar field is `cbKey / 2` in a hurry -- which is another common practice when returning x/y coordinates or r/s values of ECDSA signatures in some crypto APIs.

This seems like an easy fix just to ensure clarity.
