### PR TITLE
Update Get/SetPriorityClass docs

### DIFF
--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getpriorityclass.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-getpriorityclass.md
@@ -124,7 +124,7 @@ Process that has priority above <b>NORMAL_PRIORITY_CLASS</b> but below <b>HIGH_P
 </dl>
 </td>
 <td width="60%">
-Process that performs time-critical tasks that must be executed immediately for it to run correctly. The threads of a high-priority class process preempt the threads of normal or idle priority class processes. An example is the Task List, which must respond quickly when called by the user, regardless of the load on the operating system. Use extreme care when using the high-priority class, because a high-priority class CPU-bound application can use nearly all available cycles.
+Process that performs time-critical tasks that must be executed immediately for it to run correctly. The threads of a high-priority class process preempt the threads of normal or idle priority class processes. An example is the Task Manager, which must respond quickly when called by the user, regardless of the load on the operating system. Use extreme care when using the high-priority class, because a high-priority class CPU-bound application can use nearly all available cycles.
 
 </td>
 </tr>

--- a/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setpriorityclass.md
+++ b/sdk-api-src/content/processthreadsapi/nf-processthreadsapi-setpriorityclass.md
@@ -114,7 +114,7 @@ The priority class for the process. This parameter can be one of the following v
 </dl>
 </td>
 <td width="60%">
-Process that performs time-critical tasks that must be executed immediately. The threads of the process preempt the threads of normal or idle priority class processes. An example is the Task List, which must respond quickly when called by the user, regardless of the load on the operating system. Use extreme care when using the high-priority class, because a high-priority class application can use nearly all available CPU time.
+Process that performs time-critical tasks that must be executed immediately. The threads of the process preempt the threads of normal or idle priority class processes. An example is the Task Manager, which must respond quickly when called by the user, regardless of the load on the operating system. Use extreme care when using the high-priority class, because a high-priority class application can use nearly all available CPU time.
 
 </td>
 </tr>


### PR DESCRIPTION
Task List was the name used in Windows 9x. Task Manager is the modern name.