### PR TITLE
Docs: document GetProcAddress name-lookup failure when the export name table is not sorted

### DIFF
--- a/sdk-api-src/content/libloaderapi/nf-libloaderapi-getprocaddress.md
+++ b/sdk-api-src/content/libloaderapi/nf-libloaderapi-getprocaddress.md
@@ -83,6 +83,8 @@ If the function fails, the return value is NULL. To get extended error informati
 
 The spelling and case of a function name pointed to by *lpProcName* must be identical to that in the **EXPORTS** statement of the source DLL's module-definition (.def) file. The exported names of functions may differ from the names you use when calling these functions in your code. This difference is hidden by macros used in the SDK header files. For more information, see [Conventions for Function Prototypes](/windows/win32/Intl/conventions-for-function-prototypes).
 
+Name-based lookup relies on the module's export name table being sorted, as required by the PE/COFF specification. If a module's export name table is not correctly sorted, **GetProcAddress** may fail to locate an exported function **by name**, returning `NULL` with an extended error of **ERROR_PROC_NOT_FOUND**, even though the function is present in the module. In that situation the function may still be resolvable **by ordinal**, because ordinal lookup does not consult the export name table.
+
 The *lpProcName* parameter can identify the DLL function by specifying an ordinal value associated with the function in the **EXPORTS** statement. **GetProcAddress** verifies that the specified ordinal is in the range 1 through the highest ordinal value exported in the .def file. The function then uses the ordinal as an index to read the function's address from a function table.
 
 If the .def file does not number the functions consecutively from 1 to *N* (where *N* is the number of exported functions), an error can occur where **GetProcAddress** returns an invalid, non-NULL address, even though there is no function with the specified ordinal.


### PR DESCRIPTION
## Summary

The **GetProcAddress** Remarks describe the *ordinal* lookup path in detail ("uses the ordinal as an index to read the function's address from a function table") but say nothing about the behaviour of *name-based* lookup when a module's Export Name Pointer Table (ENPT) is not sorted.

In practice, name-based lookup depends on the ENPT being sorted, as required by the PE/COFF specification. If the ENPT is **not** correctly sorted, **GetProcAddress** can fail to locate an export **by name**, returning `NULL` with `GetLastError() == ERROR_PROC_NOT_FOUND (127)`, **even though the export is physically present in the module** and remains resolvable **by ordinal**.

This is a caller-visible outcome that is easy to hit when analysing or loading hand-crafted, packed, or malformed PE modules, and the current documentation gives no indication it can occur. This PR adds a short Remarks paragraph covering the observable behaviour and the ordinal workaround.

> Note: this change does **not** describe the internal search algorithm (that's an implementation detail Microsoft may reasonably wish to leave unspecified). It documents only the **caller-visible consequence** and the existing, documented ordinal alternative.

---

## Background (specification basis)

The PE/COFF specification states that the Export Name Pointer Table is "ordered lexically to allow binary searches." Name-based resolution relies on that ordering. When the ordering invariant is violated, a name that would otherwise be found can become unreachable via the name path, while ordinal-based resolution (which indexes the Export Address Table directly) is unaffected.

---

## What changed

Added one paragraph to the Remarks section, placed immediately after the existing paragraph on case-sensitive name matching and immediately before the ordinal-lookup paragraph, so the name/ordinal contrast reads as a deliberate pair:

```diff
 The spelling and case of a function name pointed to by *lpProcName* must be identical to that in the **EXPORTS** statement of the source DLL's module-definition (.def) file. The exported names of functions may differ from the names you use when calling these functions in your code. This difference is hidden by macros used in the SDK header files. For more information, see [Conventions for Function Prototypes](/en-us/windows/win32/Intl/conventions-for-function-prototypes).

+Name-based lookup relies on the module's export name table being sorted, as required by the PE/COFF specification. If a module's export name table is not correctly sorted, **GetProcAddress** +may fail to locate an exported function **by name**, returning `NULL` with an extended error of **ERROR_PROC_NOT_FOUND**, even though the function is present in the module. In that situation +the function may still be resolvable **by ordinal**, because ordinal lookup does not consult the export name table.
+
 The *lpProcName* parameter can identify the DLL function by specifying an ordinal value associated with the function in the **EXPORTS** statement. **GetProcAddress** verifies that the specified ordinal is in the range 1 through the highest ordinal value exported in the .def file. The function then uses the ordinal as an index to read the function's address from a function table.
```

No other lines in the file are modified.

---

## Minimal reproduction

A minimal PE32+ DLL with three named exports whose **name pointers are stored out of lexical order** (on-disk ENPT order `gamma, alpha, beta`, while the underlying name→function mapping is preserved). All three exports are present and valid; only the *order* of the name-pointer entries is perturbed.

**Observed:**

| Lookup | Call | Result |
| --- | --- | --- |
| By name | `GetProcAddress(h, "gamma")` | `NULL`, `GetLastError() == 127` (`ERROR_PROC_NOT_FOUND`) | | By name | `GetProcAddress(h, "alpha")` | success | | By name | `GetProcAddress(h, "beta")` | success | | By ordinal | `GetProcAddress(h, MAKEINTRESOURCEA(3))` | success (resolves `gamma` to its correct address) |

The module loads normally via `LoadLibraryEx`; the export exists; only *name* resolution for the out-of-order entry fails. Environment: Windows 10 Enterprise LTSC, Build 26200.

```c
HMODULE h = LoadLibraryExA("unsorted_enpt.dll", NULL, 0);   // loads fine
FARPROC byName = GetProcAddress(h, "gamma");                 // NULL, GetLastError()==127
FARPROC byOrd  = GetProcAddress(h, MAKEINTRESOURCEA(3));     // succeeds
```

A self-contained, source-buildable repro kit (stock MSVC + Python only, no proprietary tooling) is available for independent verification:

**https://github.com/malx-labs/pe-getprocaddress-enpt-repro/tree/getprocaddress-enpt-repro-v1**

It includes the DLL source, the ENPT-patching script, the test harness, build steps, and a provenance manifest (source hashes, build ledger, byte-layout spec) so the result above can be rebuilt and confirmed independently. An archived, versioned snapshot is also available via Zenodo for long-term citation: https://doi.org/10.5281/zenodo.21921843

---

## Why this helps callers

- Explains a real, reproducible `ERROR_PROC_NOT_FOUND` that is otherwise surprising (the export *is* present).
- Gives an actionable fallback (resolve by ordinal) consistent with guidance already in the topic.
- Aligns the level of detail for the *name* path with what the doc already provides for the *ordinal* path.

---

## Scope / non-goals

- No change to the described **ordinal** behaviour.
- No request to document internal loader search mechanics.
- Behaviour is version-specific; the added wording deliberately states only the observable, spec-anchored outcome rather than any implementation detail.

---

## Checklist

- [x] Change is limited to a single Remarks paragraph addition (no deletions/edits elsewhere)
- [x] Claim is reproducible and backed by an independently buildable, public repro kit
- [x] Wording avoids describing internal loader mechanics
- [x] Follows existing doc voice/formatting conventions in the same file