### PR TITLE
Update ToUnicode and ToUnicodeEx documentation with new details

### DIFF
--- a/sdk-api-src/content/winuser/nf-winuser-tounicode.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicode.md
@@ -98,8 +98,7 @@ The behavior of the function.
 
 If bit 0 is set, a menu is active. In this mode <b>Alt+Numeric keypad</b> key combinations are not handled.
 
-If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
-
+On Windows 10, version 1607 and later, if bit 2 is set, the function does not change keyboard state. For a known issue that affects Alt+Numeric keypad input, see Remarks.
 All other bits (through 31) are reserved.
 
 ## -returns
@@ -158,7 +157,10 @@ The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficie
 
 Typically, <b>ToUnicode</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release (for example for ALT+numpad key entry).
 
-As <b>ToUnicode</b> translates the virtual-key code, it also changes the state of the kernel-mode keyboard buffer. This state-change affects dead keys, ligatures, <b>Alt+Numeric keypad</b> key entry, and so on. It might also cause undesired side-effects if used in conjunction with <a href="/windows/desktop/api/winuser/nf-winuser-translatemessage">TranslateMessage</a> (which also changes the state of the kernel-mode keyboard buffer).
+By default, as <b>ToUnicode</b> translates the virtual-key code, it also changes state in the kernel-mode keyboard buffer. This state affects dead keys, ligatures, <b>Alt+Numeric keypad</b> input, and so on. On Windows 10, version 1607 and later, setting bit 2 of the <i>wFlags</i> parameter prevents the function from changing keyboard state. State changes might cause undesired side effects if the function is used in conjunction with <a href="/windows/desktop/api/winuser/nf-winuser-translatemessage">TranslateMessage</a>, which also changes the state of the kernel-mode keyboard buffer.
+
+> [!IMPORTANT]
+> **Known issue:** Setting bit 2 currently does not prevent changes to the keyboard state used for <b>Alt+Numeric keypad</b> input. As a result, another call to <b>ToUnicode</b> in the same interactive session can affect an in-progress Alt+Numeric keypad sequence, including a call made from another thread. Microsoft is aware of this issue. Applications should not rely on this behavior.
 
 ## -see-also
 

--- a/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
+++ b/sdk-api-src/content/winuser/nf-winuser-tounicodeex.md
@@ -106,7 +106,7 @@ If bit 0 is set, a menu is active. In this mode <b>Alt+Numeric keypad</b> key co
 
 If bit 1 is set, **ToUnicodeEx** will translate scancodes marked as key break events in addition to its usual treatment of key make events.
 
-If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
+On Windows 10, version 1607 and later, if bit 2 is set, the function does not change keyboard state. For a known issue that affects Alt+Numeric keypad input, see Remarks.
 
 All other bits (through 31) are reserved.
 
@@ -172,7 +172,10 @@ The parameters supplied to the <b>ToUnicodeEx</b> function might not be sufficie
 
 Typically, <b>ToUnicodeEx</b> performs the translation based on the virtual-key code. In some cases, however, bit 15 of the <i>wScanCode</i> parameter can be used to distinguish between a key press and a key release (for example for ALT+numpad key entry).
 
-As <b>ToUnicodeEx</b> translates the virtual-key code, it also changes the state of the kernel-mode keyboard buffer. This state-change affects dead keys, ligatures, <b>Alt+Numeric keypad</b> key entry, and so on. It might also cause undesired side-effects if used in conjunction with <a href="/windows/desktop/api/winuser/nf-winuser-translatemessage">TranslateMessage</a> (which also changes the state of the kernel-mode keyboard buffer).
+By default, as <b>ToUnicodeEx</b> translates the virtual-key code, it also changes state in the kernel-mode keyboard buffer. This state affects dead keys, ligatures, <b>Alt+Numeric keypad</b> input, and so on. On Windows 10, version 1607 and later, setting bit 2 of the <i>wFlags</i> parameter prevents the function from changing keyboard state. State changes might cause undesired side effects if the function is used in conjunction with <a href="/windows/desktop/api/winuser/nf-winuser-translatemessage">TranslateMessage</a>, which also changes the state of the kernel-mode keyboard buffer.
+
+> [!IMPORTANT]
+> **Known issue:** Setting bit 2 currently does not prevent changes to the keyboard state used for <b>Alt+Numeric keypad</b> input. As a result, another call to <b>ToUnicodeEx</b> in the same interactive session can affect an in-progress Alt+Numeric keypad sequence, including a call made from another thread. Microsoft is aware of this issue. Applications should not rely on this behavior.
 
 ## -see-also
 


### PR DESCRIPTION
This pull request updates the documentation for the `ToUnicode` and `ToUnicodeEx` Windows API functions to clarify the behavior of the `wFlags` parameter, specifically regarding bit 2 on Windows 10 version 1607 and later. It also documents a known issue affecting Alt+Numeric keypad input when bit 2 is set.

Behavior clarification and known issue documentation:

* Updated the descriptions in both `nf-winuser-tounicode.md` and `nf-winuser-tounicodeex.md` to clarify that, on Windows 10 version 1607 and later, setting bit 2 of the `wFlags` parameter is intended to prevent the function from changing keyboard state. However, a known issue exists where this does not apply to Alt+Numeric keypad input. [[1]](diffhunk://#diff-68e413ab99b679b4df0601dc80c423cfc3242324df77843ccc1754ad5912550cL101-R101) [[2]](diffhunk://#diff-5dadec5b2045baf22677269a2bbe3d30f185e4bbd3213c6151a00359d4ecfea5L109-R109)
* Added an [!IMPORTANT] note in both documentation files explaining that setting bit 2 does not prevent changes to keyboard state for Alt+Numeric keypad input, and that this can affect other calls to the function within the same session or from another thread. [[1]](diffhunk://#diff-68e413ab99b679b4df0601dc80c423cfc3242324df77843ccc1754ad5912550cL161-R163) [[2]](diffhunk://#diff-5dadec5b2045baf22677269a2bbe3d30f185e4bbd3213c6151a00359d4ecfea5L175-R178)