### PR TITLE
Add usage guidance to the apiquery2 API set query reference pages

### DIFF
--- a/sdk-api-src/content/apiquery2/index.md
+++ b/sdk-api-src/content/apiquery2/index.md
@@ -1,8 +1,9 @@
 ---
 UID: NA:apiquery2
 title: Apiquery2.h header
+description: The apiquery2.h header declares functions that query the API set schema composed on the running device.
 ms.assetid: 2c1cf2bf-a7a5-3d90-a712-935f2e90a02c
-ms.date: 01/11/2019
+ms.date: 09/01/2026
 ms.keywords: 
 ms.topic: overview
 ms.update-cycle: 1095-days
@@ -17,7 +18,36 @@ f1_keywords:
 
 ## -description
 
-This header is used by Developer Notes. For more information, see:
+Declares functions that query the [API set](/windows/win32/apiindex/windows-apisets) schema composed on the running device.
 
-- [Developer Notes](../_winprog/index.md)
+Win32 APIs in the core OS are organized into functional contracts called API sets. The Windows loader resolves an API set name to the module that implements it, and that mapping varies by Windows edition, device, and enabled features. The functions in this header report what the mapping on the current device says:
 
+- [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md) reports whether an API set is available.
+- [GetApiSetModuleBaseName](./nf-apiquery2-getapisetmodulebasename.md) returns the base name recorded in the schema for the module that implements it.
+
+To gate a call to an API that isn't available on every Windows device, see [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability).
+
+## -remarks
+
+### Supported environment
+
+The declarations in this header are available to the user-mode Desktop and System API partitions.
+
+### What these functions report
+
+Both functions read the composed API set schema. Neither one probes the file system, opens the implementing module, or checks that a particular function is exported from it.
+
+A result is contract- or group-granular, not function-granular. Use it to decide whether to enter an optional code path, and then handle module-loading errors, missing exports, and the API's own documented failure results as usual.
+
+### The two functions have different availability models
+
+**IsApiSetImplemented** is reachable through the OneCore umbrella libraries, and the compatibility implementation supplied by *OneCore.lib* lets a binary that links it also run on versions of Windows that predate the underlying query support.
+
+**GetApiSetModuleBaseName** is carried by a later contract version, `api-ms-win-core-apiquery-l2-1-1`. Treat it as an advanced API: gate it with **IsApiSetImplemented**, then bind to it with **LoadLibrary** and **GetProcAddress** rather than through an import library, so that a binary that also runs on systems that predate the function still loads.
+
+Linking, dynamic binding, downlevel behavior, and buffer rules are covered on the individual function pages.
+
+## -see-also
+
+* [Windows API sets](/windows/win32/apiindex/windows-apisets)
+* [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability)

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
@@ -1,9 +1,9 @@
 ---
 UID: NF:apiquery2.GetApiSetModuleBaseName
-title: GetApiSetModuleBaseName
-description: Retrieves the file name of the module, or binary, that implements a specified API set.
+title: GetApiSetModuleBaseName function (apiquery2.h)
+description: Retrieves the base name of the module that implements a specified API set, as recorded in the API set schema of the running system.
 tech.root: winprog
-ms.date: 11/25/2025
+ms.date: 09/03/2026
 targetos: Windows
 req.construct-type: function
 req.header: apiquery2.h
@@ -20,8 +20,8 @@ req.max-support:
 req.namespace: 
 req.assembly: 
 req.type-library: 
-req.lib: onecore.lib
-req.dll: api-ms-win-core-apiquery-l2-1-0.dll
+req.lib: 
+req.dll: api-ms-win-core-apiquery-l2-1-1.dll
 req.irql: 
 req.typenames: 
 req.redist: 
@@ -29,9 +29,9 @@ ms.custom: 19H1
 topic_type:
  - apiref
 api_type:
- - HeaderDef
+ - DllExport
 api_location:
- - api-ms-win-core-apiquery-l2
+ - api-ms-win-core-apiquery-l2-1-1.dll
 api_name:
  - GetApiSetModuleBaseName
 f1_keywords:
@@ -45,78 +45,167 @@ helpviewer_keywords:
 
 ## -description
 
-Retrieves the file name of the module, or binary, (such as a `.dll` or `.sys` file) that implements a specified [API set](/windows/win32/apiindex/windows-apisets).
+Retrieves the base name of the module that implements a specified [API set](/windows/win32/apiindex/windows-apisets), as recorded in the API set schema of the running system.
 
 ## -parameters
 
 ### -param contractName
 
-Specifies the name of the API set to query. For more info, see the **Remarks** section.
+The name of the API set to query. For the accepted forms, see the **Remarks** section.
+
+The name can include a `.dll` suffix, as it appears in a PE Format import table, but the suffix isn't required. The function behaves the same with or without it.
 
 ### -param bufferLength
 
-The size of the buffer to receive the null-terminated string for the module file name, in characters. The maximum size of a host file name is **MAX_PATH**.
+The capacity of the *moduleBaseName* buffer, in wide characters, including space for the null terminator.
+
+Don't pass a capacity larger than 32,767 characters. A larger value is rejected with **E_NOT_SUFFICIENT_BUFFER** even when the name would otherwise fit. **MAX_PATH** is a suitable size, because the result is a file name rather than a path.
 
 ### -param moduleBaseName
 
-A pointer to a string that receives the module file name.
+A pointer to a caller-allocated buffer that receives the null-terminated host module base name.
+
+This parameter is optional. To determine the required capacity without retrieving the name, pass **NULL** with *bufferLength* set to 0, and then read *actualNameLength* when the function returns **E_NOT_SUFFICIENT_BUFFER**.
+
+When the function fails after its initial availability checks, a supplied buffer contains an empty string.
 
 ### -param actualNameLength
 
-The number of characters returned in the *moduleBaseName* buffer (including the null terminator).
+A pointer to a variable that receives the length of the host module base name, in wide characters, including the null terminator.
+
+This parameter is optional and can be **NULL**.
+
+The function writes this value on success, and also when it returns **E_NOT_SUFFICIENT_BUFFER**. A call that fails for insufficient capacity therefore reports the capacity that the buffer requires.
 
 ## -returns
 
-Returns S_OK on success. Other possible values returned include the following.
+Returns **S_OK** on success. Other possible values returned include the following.
 
 |Return code|Description|
 |-|-|
-|E_INVALIDARG|The API set contract name was not correctly formed.|
-|HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND)|The API set contract name was not found.|
-|E_NOT_SUFFICIENT_BUFFER|The buffer length is insufficient for the host file name length. If actualNameLength is provided, the length required will be written to this parameter.|
+|HRESULT_FROM_NT(STATUS_INVALID_PARAMETER)|The API set contract name isn't well formed.|
+|HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND)|The schema query succeeded, but no host module is recorded for the API set contract name.|
+|E_NOT_SUFFICIENT_BUFFER|*bufferLength* is too small for the name, or is larger than 32,767 characters. If *actualNameLength* is provided, the required length is written to that parameter.|
+|E_POINTER|*moduleBaseName* is **NULL** even though *bufferLength* is large enough to receive the name.|
+
+Additional failures from the underlying schema query are converted to an **HRESULT** and can propagate to the caller. Test the result with the **FAILED** macro rather than comparing it against a fixed set of values.
 
 ## -remarks
 
-An [API set](/windows/win32/apiindex/windows-apisets) acts as an abstraction layer between the functional contract of a Win32 API and the actual DLL that implements it. That mapping can vary depending on the specific Windows product or enabled features. API set contract names might appear in a PE Format import table instead of a physical module name. The Windows loader resolves these names according to the installed API set mapping.
+An [API set](/windows/win32/apiindex/windows-apisets) acts as an abstraction layer between the functional contract of a Win32 API and the module that implements it. That mapping can vary depending on the specific Windows product or enabled features. API set contract names might appear in a PE Format import table instead of a physical module name. The Windows loader resolves these names according to the API set schema composed for the running system.
 
-The **GetApiSetModuleBaseName** function builds on the capabilities of [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md). While **IsApiSetImplemented** checks whether a specific API contract is available, **GetApiSetModuleBaseName** retrieves the corresponding implementation file name if it exists.
+**GetApiSetModuleBaseName** reports the host module base name that the schema records for a contract. It's especially useful for tools that analyze dependencies between Windows binaries, such as `.exe`, `.dll`, or `.sys` files, because it resolves API set contract names the same way the loader does.
 
-If the API set contract isn't implemented, then **GetApiSetModuleBaseName** returns **HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND)**. That's the same result as **IsApiSetImplemented** returning **FALSE**.
+The result is a schema lookup, not a file system operation. The function doesn't search the file system, confirm that the module exists on disk, load the module, or inspect its exports. A successful call reports the name that the running system's schema associates with the contract.
 
-> [!NOTE]
-> The API set contract name may include the `.dll` extension, as is common in a PE Format import table, but it's not required. The function will behave the same with or without a specified `.dll` extension. But the output *moduleFileName* will always include a file extension.
+**GetApiSetModuleBaseName** is related to [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md), which tests whether a contract is available without reporting the implementing module. The two functions consult the same schema but apply different resolution rules, so don't treat **HRESULT_FROM_WIN32(ERROR_OBJECT_NOT_FOUND)** as exactly equivalent to **IsApiSetImplemented** returning **FALSE**. Call the function whose result you actually need.
 
-**GetApiSetModuleBaseName** is especially useful for tools that analyze dependencies between Windows binaries (such as `.exe`, `.dll`, or `.sys` files), as it allows them to resolve API set contract names to actual file names.
+### Contract name forms
+
+The *contractName* parameter uses the same contract-name vocabulary as **IsApiSetImplemented**.
+
+| API surface | Name form | Example |
+|---|---|---|
+| Named group | `<contract>~<group>` | `api-win-core-samplefeature~AdvancedOperations` |
+| Default group | Contract alias, without `~Default` | `api-win-core-samplefeature` |
+| Versioned contract | Complete versioned contract name | `ext-ms-win-core-samplefeature-l1-1-0` |
+
+The `samplefeature` names are illustrative names for a fictional Windows component. The contract prefix (`api-` or `ext-`) doesn't affect resolution behavior.
+
+A `.dll` suffix is accepted but not required, which lets you pass a name taken directly from an import table.
+
+### Buffer and length semantics
+
+*bufferLength* and *actualNameLength* are both counts of wide characters, and both include the null terminator.
+
+To retrieve a name in a single call, supply a buffer of **MAX_PATH** characters. To size the buffer first, make one call with *moduleBaseName* set to **NULL** and *bufferLength* set to 0, allocate the reported number of characters, and then call again.
+
+### Availability and binding
+
+This function is carried by the `api-ms-win-core-apiquery-l2-1-1` API set contract, which is a later version of the contract that carries **IsApiSetImplemented**. It isn't present on every system that provides *apiquery2.h*, and there's no import library that provides a downlevel-capable binding for it. Bind to it dynamically.
+
+1. Call `IsApiSetImplemented("api-ms-win-core-apiquery-l2-1-1")`.
+2. If the result is **TRUE**, call **LoadLibrary** on *api-ms-win-core-apiquery-l2-1-1.dll* and then **GetProcAddress** for `GetApiSetModuleBaseName`.
+3. If the result is **FALSE**, use your fallback path and don't attempt the load.
+4. Check the returned **HRESULT** and handle failure by taking the same fallback path as step 3.
+
+Note the difference between steps 1 and 2: the query omits the `.dll` suffix, and the loader call requires it.
+
+**IsApiSetImplemented** is available through the OneCore umbrella libraries, so a program that uses this sequence still links an umbrella library for the query itself. For more info about that function and about umbrella library choice, see [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md).
+
+The declaration is available to the user-mode Desktop and System API partitions.
 
 ## Examples
 
-The following example shows a simple console app that prints the API set module file name for a contract name passed as a parameter. The contract name must conform to the naming convention described in the *API set contract names* section in the [Windows API sets](/windows/win32/apiindex/windows-apisets) topic.
+The following example is a console app that prints the host module base name for an API set contract name passed as an argument. It binds to **GetApiSetModuleBaseName** dynamically, so it also runs on systems where the function isn't available.
 
 ```cpp
 #include <windows.h>
+#include <apiquery2.h>
 #include <stdio.h>
- 
-int __cdecl main(int argc, PCSTR argv[])
+
+typedef HRESULT (WINAPI *PFN_GET_API_SET_MODULE_BASE_NAME)(
+    PCSTR   contractName,
+    UINT32  bufferLength,
+    PWSTR   moduleBaseName,
+    UINT32* actualNameLength);
+
+int __cdecl main(int argc, char* argv[])
 {
     if (argc < 2)
     {
         wprintf(L"\nPlease supply an API set contract name\n\n");
         return 1;
     }
- 
-    PCSTR apiSetContract = argv[1];
- 
+
+    PCSTR contractName = argv[1];
+
+    // Test for the contract version that carries GetApiSetModuleBaseName.
+    // The query form omits the .dll suffix.
+    if (!IsApiSetImplemented("api-ms-win-core-apiquery-l2-1-1"))
+    {
+        wprintf(L"GetApiSetModuleBaseName isn't available on this system.\n");
+        return 1;
+    }
+
+    // The loader form requires the .dll suffix.
+    HMODULE apiQuery = LoadLibraryExW(L"api-ms-win-core-apiquery-l2-1-1.dll",
+                                      NULL,
+                                      LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (apiQuery == NULL)
+    {
+        wprintf(L"Couldn't load the API set: %u\n", GetLastError());
+        return 1;
+    }
+
+    PFN_GET_API_SET_MODULE_BASE_NAME getApiSetModuleBaseName =
+        (PFN_GET_API_SET_MODULE_BASE_NAME)GetProcAddress(apiQuery,
+                                                         "GetApiSetModuleBaseName");
+    if (getApiSetModuleBaseName == NULL)
+    {
+        wprintf(L"Couldn't resolve GetApiSetModuleBaseName: %u\n", GetLastError());
+        FreeLibrary(apiQuery);
+        return 1;
+    }
+
     wchar_t baseName[MAX_PATH] = { 0 };
-    UINT32 returnedLength;
-    HRESULT hr = GetApiSetModuleBaseName(apiSetContract, MAX_PATH, baseName, &returnedLength);
+    UINT32 returnedLength = 0;
+
+    HRESULT hr = getApiSetModuleBaseName(contractName,
+                                         ARRAYSIZE(baseName),
+                                         baseName,
+                                         &returnedLength);
     if (FAILED(hr))
     {
-        wprintf(L"GetApiSetModuleBaseName on %hs returns failure: 0x%x\n", apiSetContract, hr);
+        wprintf(L"GetApiSetModuleBaseName on %hs returns failure: 0x%08x\n",
+                contractName, hr);
+        FreeLibrary(apiQuery);
         return 2;
     }
- 
-    wprintf(L"API set %hs is implemented by %s\n", apiSetContract, hostName);
- 
+
+    wprintf(L"API set %hs is implemented by %s\n", contractName, baseName);
+
+    FreeLibrary(apiQuery);
     return 0;
 }
 ```
@@ -124,3 +213,7 @@ int __cdecl main(int argc, PCSTR argv[])
 ## -see-also
 
 * [Windows API sets](/windows/win32/apiindex/windows-apisets)
+
+* [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability)
+
+* [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md)

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
@@ -129,7 +129,7 @@ This function is carried by the `api-ms-win-core-apiquery-l2-1-1` API set contra
 3. If the result is **FALSE**, use your fallback path and don't attempt the load.
 4. Check the returned **HRESULT** and handle failure by taking the same fallback path as step 3.
 
-Note the difference between steps 1 and 2: the query omits the `.dll` suffix, and the loader call requires it.
+Note the difference between steps 1 and 2. The query omits the `.dll` suffix, which isn't part of the API set name. The loader call includes it because that's how the contract name appears in an import table; either form works there, because the API set runtime parses the name by API set naming rules rather than as a file name.
 
 **IsApiSetImplemented** is available through the OneCore umbrella libraries, so a program that uses this sequence still links an umbrella library for the query itself. For more info about that function and about umbrella library choice, see [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md).
 
@@ -168,7 +168,8 @@ int __cdecl main(int argc, char* argv[])
         return 1;
     }
 
-    // The loader form requires the .dll suffix.
+    // The .dll suffix is optional here. It matches the spelling that
+    // appears in an import table.
     HMODULE apiQuery = LoadLibraryExW(L"api-ms-win-core-apiquery-l2-1-1.dll",
                                       NULL,
                                       LOAD_LIBRARY_SEARCH_SYSTEM32);

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-getapisetmodulebasename.md
@@ -129,7 +129,7 @@ This function is carried by the `api-ms-win-core-apiquery-l2-1-1` API set contra
 3. If the result is **FALSE**, use your fallback path and don't attempt the load.
 4. Check the returned **HRESULT** and handle failure by taking the same fallback path as step 3.
 
-Note the difference between steps 1 and 2. The query omits the `.dll` suffix, which isn't part of the API set name. The loader call includes it because that's how the contract name appears in an import table; either form works there, because the API set runtime parses the name by API set naming rules rather than as a file name.
+The query in step 1 uses the conventional API set name without a `.dll` suffix. The loader call in step 2 uses the spelling found in an import table; either form works for that call.
 
 **IsApiSetImplemented** is available through the OneCore umbrella libraries, so a program that uses this sequence still links an umbrella library for the query itself. For more info about that function and about umbrella library choice, see [IsApiSetImplemented](./nf-apiquery2-isapisetimplemented.md).
 
@@ -161,7 +161,7 @@ int __cdecl main(int argc, char* argv[])
     PCSTR contractName = argv[1];
 
     // Test for the contract version that carries GetApiSetModuleBaseName.
-    // The query form omits the .dll suffix.
+    // Use the conventional API set name without the .dll suffix.
     if (!IsApiSetImplemented("api-ms-win-core-apiquery-l2-1-1"))
     {
         wprintf(L"GetApiSetModuleBaseName isn't available on this system.\n");

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
@@ -84,7 +84,7 @@ The *Contract* parameter takes one of these forms.
 
 The `samplefeature` names are illustrative names for a fictional Windows component. The *Contract* prefix (`api-` or `ext-`) doesn't play a role in availability behavior.
 
-Omit the `.dll` suffix. Use the suffix only when passing an API set name to a loader operation such as **LoadLibrary**.
+Omit the `.dll` suffix; it isn't part of the API set name. A loader operation such as **LoadLibrary** accepts either form, because the API set runtime parses the name by API set naming rules.
 
 For a named group, a **TRUE** result means that the group exists, its contract is mapped to an implementation module, that host is usable in the current execution environment, the group isn't disabled, and any system feature associated with the group is enabled. A query that passes a contract alias applies the contract and host checks.
 

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["IsApiSetImplemented","IsApiSetImplemented function [Windo
 old-location: winprog\isapisetimplemented.htm
 tech.root: winprog
 ms.assetid: DF177716-9F33-4E39-BD63-D1B8E39CD67C
-ms.date: 10/23/2020
+ms.date: 09/03/2026
 ms.keywords: IsApiSetImplemented, IsApiSetImplemented function [Windows API], apiquery2/IsApiSetImplemented, winprog.isapisetimplemented
 req.construct-type: function
 req.header: apiquery2.h
@@ -54,23 +54,74 @@ Tests whether a specified *API set* is present on the computer.
 
 ### -param Contract
 
-Specifies the name of the API set to query. For more info, see the Remarks section.
+Specifies the name of the API set to query, without a `.dll` suffix. For more info, see the Remarks section.
 
 ## -returns
 
-**IsApiSetImplemented** returns **TRUE** if the specified API set is present. In this case, APIs in the target API set have valid implementations on the current platform.
+**IsApiSetImplemented** returns **TRUE** if the specified API set is present on the current platform. Otherwise, this function returns **FALSE**.
 
-Otherwise, this function returns **FALSE**.
+A **TRUE** result reports that the API set is available in the composed API set schema on the running device. It isn't a guarantee that a particular file or export is present, or that a later call into the API set will succeed.
 
 ## -remarks
 
-All versions of Windows 10 share a common base of OS components that is called the *core OS* (in some contexts this is also called *OneCore*). In core OS components, Win32 APIs are organized into functional groups called [API sets](/windows/win32/apiindex/windows-apisets).
+Windows editions share a common base of OS components that is called the *core OS* (in some contexts this is also called *OneCore*). In core OS components, Win32 APIs are organized into functional groups called [API sets](/windows/win32/apiindex/windows-apisets).
 
-Some API sets are not available on all Windows 10 platforms. For example, although the full breadth of the Win32 API is supported on PCs, only a subset of the Win32 API is available on other devices such as HoloLens, Xbox, and other devices running Windows 10x.
+Some API sets aren't available on all Windows platforms. For example, although the full breadth of the Win32 API is supported on PCs, only a subset of the Win32 API is available on other devices such as HoloLens and Xbox. An API set can also be absent from an edition or device configuration where the feature that it represents has been removed.
 
-When writing code that targets both desktop and non-desktop Windows 10 devices, wrap the API call in **IsApiSetImplemented**. This function tests at runtime if the API set that the API belongs to is present on the target platform. For more details see [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability).
+When writing code that targets both desktop and non-desktop Windows devices, wrap the API call in **IsApiSetImplemented**. This function tests at run time if the API set that the API belongs to is present on the target platform. For more details see [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability).
 
 To identify whether a given Win32 API belongs to an API set, review the requirements table in the reference documentation for the API. If the API belongs to an API set, the requirements table in the article lists the API set name.
+
+### Query forms
+
+The *Contract* parameter takes one of these forms.
+
+| API surface | Query form | Example |
+|---|---|---|
+| Named group | `<contract>~<group>` | `api-win-core-samplefeature~AdvancedOperations` |
+| Default group | Contract alias, without `~Default` | `api-win-core-samplefeature` |
+| Versioned contract | Complete versioned contract name | `ext-ms-win-core-samplefeature-l1-1-0` |
+
+The `samplefeature` names are illustrative names for a fictional Windows component. The *Contract* prefix (`api-` or `ext-`) doesn't play a role in availability behavior.
+
+Omit the `.dll` suffix. Use the suffix only when passing an API set name to a loader operation such as **LoadLibrary**.
+
+For a named group, a **TRUE** result means that the group exists, its contract is mapped to an implementation module, that host is usable in the current execution environment, the group isn't disabled, and any system feature associated with the group is enabled. A query that passes a contract alias applies the contract and host checks.
+
+The result is contract- or group-granular, not function-granular.
+
+When an API's public header supplies an `Is<APIName>Present` helper, prefer that helper for a single optional API, because it already contains the correct name. Call **IsApiSetImplemented** directly when one decision guards several APIs, or when no helper is available. A helper is named for an API but its result is still group- or contract-granular, so two helpers backed by the same named group always agree.
+
+### Calling an optional API
+
+An availability query can protect process startup only if the optional target is delay-loaded or resolved dynamically. With a static import, the loader can fail the process before execution reaches the query.
+
+1. Query the API set name, alias, or named group.
+2. Enter the optional code path only when the query returns **TRUE**.
+3. Load or call the target API.
+4. Handle module-loading errors, missing exports, and the API's own documented failure results.
+
+For a complete example, see [Detect API set availability](/windows/win32/apiindex/detect-api-set-availability). For delay-load configuration, see [Linker support for delay-loaded DLLs](/cpp/build/reference/linker-support-for-delay-loaded-dlls).
+
+A versioned contract name gates APIs added in a later contract version; [GetApiSetModuleBaseName](./nf-apiquery2-getapisetmodulebasename.md) is an example.
+
+### Linking
+
+Include *apiquery2.h* and link one of the OneCore umbrella libraries. The choice is a trade-off between downlevel reach and directness of binding.
+
+- *OneCore.lib* is the general-purpose choice. For this function it supplies a compatibility implementation that selects an API set query mechanism available on the running system, so the binary can also run on versions of Windows that predate the underlying support.
+- *OneCore_apiset.lib* binds API set contract names directly, so no intermediate forwarding DLL is involved at run time. This is the most direct form, but a binary linked this way isn't guaranteed to run as-is on earlier versions of Windows. Choose it when the binary targets recent versions of Windows and you want direct binding for efficiency.
+
+The declaration is available to the user-mode Desktop and System API partitions.
+
+### Behavior on earlier versions of Windows
+
+The compatibility implementation supplied by *OneCore.lib* still runs on a system where no API set query mechanism is available. In that case:
+
+- A group-qualified name that contains `~` returns **FALSE**. A system that can't evaluate named groups can't report that a group is available.
+- A name that isn't group-qualified can return **TRUE**. This preserves compatibility with applications that supplied their own forwarder DLLs on early versions of Windows, where the contract was in fact satisfied by that forwarder.
+
+For this reason, treat the result as an availability signal rather than as a security boundary or a function-export test.
 
 ## -see-also
 
@@ -78,6 +129,8 @@ To identify whether a given Win32 API belongs to an API set, review the requirem
 
 <a href="/windows/win32/apiindex/detect-api-set-availability">Detect API set availability</a>
 
+<a href="/windows/win32/api/apiquery2/nf-apiquery2-getapisetmodulebasename">GetApiSetModuleBaseName</a>
+
 <a href="/windows-hardware/drivers/develop/building-for-onecore">Building for OneCore</a>
 
-<a href="/windows-hardware/drivers/develop/validating-universal-drivers">Validating Universal Windows drivers</a>
+<a href="/windows-hardware/drivers/develop/validating-windows-drivers">Validating Windows drivers</a>

--- a/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
+++ b/sdk-api-src/content/apiquery2/nf-apiquery2-isapisetimplemented.md
@@ -54,7 +54,7 @@ Tests whether a specified *API set* is present on the computer.
 
 ### -param Contract
 
-Specifies the name of the API set to query, without a `.dll` suffix. For more info, see the Remarks section.
+Specifies the name of the API set to query. API set names are conventionally written without a `.dll` suffix. For more info, see the Remarks section.
 
 ## -returns
 
@@ -84,7 +84,7 @@ The *Contract* parameter takes one of these forms.
 
 The `samplefeature` names are illustrative names for a fictional Windows component. The *Contract* prefix (`api-` or `ext-`) doesn't play a role in availability behavior.
 
-Omit the `.dll` suffix; it isn't part of the API set name. A loader operation such as **LoadLibrary** accepts either form, because the API set runtime parses the name by API set naming rules.
+The examples omit the `.dll` suffix because it isn't part of the API set name.
 
 For a named group, a **TRUE** result means that the group exists, its contract is mapped to an implementation module, that host is usable in the current execution environment, the group isn't disabled, and any system feature associated with the group is enabled. A query that passes a contract alias applies the contract and host checks.
 


### PR DESCRIPTION
## Summary

Updates the `apiquery2` reference pages under
`sdk-api-src/content/apiquery2`. The existing pages document the function
signatures correctly but say little about how to use them, so this adds
remarks rather than restating the syntax.

The gaps addressed:

- Neither page described the accepted form of an API set contract name, which
  is what the caller actually has to get right.
- The two functions have different availability and binding models, and the
  pages did not distinguish them.
- There was no guidance on linking, or on behavior when the query is made on
  an earlier version of Windows.

## Changes by page

| Page | Summary |
|---|---|
| `index.md` | Adds remarks covering the supported environment, what these functions report, and the differing availability models of the two functions. |
| `nf-apiquery2-isapisetimplemented.md` | Documents contract name forms, query forms, calling an optional API, linking, and behavior on earlier versions of Windows. |
| `nf-apiquery2-getapisetmodulebasename.md` | Documents buffer and length semantics, and availability and binding. |

## Metadata

`ms.date` is updated on all three pages.

Two `req.*` fields change on `nf-apiquery2-getapisetmodulebasename.md`, and I'd
appreciate a close look at these since they are normally harvest-owned:

- `req.dll` — `api-ms-win-core-apiquery-l2-1-0.dll` to
  `api-ms-win-core-apiquery-l2-1-1.dll`. `GetApiSetModuleBaseName` is exported
  from the `l2-1-1` contract; `l2-1-0` does not carry it.
- `req.lib` — `onecore.lib` to empty. The function has no import thunk in plain
  `OneCore.lib`; it appears only in the `_apiset` umbrella variants. Since the
  documented usage is to bind it dynamically with `LoadLibrary` and
  `GetProcAddress`, naming a link library here would be misleading, so the
  Requirements table now omits the **Library** row rather than naming one.

No minimum supported release is asserted, and no other metadata is changed.

## Companion pull request

MicrosoftDocs/win32#2214 — https://github.com/MicrosoftDocs/win32/pull/2214

That pull request updates the four API Set conceptual topics under
`desktop-src/apiindex`.

The two sets are complementary: the conceptual pages describe *when* to query
for availability, and these reference pages define the exact query name forms
and binding requirements. Reviewing them together is recommended.
