### PR TITLE
GetModuleBaseNameW (return value clarification)

### DIFF
--- a/sdk-api-src/content/psapi/nf-psapi-getmodulebasenamew.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getmodulebasenamew.md
@@ -86,7 +86,7 @@ The size of the <i>lpBaseName</i> buffer, in characters.
 
 ## -returns
 
-If the function succeeds, the return value specifies the length of the string copied to the buffer, in characters.
+If the function succeeds, the return value is the length of the string that is copied to the buffer, in characters, not including the terminating null character. If the buffer is too small to hold the module name, the string is truncated to nSize characters (including the terminating null character), the function returns _nSize_.
 
 If the function fails, the return value is zero. To get extended error information, call 
 <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.


### PR DESCRIPTION
Based on my tests, the behavior is similar to [GetMappedFileNameW](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmappedfilenamew#return-value), except that last error is not set to **ERROR_INSUFFICIENT_BUFFER**.

<img width="1350" height="540" alt="image" src="https://github.com/user-attachments/assets/a365511e-49ab-4115-8511-3ec85cb90009" />
