### PR TITLE
GetModuleFileNameExW (return value clarification)

### DIFF
--- a/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexw.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexw.md
@@ -89,7 +89,7 @@ The size of the <i>lpFilename</i> buffer, in characters.
 
 ## -returns
 
-If the function succeeds, the return value specifies the length of the string copied to the buffer.
+If the function succeeds, the return value is the length of the string that is copied to the buffer, in characters, not including the terminating null character. If the buffer is too small to hold the module name, the string is truncated to nSize characters (including the terminating null character), the function returns _nSize - 1_.
 
 If the function fails, the return value is zero. To get extended error information, call 
        <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.

--- a/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexw.md
+++ b/sdk-api-src/content/psapi/nf-psapi-getmodulefilenameexw.md
@@ -89,7 +89,7 @@ The size of the <i>lpFilename</i> buffer, in characters.
 
 ## -returns
 
-If the function succeeds, the return value is the length of the string that is copied to the buffer, in characters, not including the terminating null character. If the buffer is too small to hold the module name, the string is truncated to nSize characters (including the terminating null character), the function returns _nSize - 1_.
+If the function succeeds, the return value is the length of the string that is copied to the buffer, in characters, not including the terminating null character. If the buffer is too small to hold the module name, the string is truncated to nSize characters (including the terminating null character), and the function returns _nSize - 1_. The function does not set the last error to **ERROR_INSUFFICIENT_BUFFER** in this case.
 
 If the function fails, the return value is zero. To get extended error information, call 
        <a href="/windows/desktop/api/errhandlingapi/nf-errhandlingapi-getlasterror">GetLastError</a>.


### PR DESCRIPTION
Based on my tests, if the buffer is too small, the behavior is similar to [GetMappedFileNameW](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmappedfilenamew#return-value), except that last error is not set to **ERROR_INSUFFICIENT_BUFFER**, and the function returns nSize - 1 instead of nSize.

<img width="1700" height="800" alt="image" src="https://github.com/user-attachments/assets/bdce9a3c-f462-4fd9-85a0-eda6bd8a92ef" />
<img width="1700" height="800" alt="image" src="https://github.com/user-attachments/assets/4a42153d-9df1-4f13-8165-890f4f6fb564" />
